### PR TITLE
PR2: Add guardrails, tests, and CI for rookie alpha pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Compile pipeline script
+        run: python3 -m py_compile scripts/compute_rookie_alpha.py
+
+      - name: Run tests
+        run: python3 -m unittest discover -s tests -p 'test_*.py' -v

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 __pycache__/
 *.pyc
+.pytest_cache/
+.coverage
+.DS_Store
+.venv/

--- a/README.md
+++ b/README.md
@@ -41,11 +41,11 @@ This is explicitly labeled as `pre-draft v0` in export metadata.
 
 ## Inputs
 
-Default artifact inputs:
+By default, inputs are resolved from the `--season` flag (defaults to current UTC year):
 
-- `data/raw/2026_combine_results.json`
-- `data/processed/2026_college_production.json`
-- `data/processed/2026_draft_capital_proxy.json`
+- `data/raw/{season}_combine_results.json`
+- `data/processed/{season}_college_production.json`
+- `data/processed/{season}_draft_capital_proxy.json`
 
 ## Run
 
@@ -67,8 +67,8 @@ python3 scripts/compute_rookie_alpha.py \
 
 ## Outputs (promoted contract)
 
-- `exports/promoted/rookie-alpha/2026_rookie_alpha_predraft_v0.json`
-- `exports/promoted/rookie-alpha/2026_rookie_alpha_predraft_v0.csv`
+- `exports/promoted/rookie-alpha/{season}_rookie_alpha_predraft_v0.json`
+- `exports/promoted/rookie-alpha/{season}_rookie_alpha_predraft_v0.csv`
 
 Export metadata includes:
 
@@ -79,6 +79,11 @@ Export metadata includes:
 - `source_files_used`
 
 Full field-level contract is documented in `docs/export-contract.md`.
+
+## Known v0 caveats
+
+- Small-group positional samples (especially when very few prospects test) can distort relative RAS separation.
+- If any upstream input artifact changes, committed exports must be regenerated so promoted outputs remain in sync with source files.
 
 ## How TIBER-Fantasy should consume this later
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -13,6 +13,11 @@ Implemented formula (honest current state):
 
 The pipeline consumes local artifacts only and writes promoted exports (JSON + CSV). There are no DB writes and no dependency on TIBER-Fantasy runtime services.
 
+## Known v0 caveats
+
+- Small positional cohorts can produce noisy or exaggerated RAS separation due to thin within-position samples.
+- Promoted exports are build artifacts and must be regenerated after any input artifact update.
+
 ## Upstream conceptual lineage
 
 This standalone flow ports the intent of the existing TIBER-Fantasy rookie scripts into a clean handoff shape:

--- a/scripts/compute_rookie_alpha.py
+++ b/scripts/compute_rookie_alpha.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import argparse
 import csv
 import json
+import logging
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -28,8 +29,15 @@ class PlayerInputs:
 
 
 def load_json(path: Path) -> Any:
