### PR TITLE
Promote standalone pre-draft Rookie Alpha export pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,99 @@
 # TIBER-Rookies
+
+Standalone rookie grading lab for the **current implemented pre-draft Rookie Alpha model (v0)**.
+
+## Why this repo exists
+
+This repository extracts the rookie scoring path out of TIBER-Fantasy into a minimal, honest handoff artifact pipeline:
+
+- no frontend
+- no Express routes
+- no Drizzle/Postgres dependency
+- no dependency on TIBER-Fantasy runtime services
+
+Primary output is a **promoted export** that TIBER-Fantasy (or any consumer) can ingest later.
+
+## Repository layout
+
+- `README.md`
+- `docs/`
+  - `architecture.md`
+  - `export-contract.md`
+- `scripts/`
+  - `compute_rookie_alpha.py`
+- `data/raw/`
+  - combine inputs (example 2026 artifact)
+- `data/processed/`
+  - college production and draft-capital-proxy artifacts
+- `exports/promoted/rookie-alpha/`
+  - generated promoted JSON + CSV outputs
+
+## Current model implementation (pre-draft v0)
+
+The formula preserved in this standalone pipeline is:
+
+- **RAS 35%**
+- **Production 45%**
+- **Draft capital proxy 20%**
+- **No age-at-entry support yet**
+
+This is explicitly labeled as `pre-draft v0` in export metadata.
+
+## Inputs
+
+Default artifact inputs:
+
+- `data/raw/2026_combine_results.json`
+- `data/processed/2026_college_production.json`
+- `data/processed/2026_draft_capital_proxy.json`
+
+## Run
+
+```bash
+python3 scripts/compute_rookie_alpha.py
+```
+
+Optional flags:
+
+```bash
+python3 scripts/compute_rookie_alpha.py \
+  --season 2026 \
+  --combine-input data/raw/2026_combine_results.json \
+  --production-input data/processed/2026_college_production.json \
+  --draft-proxy-input data/processed/2026_draft_capital_proxy.json \
+  --output-json exports/promoted/rookie-alpha/2026_rookie_alpha_predraft_v0.json \
+  --output-csv exports/promoted/rookie-alpha/2026_rookie_alpha_predraft_v0.csv
+```
+
+## Outputs (promoted contract)
+
+- `exports/promoted/rookie-alpha/2026_rookie_alpha_predraft_v0.json`
+- `exports/promoted/rookie-alpha/2026_rookie_alpha_predraft_v0.csv`
+
+Export metadata includes:
+
+- `model_version`
+- `generated_at`
+- `season`
+- `coverage_summary`
+- `source_files_used`
+
+Full field-level contract is documented in `docs/export-contract.md`.
+
+## How TIBER-Fantasy should consume this later
+
+TIBER-Fantasy should treat this repo as a producer and ingest the promoted JSON export as input data, not as a live service dependency.
+
+Recommended handoff pattern:
+
+1. Run this repo's pipeline for the season.
+2. Publish/version the promoted JSON artifact.
+3. TIBER-Fantasy import job reads the export and maps by `player_id`.
+4. Keep downstream UI/runtime logic separate from this model computation pipeline.
+
+## Future roadmap (not implemented yet)
+
+- Landing spot adjustment phase
+- NFL transition blending phase
+
+Those phases should extend the promoted artifact chain without breaking the pre-draft v0 contract.

--- a/data/processed/2026_college_production.json
+++ b/data/processed/2026_college_production.json
@@ -1,0 +1,26 @@
+[
+  {
+    "player_id": "rb-ashley-jennings",
+    "player_name": "Ashley Jennings",
+    "position": "RB",
+    "production_score_0_100": 86.2
+  },
+  {
+    "player_id": "rb-darius-cole",
+    "player_name": "Darius Cole",
+    "position": "RB",
+    "production_score_0_100": 78.4
+  },
+  {
+    "player_id": "wr-malik-ford",
+    "player_name": "Malik Ford",
+    "position": "WR",
+    "production_score_0_100": 88.1
+  },
+  {
+    "player_id": "wr-keon-banks",
+    "player_name": "Keon Banks",
+    "position": "WR",
+    "production_score_0_100": 73.9
+  }
+]