-    with path.open("r", encoding="utf-8") as f:
-        return json.load(f)
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            return json.load(f)
+    except FileNotFoundError as exc:
+        raise SystemExit(f"Input file not found: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"Invalid JSON in {path}: {exc.msg} (line {exc.lineno}, column {exc.colno})") from exc
+    except OSError as exc:
+        raise SystemExit(f"Unable to read input file {path}: {exc}") from exc
 
 
 def clamp_0_100(value: float) -> float:
@@ -50,18 +58,82 @@ def safe_stats(values: list[float]) -> tuple[float, float]:
     return (mean(values), sd if sd > 1e-9 else 1.0)
 
 
+def coerce_float(value: Any, field_name: str, player_id: str, source_name: str) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        logging.warning(
+            "Skipping invalid %s value %r for player_id=%s in %s; field will be treated as missing.",
+            field_name,
+            value,
+            player_id,
+            source_name,
+        )
+        return None
+
+
+def normalize_row(
+    row: dict[str, Any],
+    source_name: str,
+    row_number: int,
+) -> tuple[str, str, str] | None:
+    player_id_raw = row.get("player_id")
+    if player_id_raw is None or str(player_id_raw).strip() == "":
+        logging.warning(
+            "Skipping row %s in %s because required field player_id is missing.",
+            row_number,
+            source_name,
+        )
+        return None
+    player_id = str(player_id_raw)
+    player_name = str(row.get("player_name", player_id))
+    position = str(row.get("position", "UNK"))
+    return (player_id, player_name, position)
+
+
 def compute_ras_scores(combine_rows: list[dict[str, Any]]) -> dict[str, float]:
     by_position: dict[str, list[dict[str, Any]]] = {}
-    for row in combine_rows:
-        by_position.setdefault(str(row.get("position", "UNK")), []).append(row)
+    for idx, row in enumerate(combine_rows, start=1):
+        normalized = normalize_row(row, "combine input", idx)
+        if normalized is None:
+            continue
+        pid, _, position = normalized
+        by_position.setdefault(position, []).append({"player_id": pid, **row})
 
     scores: dict[str, float] = {}
     for position, rows in by_position.items():
-        forties = [float(r["forty"]) for r in rows if r.get("forty") is not None]
-        verticals = [float(r["vertical"]) for r in rows if r.get("vertical") is not None]
-        broads = [float(r["broad"]) for r in rows if r.get("broad") is not None]
-        heights = [float(r["height_in"]) for r in rows if r.get("height_in") is not None]
-        weights = [float(r["weight_lb"]) for r in rows if r.get("weight_lb") is not None]
+        forties = [
+            value
+            for r in rows
+            for value in [coerce_float(r.get("forty"), "forty", str(r["player_id"]), "combine input")]
+            if value is not None
+        ]
+        verticals = [
+            value
+            for r in rows
+            for value in [coerce_float(r.get("vertical"), "vertical", str(r["player_id"]), "combine input")]
+            if value is not None
+        ]
+        broads = [
+            value
+            for r in rows
+            for value in [coerce_float(r.get("broad"), "broad", str(r["player_id"]), "combine input")]
+            if value is not None
+        ]
+        heights = [
+            value
+            for r in rows
+            for value in [coerce_float(r.get("height_in"), "height_in", str(r["player_id"]), "combine input")]
+            if value is not None
+        ]
+        weights = [
+            value
+            for r in rows
+            for value in [coerce_float(r.get("weight_lb"), "weight_lb", str(r["player_id"]), "combine input")]
+            if value is not None
+        ]
 
         forty_mu, forty_sd = safe_stats(forties)
         vert_mu, vert_sd = safe_stats(verticals)
@@ -71,21 +143,27 @@ def compute_ras_scores(combine_rows: list[dict[str, Any]]) -> dict[str, float]:
 
         for r in rows:
             components: list[tuple[float, float]] = []
-            if r.get("forty") is not None:
-                z = (forty_mu - float(r["forty"])) / forty_sd  # lower is better
+            forty = coerce_float(r.get("forty"), "forty", str(r["player_id"]), "combine input")
+            vertical = coerce_float(r.get("vertical"), "vertical", str(r["player_id"]), "combine input")
+            broad = coerce_float(r.get("broad"), "broad", str(r["player_id"]), "combine input")
+            height = coerce_float(r.get("height_in"), "height_in", str(r["player_id"]), "combine input")
+            weight = coerce_float(r.get("weight_lb"), "weight_lb", str(r["player_id"]), "combine input")
+
+            if forty is not None:
+                z = (forty_mu - forty) / forty_sd  # lower is better
                 components.append((0.35, z_to_score(z)))
-            if r.get("vertical") is not None:
-                z = (float(r["vertical"]) - vert_mu) / vert_sd
+            if vertical is not None:
+                z = (vertical - vert_mu) / vert_sd
                 components.append((0.25, z_to_score(z)))
-            if r.get("broad") is not None:
-                z = (float(r["broad"]) - broad_mu) / broad_sd
+            if broad is not None:
+                z = (broad - broad_mu) / broad_sd
                 components.append((0.25, z_to_score(z)))
 
             size_parts: list[float] = []
-            if r.get("height_in") is not None:
-                size_parts.append(z_to_score((float(r["height_in"]) - h_mu) / h_sd))
-            if r.get("weight_lb") is not None:
-                size_parts.append(z_to_score((float(r["weight_lb"]) - w_mu) / w_sd))
+            if height is not None:
+                size_parts.append(z_to_score((height - h_mu) / h_sd))
+            if weight is not None:
+                size_parts.append(z_to_score((weight - w_mu) / w_sd))
             if size_parts:
                 components.append((0.15, mean(size_parts)))
 
@@ -105,19 +183,50 @@ def merge_inputs(
     draft_proxy_rows: list[dict[str, Any]],
 ) -> list[PlayerInputs]:
     ras_by_id = compute_ras_scores(combine_rows)
-    prod_by_id = {str(r["player_id"]): float(r["production_score_0_100"]) for r in production_rows}
-    draft_by_id = {str(r["player_id"]): float(r["draft_capital_proxy_0_100"]) for r in draft_proxy_rows}
+    prod_by_id: dict[str, float] = {}
+    for idx, row in enumerate(production_rows, start=1):
+        normalized = normalize_row(row, "production input", idx)
+        if normalized is None:
+            continue
+        player_id, _, _ = normalized
+        value = coerce_float(row.get("production_score_0_100"), "production_score_0_100", player_id, "production input")
+        if value is not None:
+            prod_by_id[player_id] = value
+
+    draft_by_id: dict[str, float] = {}
+    for idx, row in enumerate(draft_proxy_rows, start=1):
+        normalized = normalize_row(row, "draft proxy input", idx)
+        if normalized is None:
+            continue
+        player_id, _, _ = normalized
+        value = coerce_float(
+            row.get("draft_capital_proxy_0_100"),
+            "draft_capital_proxy_0_100",
+            player_id,
+            "draft proxy input",
+        )
+        if value is not None:
+            draft_by_id[player_id] = value
 
     names_positions: dict[str, tuple[str, str]] = {}
-    for row in combine_rows:
-        pid = str(row["player_id"])
-        names_positions[pid] = (str(row.get("player_name", pid)), str(row.get("position", "UNK")))
-    for row in production_rows:
-        pid = str(row["player_id"])
-        names_positions.setdefault(pid, (str(row.get("player_name", pid)), str(row.get("position", "UNK"))))
-    for row in draft_proxy_rows:
-        pid = str(row["player_id"])
-        names_positions.setdefault(pid, (str(row.get("player_name", pid)), str(row.get("position", "UNK"))))
+    for idx, row in enumerate(combine_rows, start=1):
+        normalized = normalize_row(row, "combine input", idx)
+        if normalized is None:
+            continue
+        pid, player_name, position = normalized
+        names_positions[pid] = (player_name, position)
+    for idx, row in enumerate(production_rows, start=1):
+        normalized = normalize_row(row, "production input", idx)
+        if normalized is None:
+            continue
+        pid, player_name, position = normalized
+        names_positions.setdefault(pid, (player_name, position))
+    for idx, row in enumerate(draft_proxy_rows, start=1):
+        normalized = normalize_row(row, "draft proxy input", idx)
+        if normalized is None:
+            continue
+        pid, player_name, position = normalized
+        names_positions.setdefault(pid, (player_name, position))
 
     all_ids = sorted(set(ras_by_id) | set(prod_by_id) | set(draft_by_id))
     players: list[PlayerInputs] = []
@@ -169,6 +278,12 @@ def write_outputs(
         ]
         if missing_components:
             missing_any += 1
+            logging.warning(
+                "Missing model inputs for player_id=%s (%s): %s. Defaulting missing inputs to 50.0.",
+                p.player_id,
+                p.player_name,
+                ",".join(missing_components),
+            )
         ranked.append(
             {
                 "player_id": p.player_id,
@@ -263,49 +378,62 @@ def write_outputs(
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Compute standalone Rookie Alpha promoted export")
-    parser.add_argument("--season", type=int, default=2026)
+    parser.add_argument("--season", type=int, default=datetime.now(tz=timezone.utc).year)
     parser.add_argument(
         "--combine-input",
         type=Path,
-        default=Path("data/raw/2026_combine_results.json"),
+        default=None,
     )
     parser.add_argument(
         "--production-input",
         type=Path,
-        default=Path("data/processed/2026_college_production.json"),
+        default=None,
     )
     parser.add_argument(
         "--draft-proxy-input",
         type=Path,
-        default=Path("data/processed/2026_draft_capital_proxy.json"),
+        default=None,
     )
     parser.add_argument(
         "--output-json",
         type=Path,
-        default=Path("exports/promoted/rookie-alpha/2026_rookie_alpha_predraft_v0.json"),
+        default=None,
     )
     parser.add_argument(
         "--output-csv",
         type=Path,
-        default=Path("exports/promoted/rookie-alpha/2026_rookie_alpha_predraft_v0.csv"),
+        default=None,
     )
     return parser.parse_args()
 
 
 def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
     args = parse_args()
-    combine_rows = load_json(args.combine_input)
-    production_rows = load_json(args.production_input)
-    draft_rows = load_json(args.draft_proxy_input)
+    combine_input = args.combine_input or Path(f"data/raw/{args.season}_combine_results.json")
+    production_input = args.production_input or Path(f"data/processed/{args.season}_college_production.json")
+    draft_proxy_input = args.draft_proxy_input or Path(f"data/processed/{args.season}_draft_capital_proxy.json")
+    output_json = args.output_json or Path(f"exports/promoted/rookie-alpha/{args.season}_rookie_alpha_predraft_v0.json")
+    output_csv = args.output_csv or Path(f"exports/promoted/rookie-alpha/{args.season}_rookie_alpha_predraft_v0.csv")
+
+    combine_rows = load_json(combine_input)
+    production_rows = load_json(production_input)
+    draft_rows = load_json(draft_proxy_input)
+    if not isinstance(combine_rows, list):
+        raise SystemExit(f"Expected list JSON in {combine_input}, got {type(combine_rows).__name__}")
+    if not isinstance(production_rows, list):
+        raise SystemExit(f"Expected list JSON in {production_input}, got {type(production_rows).__name__}")
+    if not isinstance(draft_rows, list):
+        raise SystemExit(f"Expected list JSON in {draft_proxy_input}, got {type(draft_rows).__name__}")
     players = merge_inputs(combine_rows, production_rows, draft_rows)
     write_outputs(
         players=players,
         season=args.season,
-        combine_path=args.combine_input,
-        production_path=args.production_input,
-        draft_proxy_path=args.draft_proxy_input,
-        output_json=args.output_json,
-        output_csv=args.output_csv,
+        combine_path=combine_input,
+        production_path=production_input,
+        draft_proxy_path=draft_proxy_input,
+        output_json=output_json,
+        output_csv=output_csv,
     )
 
 

--- a/tests/test_compute_rookie_alpha.py
+++ b/tests/test_compute_rookie_alpha.py
@@ -1,0 +1,138 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.compute_rookie_alpha import (
+    PlayerInputs,
+    compute_ras_scores,
+    load_json,
+    merge_inputs,
+    rookie_alpha_score,
+    write_outputs,
+)
+
+
+class RookieAlphaTests(unittest.TestCase):
+    def test_ras_scoring_behavior(self) -> None:
+        combine_rows = [
+            {
+                "player_id": "rb_fast",
+                "player_name": "Fast Back",
+                "position": "RB",
+                "forty": 4.4,
+                "vertical": 38,
+                "broad": 125,
+                "height_in": 71,
+                "weight_lb": 210,
+            },
+            {
+                "player_id": "rb_slow",
+                "player_name": "Slow Back",
+                "position": "RB",
+                "forty": 4.65,
+                "vertical": 31,
+                "broad": 113,
+                "height_in": 70,
+                "weight_lb": 208,
+            },
+        ]
+
+        scores = compute_ras_scores(combine_rows)
+        self.assertIn("rb_fast", scores)
+        self.assertIn("rb_slow", scores)
+        self.assertGreater(scores["rb_fast"], scores["rb_slow"])
+
+    def test_rookie_alpha_score(self) -> None:
+        player = PlayerInputs(
+            player_id="p1",
+            player_name="Player 1",
+            position="WR",
+            ras_score_0_100=80.0,
+            production_score_0_100=60.0,
+            draft_capital_proxy_0_100=70.0,
+        )
+        self.assertAlmostEqual(rookie_alpha_score(player), 69.0)
+
+    def test_merge_inputs(self) -> None:
+        combine_rows = [
+            {
+                "player_id": "p1",
+                "player_name": "One",
+                "position": "WR",
+                "forty": 4.4,
+            }
+        ]
+        production_rows = [
+            {
+                "player_id": "p2",
+                "player_name": "Two",
+                "position": "RB",
+                "production_score_0_100": 75,
+            }
+        ]
+        draft_rows = [
+            {
+                "player_id": "p3",
+                "player_name": "Three",
+                "position": "TE",
+                "draft_capital_proxy_0_100": 85,
+            }
+        ]
+
+        players = merge_inputs(combine_rows, production_rows, draft_rows)
+        self.assertEqual([p.player_id for p in players], ["p1", "p2", "p3"])
+
+    def test_draft_capital_proxy_handling(self) -> None:
+        players = [
+            PlayerInputs("p1", "One", "WR", 80, 80, None),
+            PlayerInputs("p2", "Two", "WR", 80, 80, 100),
+        ]
+        self.assertLess(rookie_alpha_score(players[0]), rookie_alpha_score(players[1]))
+
+    def test_missing_input_behavior_and_logging(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            out_json = Path(tmp) / "out.json"
+            out_csv = Path(tmp) / "out.csv"
+            player = PlayerInputs(
+                player_id="p_missing",
+                player_name="Missing Inputs",
+                position="QB",
+                ras_score_0_100=None,
+                production_score_0_100=60.0,
+                draft_capital_proxy_0_100=None,
+            )
+            with self.assertLogs(level="WARNING") as cm:
+                write_outputs(
+                    players=[player],
+                    season=2026,
+                    combine_path=Path("combine.json"),
+                    production_path=Path("production.json"),
+                    draft_proxy_path=Path("draft.json"),
+                    output_json=out_json,
+                    output_csv=out_csv,
+                )
+            self.assertTrue(any("Defaulting missing inputs to 50.0" in line for line in cm.output))
+
+    def test_missing_required_player_fields_are_skipped(self) -> None:
+        players = merge_inputs(
+            combine_rows=[{"player_name": "No Id", "position": "WR", "forty": 4.5}],
+            production_rows=[],
+            draft_proxy_rows=[],
+        )
+        self.assertEqual(players, [])
+
+    def test_load_json_errors_are_friendly(self) -> None:
+        with self.assertRaises(SystemExit) as missing_file_error:
+            load_json(Path("/tmp/does-not-exist.json"))
+        self.assertIn("Input file not found", str(missing_file_error.exception))
+
+        with tempfile.TemporaryDirectory() as tmp:
+            invalid_json = Path(tmp) / "bad.json"
+            invalid_json.write_text("{not-json", encoding="utf-8")
+            with self.assertRaises(SystemExit) as invalid_json_error:
+                load_json(invalid_json)
+            self.assertIn("Invalid JSON", str(invalid_json_error.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Improve minimum quality and safety of the standalone Rookie Alpha artifact pipeline without changing model weights or architecture. 
- Make runtime behavior friendlier on bad inputs and avoid silent failures when the script is run with different seasons or missing/invalid artifacts.

### Description
- Added input validation and friendly error messages in `scripts/compute_rookie_alpha.py`, including `load_json` error handling for missing files and invalid JSON, top-level list-shape checks, row normalization that skips records missing `player_id`, and numeric coercion with warnings for invalid metric values.
- Parameterized defaults so season-driven paths are used by default instead of hardcoded 2026 file names, and default output paths follow the selected `--season`.
- Emit explicit `WARNING` logs when model components are missing and defaults of `50.0` are used for scoring.
- Added unit tests covering RAS scoring behavior, `rookie_alpha_score()`, `merge_inputs()`, draft-capital-proxy handling, missing-input defaults/logging, required-field skipping, and friendly JSON/file error handling in `tests/test_compute_rookie_alpha.py`.
- Added a basic GitHub Actions CI workflow (`.github/workflows/ci.yml`) that runs `python3 -m py_compile scripts/compute_rookie_alpha.py` and the test suite, updated docs to document v0 caveats, and expanded `.gitignore` for common Python/local artifacts.

### Testing
- Ran `python3 -m py_compile scripts/compute_rookie_alpha.py`, which succeeded. 
- Ran the full unit test suite with `python3 -m unittest discover -s tests -p 'test_*.py' -v`, and all tests passed locally (tests cover RAS, merging, scoring, missing-input behavior, and load error messages).
- Added CI workflow to reproduce the above steps on push/pull requests (`.github/workflows/ci.yml`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c333a7293483329eb891c310966de3)