--- a/data/processed/2026_draft_capital_proxy.json
+++ b/data/processed/2026_draft_capital_proxy.json
@@ -1,0 +1,26 @@
+[
+  {
+    "player_id": "rb-ashley-jennings",
+    "player_name": "Ashley Jennings",
+    "position": "RB",
+    "draft_capital_proxy_0_100": 74.0
+  },
+  {
+    "player_id": "rb-darius-cole",
+    "player_name": "Darius Cole",
+    "position": "RB",
+    "draft_capital_proxy_0_100": 67.5
+  },
+  {
+    "player_id": "wr-malik-ford",
+    "player_name": "Malik Ford",
+    "position": "WR",
+    "draft_capital_proxy_0_100": 82.3
+  },
+  {
+    "player_id": "wr-keon-banks",
+    "player_name": "Keon Banks",
+    "position": "WR",
+    "draft_capital_proxy_0_100": 64.8
+  }
+]

--- a/data/raw/2026_combine_results.json
+++ b/data/raw/2026_combine_results.json
@@ -1,0 +1,42 @@
+[
+  {
+    "player_id": "rb-ashley-jennings",
+    "player_name": "Ashley Jennings",
+    "position": "RB",
+    "height_in": 70,
+    "weight_lb": 212,
+    "forty": 4.45,
+    "vertical": 38.5,
+    "broad": 126
+  },
+  {
+    "player_id": "rb-darius-cole",
+    "player_name": "Darius Cole",
+    "position": "RB",
+    "height_in": 71,
+    "weight_lb": 220,
+    "forty": 4.53,
+    "vertical": 35,
+    "broad": 121
+  },
+  {
+    "player_id": "wr-malik-ford",
+    "player_name": "Malik Ford",
+    "position": "WR",
+    "height_in": 73,
+    "weight_lb": 198,
+    "forty": 4.38,
+    "vertical": 39,
+    "broad": 129
+  },
+  {
+    "player_id": "wr-keon-banks",
+    "player_name": "Keon Banks",
+    "position": "WR",
+    "height_in": 74,
+    "weight_lb": 207,
+    "forty": 4.49,
+    "vertical": 36.5,
+    "broad": 123
+  }
+]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,29 @@
+# TIBER-Rookies Architecture Note
+
+## Scope now (implemented)
+
+This repo intentionally contains only a standalone pre-draft Rookie Alpha pipeline.
+
+Implemented formula (honest current state):
+
+- RAS: 35%
+- College production: 45%
+- Draft capital proxy: 20%
+- Age-at-entry: **not yet implemented**
+
+The pipeline consumes local artifacts only and writes promoted exports (JSON + CSV). There are no DB writes and no dependency on TIBER-Fantasy runtime services.
+
+## Upstream conceptual lineage
+
+This standalone flow ports the intent of the existing TIBER-Fantasy rookie scripts into a clean handoff shape:
+
+- RAS scoring
+- College production scoring
+- Rookie Alpha fusion/ranking
+
+## Future phases (not implemented yet)
+
+1. Landing spot adjustment
+2. NFL transition blending
+
+These later phases should layer on top of the promoted pre-draft export rather than coupling this repository back to runtime services.

--- a/docs/export-contract.md
+++ b/docs/export-contract.md
@@ -1,0 +1,58 @@
+# Promoted Export Contract: Rookie Alpha (2026 pre-draft v0)
+
+This repository's primary artifact is a promoted export under:
+
+- `exports/promoted/rookie-alpha/2026_rookie_alpha_predraft_v0.json`
+- `exports/promoted/rookie-alpha/2026_rookie_alpha_predraft_v0.csv`
+
+## JSON contract
+
+Top-level fields:
+
+- `model`
+  - `name`: `tiber-rookie-alpha`
+  - `stage`: `pre-draft`
+  - `label`: `pre-draft v0`
+  - `model_version`: semantic version for handoff safety
+  - `formula`
+    - `ras_weight` (0.35)
+    - `production_weight` (0.45)
+    - `draft_capital_proxy_weight` (0.20)
+    - `age_at_entry_supported` (false in v0)
+- `generated_at`: ISO-8601 UTC timestamp
+- `season`: integer season, e.g. `2026`
+- `coverage_summary`
+  - `players_total`
+  - `players_with_any_missing_input`
+  - `players_with_full_inputs`
+- `source_files_used`: list of artifact file paths used for the run
+- `players`: ordered list, highest `rookie_alpha_0_100` first
+
+Player fields:
+
+- `rookie_alpha_rank`
+- `player_id`
+- `player_name`
+- `position`
+- `scores`
+  - `ras_0_100`
+  - `production_0_100`
+  - `draft_capital_proxy_0_100`
+  - `rookie_alpha_0_100`
+- `model_inputs_missing`: list of missing components (`ras`, `production`, `draft_capital_proxy`)
+
+## CSV contract
+
+Columns:
+
+1. `rookie_alpha_rank`
+2. `player_id`
+3. `player_name`
+4. `position`
+5. `ras_0_100`
+6. `production_0_100`
+7. `draft_capital_proxy_0_100`
+8. `rookie_alpha_0_100`
+9. `model_inputs_missing`
+
+CSV is a flattened companion artifact for simpler downstream ingestion.

--- a/exports/promoted/rookie-alpha/2026_rookie_alpha_predraft_v0.csv
+++ b/exports/promoted/rookie-alpha/2026_rookie_alpha_predraft_v0.csv
@@ -1,0 +1,5 @@
+rookie_alpha_rank,player_id,player_name,position,ras_0_100,production_0_100,draft_capital_proxy_0_100,rookie_alpha_0_100,model_inputs_missing
+1,wr-malik-ford,Malik Ford,WR,61.6667,88.1,82.3,77.6883,
+2,rb-ashley-jennings,Ashley Jennings,RB,61.6667,86.2,74.0,75.1733,
+3,rb-darius-cole,Darius Cole,RB,38.3333,78.4,67.5,62.1967,
+4,wr-keon-banks,Keon Banks,WR,38.3333,73.9,64.8,59.6317,

--- a/exports/promoted/rookie-alpha/2026_rookie_alpha_predraft_v0.json
+++ b/exports/promoted/rookie-alpha/2026_rookie_alpha_predraft_v0.json
@@ -1,0 +1,80 @@
+{
+  "model": {
+    "name": "tiber-rookie-alpha",
+    "stage": "pre-draft",
+    "label": "pre-draft v0",
+    "model_version": "rookie-alpha-predraft-v0.1.0",
+    "formula": {
+      "ras_weight": 0.35,
+      "production_weight": 0.45,
+      "draft_capital_proxy_weight": 0.2,
+      "age_at_entry_supported": false
+    }
+  },
+  "generated_at": "2026-03-25T00:36:09+00:00",
+  "season": 2026,
+  "coverage_summary": {
+    "players_total": 4,
+    "players_with_any_missing_input": 0,
+    "players_with_full_inputs": 4
+  },
+  "source_files_used": [
+    "data/raw/2026_combine_results.json",
+    "data/processed/2026_college_production.json",
+    "data/processed/2026_draft_capital_proxy.json"
+  ],
+  "players": [
+    {
+      "player_id": "wr-malik-ford",
+      "player_name": "Malik Ford",
+      "position": "WR",
+      "scores": {
+        "ras_0_100": 61.6667,
+        "production_0_100": 88.1,
+        "draft_capital_proxy_0_100": 82.3,
+        "rookie_alpha_0_100": 77.6883
+      },
+      "model_inputs_missing": [],
+      "rookie_alpha_rank": 1
+    },
+    {
+      "player_id": "rb-ashley-jennings",
+      "player_name": "Ashley Jennings",
+      "position": "RB",
+      "scores": {
+        "ras_0_100": 61.6667,
+        "production_0_100": 86.2,
+        "draft_capital_proxy_0_100": 74.0,
+        "rookie_alpha_0_100": 75.1733
+      },
+      "model_inputs_missing": [],
+      "rookie_alpha_rank": 2
+    },
+    {
+      "player_id": "rb-darius-cole",
+      "player_name": "Darius Cole",
+      "position": "RB",
+      "scores": {
+        "ras_0_100": 38.3333,
+        "production_0_100": 78.4,
+        "draft_capital_proxy_0_100": 67.5,
+        "rookie_alpha_0_100": 62.1967
+      },
+      "model_inputs_missing": [],
+      "rookie_alpha_rank": 3
+    },
+    {
+      "player_id": "wr-keon-banks",
+      "player_name": "Keon Banks",
+      "position": "WR",
+      "scores": {
+        "ras_0_100": 38.3333,
+        "production_0_100": 73.9,
+        "draft_capital_proxy_0_100": 64.8,
+        "rookie_alpha_0_100": 59.6317
+      },
+      "model_inputs_missing": [],
+      "rookie_alpha_rank": 4
+    }
+  ]
+}

--- a/scripts/compute_rookie_alpha.py
+++ b/scripts/compute_rookie_alpha.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+"""Standalone pre-draft Rookie Alpha pipeline (v0).
+
+Reads artifact-only JSON inputs and writes promoted JSON + CSV outputs.
+No DB writes. No runtime dependencies on TIBER-Fantasy services.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from statistics import mean, pstdev
+from typing import Any
+
+
+@dataclass(frozen=True)
+class PlayerInputs:
+    player_id: str
+    player_name: str
+    position: str
+    ras_score_0_100: float | None
+    production_score_0_100: float | None
+    draft_capital_proxy_0_100: float | None
+
+
+def load_json(path: Path) -> Any:
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def clamp_0_100(value: float) -> float:
+    return max(0.0, min(100.0, value))
+
+
+def z_to_score(z: float) -> float:
+    # 50 at average, ~16.7 points per standard deviation.
+    return clamp_0_100(50.0 + (z * 16.6667))
+
+
+def safe_stats(values: list[float]) -> tuple[float, float]:
+    if not values:
+        return (0.0, 1.0)
+    if len(values) == 1:
+        return (values[0], 1.0)
+    sd = pstdev(values)
+    return (mean(values), sd if sd > 1e-9 else 1.0)
+
+
+def compute_ras_scores(combine_rows: list[dict[str, Any]]) -> dict[str, float]:
+    by_position: dict[str, list[dict[str, Any]]] = {}
+    for row in combine_rows:
+        by_position.setdefault(str(row.get("position", "UNK")), []).append(row)
+
+    scores: dict[str, float] = {}
+    for position, rows in by_position.items():
+        forties = [float(r["forty"]) for r in rows if r.get("forty") is not None]
+        verticals = [float(r["vertical"]) for r in rows if r.get("vertical") is not None]
+        broads = [float(r["broad"]) for r in rows if r.get("broad") is not None]
+        heights = [float(r["height_in"]) for r in rows if r.get("height_in") is not None]
+        weights = [float(r["weight_lb"]) for r in rows if r.get("weight_lb") is not None]
+
+        forty_mu, forty_sd = safe_stats(forties)
+        vert_mu, vert_sd = safe_stats(verticals)
+        broad_mu, broad_sd = safe_stats(broads)
+        h_mu, h_sd = safe_stats(heights)
+        w_mu, w_sd = safe_stats(weights)
+
+        for r in rows:
+            components: list[tuple[float, float]] = []
+            if r.get("forty") is not None:
+                z = (forty_mu - float(r["forty"])) / forty_sd  # lower is better
+                components.append((0.35, z_to_score(z)))
+            if r.get("vertical") is not None:
+                z = (float(r["vertical"]) - vert_mu) / vert_sd
+                components.append((0.25, z_to_score(z)))
+            if r.get("broad") is not None:
+                z = (float(r["broad"]) - broad_mu) / broad_sd
+                components.append((0.25, z_to_score(z)))
+
+            size_parts: list[float] = []
+            if r.get("height_in") is not None:
+                size_parts.append(z_to_score((float(r["height_in"]) - h_mu) / h_sd))
+            if r.get("weight_lb") is not None:
+                size_parts.append(z_to_score((float(r["weight_lb"]) - w_mu) / w_sd))
+            if size_parts:
+                components.append((0.15, mean(size_parts)))
+
+            if components:
+                weight_sum = sum(weight for weight, _ in components)
+                weighted = sum(weight * score for weight, score in components) / weight_sum
+                scores[str(r["player_id"])] = clamp_0_100(weighted)
+            else:
+                scores[str(r["player_id"])] = 50.0
+
+    return scores
+
+
+def merge_inputs(
+    combine_rows: list[dict[str, Any]],
+    production_rows: list[dict[str, Any]],
+    draft_proxy_rows: list[dict[str, Any]],
+) -> list[PlayerInputs]:
+    ras_by_id = compute_ras_scores(combine_rows)
+    prod_by_id = {str(r["player_id"]): float(r["production_score_0_100"]) for r in production_rows}
+    draft_by_id = {str(r["player_id"]): float(r["draft_capital_proxy_0_100"]) for r in draft_proxy_rows}
+
+    names_positions: dict[str, tuple[str, str]] = {}
+    for row in combine_rows:
+        pid = str(row["player_id"])
+        names_positions[pid] = (str(row.get("player_name", pid)), str(row.get("position", "UNK")))
+    for row in production_rows:
+        pid = str(row["player_id"])
+        names_positions.setdefault(pid, (str(row.get("player_name", pid)), str(row.get("position", "UNK"))))
+    for row in draft_proxy_rows:
+        pid = str(row["player_id"])
+        names_positions.setdefault(pid, (str(row.get("player_name", pid)), str(row.get("position", "UNK"))))
+
+    all_ids = sorted(set(ras_by_id) | set(prod_by_id) | set(draft_by_id))
+    players: list[PlayerInputs] = []
+    for pid in all_ids:
+        name, position = names_positions.get(pid, (pid, "UNK"))
+        players.append(
+            PlayerInputs(
+                player_id=pid,
+                player_name=name,
+                position=position,
+                ras_score_0_100=ras_by_id.get(pid),
+                production_score_0_100=prod_by_id.get(pid),
+                draft_capital_proxy_0_100=draft_by_id.get(pid),
+            )
+        )
+    return players
+
+
+def rookie_alpha_score(player: PlayerInputs) -> float:
+    ras = player.ras_score_0_100 if player.ras_score_0_100 is not None else 50.0
+    production = player.production_score_0_100 if player.production_score_0_100 is not None else 50.0
+    draft = player.draft_capital_proxy_0_100 if player.draft_capital_proxy_0_100 is not None else 50.0
+    return clamp_0_100((0.35 * ras) + (0.45 * production) + (0.20 * draft))
+
+
+def write_outputs(
+    players: list[PlayerInputs],
+    season: int,
+    combine_path: Path,
+    production_path: Path,
+    draft_proxy_path: Path,
+    output_json: Path,
+    output_csv: Path,
+) -> None:
+    generated_at = datetime.now(tz=timezone.utc).replace(microsecond=0).isoformat()
+
+    ranked: list[dict[str, Any]] = []
+    missing_any = 0
+    for p in players:
+        alpha = rookie_alpha_score(p)
+        missing_components = [
+            key
+            for key, value in {
+                "ras": p.ras_score_0_100,
+                "production": p.production_score_0_100,
+                "draft_capital_proxy": p.draft_capital_proxy_0_100,
+            }.items()
+            if value is None
+        ]
+        if missing_components:
+            missing_any += 1
+        ranked.append(
+            {
+                "player_id": p.player_id,
+                "player_name": p.player_name,
+                "position": p.position,
+                "scores": {
+                    "ras_0_100": round(p.ras_score_0_100 if p.ras_score_0_100 is not None else 50.0, 4),
+                    "production_0_100": round(
+                        p.production_score_0_100 if p.production_score_0_100 is not None else 50.0,
+                        4,
+                    ),
+                    "draft_capital_proxy_0_100": round(
+                        p.draft_capital_proxy_0_100 if p.draft_capital_proxy_0_100 is not None else 50.0,
+                        4,
+                    ),
+                    "rookie_alpha_0_100": round(alpha, 4),
+                },
+                "model_inputs_missing": missing_components,
+            }
+        )
+
+    ranked.sort(key=lambda r: r["scores"]["rookie_alpha_0_100"], reverse=True)
+    for i, row in enumerate(ranked, start=1):
+        row["rookie_alpha_rank"] = i
+
+    payload = {
+        "model": {
+            "name": "tiber-rookie-alpha",
+            "stage": "pre-draft",
+            "label": "pre-draft v0",
+            "model_version": "rookie-alpha-predraft-v0.1.0",
+            "formula": {
+                "ras_weight": 0.35,
+                "production_weight": 0.45,
+                "draft_capital_proxy_weight": 0.20,
+                "age_at_entry_supported": False,
+            },
+        },
+        "generated_at": generated_at,
+        "season": season,
+        "coverage_summary": {
+            "players_total": len(ranked),
+            "players_with_any_missing_input": missing_any,
+            "players_with_full_inputs": len(ranked) - missing_any,
+        },
+        "source_files_used": [
+            str(combine_path),
+            str(production_path),
+            str(draft_proxy_path),
+        ],
+        "players": ranked,
+    }
+
+    output_json.parent.mkdir(parents=True, exist_ok=True)
+    output_csv.parent.mkdir(parents=True, exist_ok=True)
+
+    with output_json.open("w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2)
+        f.write("\n")
+
+    with output_csv.open("w", encoding="utf-8", newline="") as f:
+        writer = csv.DictWriter(
+            f,
+            fieldnames=[
+                "rookie_alpha_rank",
+                "player_id",
+                "player_name",
+                "position",
+                "ras_0_100",
+                "production_0_100",
+                "draft_capital_proxy_0_100",
+                "rookie_alpha_0_100",
+                "model_inputs_missing",
+            ],
+        )
+        writer.writeheader()
+        for row in ranked:
+            writer.writerow(
+                {
+                    "rookie_alpha_rank": row["rookie_alpha_rank"],
+                    "player_id": row["player_id"],
+                    "player_name": row["player_name"],
+                    "position": row["position"],
+                    "ras_0_100": row["scores"]["ras_0_100"],
+                    "production_0_100": row["scores"]["production_0_100"],
+                    "draft_capital_proxy_0_100": row["scores"]["draft_capital_proxy_0_100"],
+                    "rookie_alpha_0_100": row["scores"]["rookie_alpha_0_100"],
+                    "model_inputs_missing": ",".join(row["model_inputs_missing"]),
+                }
+            )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Compute standalone Rookie Alpha promoted export")
+    parser.add_argument("--season", type=int, default=2026)
+    parser.add_argument(
+        "--combine-input",
+        type=Path,
+        default=Path("data/raw/2026_combine_results.json"),
+    )
+    parser.add_argument(
+        "--production-input",
+        type=Path,
+        default=Path("data/processed/2026_college_production.json"),
+    )
+    parser.add_argument(
+        "--draft-proxy-input",
+        type=Path,
+        default=Path("data/processed/2026_draft_capital_proxy.json"),
+    )
+    parser.add_argument(
+        "--output-json",
+        type=Path,
+        default=Path("exports/promoted/rookie-alpha/2026_rookie_alpha_predraft_v0.json"),
+    )
+    parser.add_argument(
+        "--output-csv",
+        type=Path,
+        default=Path("exports/promoted/rookie-alpha/2026_rookie_alpha_predraft_v0.csv"),
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    combine_rows = load_json(args.combine_input)
+    production_rows = load_json(args.production_input)
+    draft_rows = load_json(args.draft_proxy_input)
+    players = merge_inputs(combine_rows, production_rows, draft_rows)
+    write_outputs(
+        players=players,
+        season=args.season,
+        combine_path=args.combine_input,
+        production_path=args.production_input,
+        draft_proxy_path=args.draft_proxy_input,
+        output_json=args.output_json,
+        output_csv=args.output_csv,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Extract the rookie grading flow from TIBER-Fantasy into a minimal, standalone promoted lab for honest handoff. 
- Remove runtime/DB coupling so the Alpha stage can be run and versioned independently and consumed by TIBER-Fantasy later. 

### Description
- Scaffold repository layout with `docs/`, `scripts/`, `data/raw/`, `data/processed/`, and `exports/promoted/rookie-alpha/` and add `.gitignore` for Python artifacts. 
- Implement `scripts/compute_rookie_alpha.py` to compute RAS scores per-position, merge artifact inputs, and compute Rookie Alpha with the preserved formula (RAS 35%, Production 45%, Draft capital proxy 20%) without any DB or runtime dependencies. 
- Produce promoted JSON and CSV exports that include metadata (`model_version`, `generated_at`, `season`, `coverage_summary`, `source_files_used`) and rank players; add sample 2026 input artifacts and generated outputs. 
- Document the promoted export contract and a short architecture note that marks the implementation as `pre-draft v0` and lists future phases (landing spot adjustment and NFL transition blending). 

### Testing
- Ran the pipeline end-to-end with `python3 scripts/compute_rookie_alpha.py` which completed successfully and produced JSON + CSV outputs. 
- Verified the script compiles with `python3 -m py_compile scripts/compute_rookie_alpha.py` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c32d3011848332aefc0110ed3654f6)