### PR TITLE
Add dedicated 2026 rookie board with deterministic tiered ranking

### DIFF
--- a/cards/rookies/board/index.html
+++ b/cards/rookies/board/index.html
@@ -1,0 +1,87 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>TIBER Rookie Board | 2026</title>
+    <link rel="stylesheet" href="/components/rookies/rookieCardStyles.css" />
+  </head>
+  <body>
+    <main class="page">
+      <a class="nav-link" href="/cards/rookies/index.html">← Back to rookie gallery</a>
+      <div class="section-title" style="margin-top: 12px">TIBER 2026 Rookie Board</div>
+      <h1>Draft board surface</h1>
+      <p class="meta">Ranking-first board powered by promoted Rookie Grade artifacts. Use tiers to spot cliffs, then jump to detail/compare.</p>
+      <p style="margin-top: 10px"><a class="nav-link" href="/cards/rookies/compare/index.html">Open compare tool →</a></p>
+
+      <section id="board-summary" class="board-summary" style="margin-top: 14px">Loading board summary…</section>
+      <section id="board-controls-root" style="margin-top: 10px">Loading board controls…</section>
+      <section id="board-root" style="margin-top: 12px">Loading rookie board…</section>
+    </main>
+
+    <script type="module">
+      import { getAllRookieCards } from '/lib/rookies/getRookieCardData.js';
+      import { buildRookieBoardRows, filterRookieBoard, sortRookieBoard } from '/lib/rookies/buildRookieBoardRows.js';
+      import { groupRookiesByTier } from '/lib/rookies/groupRookiesByTier.js';
+      import { getRookieTierRules } from '/lib/rookies/deriveRookieTier.js';
+      import { renderRookieBoardControls } from '/components/rookies/RookieBoardControls.js';
+      import { renderRookieBoard } from '/components/rookies/RookieBoard.js';
+
+      const summaryRoot = document.getElementById('board-summary');
+      const controlsRoot = document.getElementById('board-controls-root');
+      const boardRoot = document.getElementById('board-root');
+      const state = { sort: 'grade', position: 'ALL', view: 'tiered' };
+
+      function collectPositions(rows) {
+        return [...new Set(rows.map((row) => row.position).filter(Boolean))].sort();
+      }
+
+      function renderSummary(allRows, activeRows) {
+        const positionCounts = activeRows.reduce((acc, row) => {
+          acc[row.position] = (acc[row.position] ?? 0) + 1;
+          return acc;
+        }, {});
+        const topPositionBits = Object.entries(positionCounts)
+          .sort((a, b) => b[1] - a[1])
+          .slice(0, 3)
+          .map(([position, count]) => `${position}: ${count}`)
+          .join(' • ');
+        const tierCount = groupRookiesByTier(activeRows).length;
+        const tierRules = getRookieTierRules().map((rule) => Number.isFinite(rule.minGrade) ? `${rule.label} (${rule.minGrade}+)` : rule.label).join(' | ');
+
+        summaryRoot.innerHTML = `
+          <div><span class="section-title">Board snapshot</span><div class="board-summary-value">${activeRows.length} shown / ${allRows.length} total</div></div>
+          <div><span class="section-title">Position mix</span><div class="meta">${topPositionBits || 'No position data available'}</div></div>
+          <div><span class="section-title">Tier bands</span><div class="meta">${tierCount} shown • ${tierRules}</div></div>
+        `;
+      }
+
+      function render(allRows) {
+        const positions = collectPositions(allRows);
+        const filtered = filterRookieBoard(allRows, { position: state.position });
+        const sorted = sortRookieBoard(filtered, state.sort);
+
+        renderSummary(allRows, sorted);
+        controlsRoot.innerHTML = renderRookieBoardControls({ positions, state });
+        boardRoot.innerHTML = renderRookieBoard(sorted, { view: state.view });
+
+        controlsRoot.querySelectorAll('select[data-board-control]').forEach((el) => {
+          el.addEventListener('change', (event) => {
+            state[event.target.dataset.boardControl] = event.target.value;
+            render(allRows);
+          });
+        });
+      }
+
+      try {
+        const cards = await getAllRookieCards();
+        const rows = buildRookieBoardRows(cards);
+        render(rows);
+      } catch (error) {
+        summaryRoot.innerHTML = '';
+        controlsRoot.innerHTML = '';
+        boardRoot.innerHTML = `<div class="meta">Failed to load rookie board: ${error.message}</div>`;
+      }
+    </script>
+  </body>
+</html>

--- a/cards/rookies/index.html
+++ b/cards/rookies/index.html
@@ -8,9 +8,10 @@
   </head>
   <body>
     <main class="page">
-      <div class="section-title">TIBER 2026 Rookie Class</div>
-      <h1>Rookie Class Board</h1>
-      <p class="meta">Pre-draft v0 data source. Sorted by Rookie Grade by default. Use controls to browse position slices.</p>
+      <div class="section-title">TIBER 2026 Rookie Gallery</div>
+      <h1>Browse rookie cards</h1>
+      <p class="meta">Browse-first card gallery for profile inspection. For ranked draft decisions, use the dedicated board.</p>
+      <p style="margin-top: 10px"><a class="nav-link" href="/cards/rookies/board/index.html">Open rookie board →</a></p>
       <p style="margin-top: 10px"><a class="nav-link" href="/cards/rookies/compare/index.html">Open rookie compare tool →</a></p>
       <div id="ranking-context" class="meta" style="margin-top: 8px">Loading class context…</div>
       <div id="controls-root">Loading controls…</div>

--- a/components/rookies/RookieBoard.js
+++ b/components/rookies/RookieBoard.js
@@ -1,0 +1,41 @@
+import { renderRookieBoardRow } from '/components/rookies/RookieBoardRow.js';
+import { groupRookiesByTier } from '/lib/rookies/groupRookiesByTier.js';
+
+export function renderRookieBoard(rows, { view = 'tiered' } = {}) {
+  if (!rows.length) {
+    return '<article class="rookie-card"><div class="meta">No rookies matched this board filter.</div></article>';
+  }
+
+  const header = `
+    <div class="board-row board-header">
+      <div class="board-cell">Rank</div>
+      <div class="board-cell">Player</div>
+      <div class="board-cell">Pos</div>
+      <div class="board-cell">School</div>
+      <div class="board-cell">Rookie Grade</div>
+      <div class="board-cell">Tier</div>
+      <div class="board-cell">Actions</div>
+    </div>
+  `;
+
+  if (view === 'flat') {
+    return `<section class="rookie-board-surface">${header}${rows.map(renderRookieBoardRow).join('')}</section>`;
+  }
+
+  const groups = groupRookiesByTier(rows);
+  return `
+    <section class="rookie-board-surface">${header}
+      ${groups
+        .map(
+          (group) => `
+            <div class="board-tier-break">
+              <div class="board-tier-title">${group.label}</div>
+              <div class="meta">${group.rows.length} rookies</div>
+            </div>
+            ${group.rows.map(renderRookieBoardRow).join('')}
+          `
+        )
+        .join('')}
+    </section>
+  `;
+}

--- a/components/rookies/RookieBoardControls.js
+++ b/components/rookies/RookieBoardControls.js
@@ -1,0 +1,43 @@
+function esc(str) {
+  return String(str ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function option(value, label, selectedValue) {
+  const selected = value === selectedValue ? ' selected' : '';
+  return `<option value="${esc(value)}"${selected}>${esc(label)}</option>`;
+}
+
+export function renderRookieBoardControls({ positions, state }) {
+  return `
+    <form class="gallery-controls board-controls" id="rookie-board-controls">
+      <label class="control-field">
+        <span class="control-label">Sort board</span>
+        <select data-board-control="sort">
+          ${option('grade', 'Rookie Grade (desc)', state.sort)}
+          ${option('rank', 'Class Rank (asc)', state.sort)}
+          ${option('position', 'Position → Grade', state.sort)}
+        </select>
+      </label>
+
+      <label class="control-field">
+        <span class="control-label">Position</span>
+        <select data-board-control="position">
+          ${option('ALL', 'All positions', state.position)}
+          ${positions.map((position) => option(position, position, state.position)).join('')}
+        </select>
+      </label>
+
+      <label class="control-field">
+        <span class="control-label">Board view</span>
+        <select data-board-control="view">
+          ${option('tiered', 'Grouped by tier', state.view)}
+          ${option('flat', 'Flat ranking', state.view)}
+        </select>
+      </label>
+    </form>
+  `;
+}

--- a/components/rookies/RookieBoardRow.js
+++ b/components/rookies/RookieBoardRow.js
@@ -1,0 +1,31 @@
+function esc(str) {
+  return String(str ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+export function renderRookieBoardRow(row) {
+  const rank = row.classRank == null ? 'N/A' : `#${row.classRank}`;
+  const grade = row.rookieGrade == null ? 'N/A' : row.rookieGrade.toFixed(1);
+  const slug = encodeURIComponent(String(row.slug ?? ''));
+
+  return `
+    <article class="board-row">
+      <div class="board-cell board-rank" data-label="Rank">${esc(rank)}</div>
+      <div class="board-cell board-player" data-label="Player">
+        <div class="board-player-name">${esc(row.name)}</div>
+        <div class="meta">${esc(row.profileSummary)}</div>
+      </div>
+      <div class="board-cell" data-label="Position">${esc(row.position)}</div>
+      <div class="board-cell" data-label="School">${esc(row.school)}</div>
+      <div class="board-cell board-grade" data-label="Rookie Grade">${esc(grade)}</div>
+      <div class="board-cell" data-label="Tier"><span class="board-tier-pill">${esc(row.tier.label)}</span></div>
+      <div class="board-cell board-actions" data-label="Actions">
+        <a class="nav-link" href="/cards/rookies/player.html?slug=${slug}">Detail</a>
+        <a class="nav-link" href="/cards/rookies/compare/index.html?left=${slug}">Compare</a>
+      </div>
+    </article>
+  `;
+}

--- a/components/rookies/rookieCardStyles.css
+++ b/components/rookies/rookieCardStyles.css
@@ -132,3 +132,102 @@ body {
 .compare-notes { margin: 8px 0 0; padding-left: 18px; color: #c7d5ea; display: grid; gap: 6px; }
 .compare-snapshot-grid { align-items: stretch; }
 .compare-snapshot { height: 100%; }
+
+.board-summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 10px;
+}
+.board-summary > div {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 12px;
+}
+.board-summary-value {
+  margin-top: 6px;
+  font-size: 22px;
+  font-weight: 700;
+}
+
+.rookie-board-surface {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: hidden;
+  background: rgba(10, 15, 24, 0.9);
+}
+.board-row {
+  display: grid;
+  grid-template-columns: 80px minmax(180px, 2fr) 80px 120px 110px 190px 130px;
+  gap: 8px;
+  align-items: center;
+  border-top: 1px solid var(--border);
+  padding: 10px 12px;
+}
+.board-row:first-child { border-top: none; }
+.board-header {
+  border-top: none;
+  background: #0f1725;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: .08em;
+  color: var(--muted);
+  font-weight: 700;
+}
+.board-cell { font-size: 14px; }
+.board-rank { color: #c3d7f4; font-weight: 700; }
+.board-player-name { font-weight: 700; margin-bottom: 2px; }
+.board-grade { color: var(--accent); font-weight: 800; font-size: 16px; }
+.board-tier-pill {
+  display: inline-block;
+  border-radius: 999px;
+  border: 1px solid rgba(83,168,255,.5);
+  background: rgba(83,168,255,.15);
+  color: #b7d8ff;
+  font-size: 12px;
+  padding: 4px 8px;
+}
+.board-actions { display: flex; flex-direction: column; gap: 4px; }
+.board-tier-break {
+  border-top: 1px solid var(--border);
+  background: rgba(19, 30, 45, 0.85);
+  padding: 10px 12px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.board-tier-title {
+  font-size: 12px;
+  letter-spacing: .1em;
+  text-transform: uppercase;
+  color: #c6d7ef;
+  font-weight: 700;
+}
+
+@media (max-width: 950px) {
+  .board-row {
+    grid-template-columns: 70px minmax(140px, 1.8fr) 60px 90px 100px 140px 110px;
+    font-size: 13px;
+  }
+}
+
+@media (max-width: 760px) {
+  .board-row {
+    grid-template-columns: 1fr;
+    gap: 4px;
+  }
+  .board-header { display: none; }
+  .board-actions { flex-direction: row; gap: 10px; }
+  .board-cell { display: flex; justify-content: space-between; }
+  .board-cell::before {
+    content: attr(data-label);
+    color: var(--muted);
+    text-transform: uppercase;
+    font-size: 11px;
+    letter-spacing: .08em;
+    margin-right: 10px;
+  }
+  .board-player { display: block; }
+  .board-player::before,
+  .board-actions::before { display: none; }
+}

--- a/docs/rookie-card-prototype.md
+++ b/docs/rookie-card-prototype.md
@@ -1,15 +1,18 @@
 # Rookie Card Prototype Handoff (2026 class)
 
-## PR8 update summary (compare surface)
+## PR9 update summary (first dedicated rookie board)
 
-- Added a dedicated rookie compare route so two real 2026 rookies can be evaluated side by side.
-- Added reusable compare UI components (selector + compare view) that render from existing mapped rookie card objects.
-- Added deterministic compare helper logic that returns verdict, grade delta, score/evidence rows, and compare notes.
-- Added lightweight compare launch affordances from class board (`Open rookie compare tool`) and compact cards (`Compare from this player`).
+- Added a dedicated 2026 rookie board route that is ranking-first and distinct from the browse-first gallery.
+- Added deterministic rookie board helpers for row building, tier derivation, sorting/filtering, and tier grouping.
+- Added a board surface with rank, position, school availability state, Rookie Grade, tier label, and short profile summary.
+- Added restrained board controls: sort, position filter, and tiered-vs-flat board view toggle.
+- Added quick board actions to jump directly into full detail (`player.html`) and compare (`compare/index.html?left=...`) flows.
+- Added a board header summary showing class coverage, position mix, tier count, and explicit tier rule bands.
 
 ## Routes
 
-- `/cards/rookies/index.html` (class board + compact cards + controls)
+- `/cards/rookies/index.html` (browse-first compact card gallery)
+- `/cards/rookies/board/index.html` (ranking-first rookie board surface)
 - `/cards/rookies/player.html?slug=<player_id>` (full detail route)
 - `/cards/rookies/compare/index.html?left=<slug>&right=<slug>` (two-player compare surface)
 - `/cards/rookies/wr-malik-ford/index.html` (direct single-player entry for one real rookie)
@@ -21,54 +24,61 @@
 - `data/processed/2026_college_production.json`
 - `data/processed/2026_draft_capital_proxy.json`
 
-## Compare verdict logic (transparent + deterministic)
+## Board sort/filter behavior
 
-Helper: `lib/rookies/compareRookies.js`
+Helper: `lib/rookies/buildRookieBoardRows.js`
 
-Returned compare object includes:
+- Default sort is `grade` (Rookie Grade descending, then class rank tiebreak).
+- Alternate sorts:
+  - `rank` (class rank ascending)
+  - `position` (position alpha, then grade desc, then class rank)
+- Position filter supports `ALL` + available class positions from mapped card objects.
+- View mode supports:
+  - `tiered` (grouped sections)
+  - `flat` (single ranked list)
 
-- `overallDelta` (left Rookie Grade − right Rookie Grade)
-- `verdict` (`Lean <name>`, `Close profile`, or `Insufficient edge`)
-- `scoreComparisons` (shared score buckets with winner/tie per row)
-- `evidenceComparisons` (shared metric rows sorted by absolute edge)
-- `sharedPosition` and `notes` (context + data-availability caveats)
+## Tier/group logic (deterministic + inspectable)
 
-Verdict decision order:
+Helper: `lib/rookies/deriveRookieTier.js`
 
-1. Compare overall Rookie Grade if available.
-2. Check edge balance from evidence rows.
-3. Emit one of:
-   - `Lean Player` (clear/slight edge)
-   - `Close profile` (small grade delta + narrow evidence split)
-   - `Insufficient edge` (grade missing / sparse evidence)
+Tier labels are intentionally coarse and score-band based:
 
-No fake model narration is used.
+- `Top cluster`: Rookie Grade >= 75
+- `Strong starter tier`: Rookie Grade >= 70
+- `Development tier`: Rookie Grade >= 65
+- `Swing tier`: Rookie Grade < 65
+- `Unscored cluster`: Rookie Grade missing
 
-## Evidence row selection behavior
+Grouping helper: `lib/rookies/groupRookiesByTier.js`
 
-- Evidence rows are derived from existing position-aware selection helper (`selectRookieEvidenceMetrics`) for each card.
-- Compare helper intersects shared metric labels and only keeps rows with values on both sides.
-- Rows are sorted by absolute delta and capped:
-  - same-position: up to 6 rows
-  - cross-position: lighter cap (up to 4 rows)
-- Directional honesty is enforced (`40 Yard Dash (s)` treats lower time as better).
+- Rows inherit the tier object from `deriveRookieTier`.
+- Tiered board sections are grouped by tier key and rendered in fixed bucket order.
+- No model-generated or opaque clustering is used.
 
-## Same-position vs cross-position handling
+## Quick action flow wiring
 
-- **Same position:** richer apples-to-apples evidence rows with stronger metric table.
-- **Cross position:** intentionally lighter evidence usage, with more weight on overall grade/scores and explicit notes.
-- If shared evidence is too sparse, compare view falls back to honest unavailable copy instead of fabricating precision.
+Board row actions intentionally reinforce:
 
-## Data honesty constraints still enforced
+`board -> inspect -> compare`
 
-- No fabricated school/age/comps/season rows.
-- No fake export claims (PNG/PDF is still TODO).
-- If artifacts do not carry a metric, card sections omit it or show explicit unavailable copy.
-- Verdict remains deterministic and inspectable from visible data fields.
+- `Detail` action links to `/cards/rookies/player.html?slug=<slug>`
+- `Compare` action links to `/cards/rookies/compare/index.html?left=<slug>`
 
-## Next likely expansion path
+This reuses existing route/query behavior and avoids introducing a parallel state system.
 
-1. Promote richer processed rookie profile artifact (school/age/bio + position-native stat fields).
-2. Add board-level “compare queue” flow (pick first, pick second) with persisted query state.
-3. Add role-specific compare templates once additional trustworthy metrics are in promoted artifacts.
-4. Reuse compare helper output for future draft-room decision views and exports.
+## Missing data handling
+
+- School remains honest to current artifact scope: board shows `School N/A` where school is not present in promoted data.
+- Profile summary falls back deterministically in this order:
+  1. archetype
+  2. projection
+  3. first tag
+  4. `Profile still forming`
+- Missing Rookie Grade is rendered as `N/A` and routed to `Unscored cluster`.
+
+## Next likely expansion path (toward draft-room)
+
+1. Add URL query-param persistence for board state (`sort`, `position`, `view`) so links can preserve board context.
+2. Add a lightweight compare queue (pick first, pick second from board rows) without simulating live draft mechanics.
+3. Expand promoted profile artifact with school/bio and position-native evidence so board rows can surface richer but still honest scouting signals.
+4. Layer in draft-room interactions (queue, targets, notes) on top of this board rather than replacing this deterministic board foundation.

--- a/lib/rookies/buildRookieBoardRows.js
+++ b/lib/rookies/buildRookieBoardRows.js
@@ -1,0 +1,53 @@
+import { deriveRookieTier } from './deriveRookieTier.js';
+
+function summarizeProfile(card) {
+  return card.summary.archetype ?? card.summary.projection ?? card.tags?.[0] ?? 'Profile still forming';
+}
+
+export function buildRookieBoardRows(cards) {
+  return cards.map((card) => {
+    const rookieGrade = card.summary.rookieGrade;
+    const tier = deriveRookieTier(rookieGrade);
+
+    return {
+      slug: card.slug,
+      name: card.identity.name,
+      position: card.identity.position ?? 'N/A',
+      school: card.identity.school ?? 'School N/A',
+      rookieGrade,
+      classRank: card.summary.classRank,
+      tier,
+      profileSummary: summarizeProfile(card),
+      tags: card.tags ?? [],
+    };
+  });
+}
+
+export function sortRookieBoard(rows, sort = 'grade') {
+  const copy = [...rows];
+
+  if (sort === 'rank') {
+    return copy.sort((a, b) => (a.classRank ?? Number.MAX_SAFE_INTEGER) - (b.classRank ?? Number.MAX_SAFE_INTEGER));
+  }
+
+  if (sort === 'position') {
+    return copy.sort((a, b) => {
+      if (a.position !== b.position) return a.position.localeCompare(b.position);
+      const bv = b.rookieGrade ?? Number.NEGATIVE_INFINITY;
+      const av = a.rookieGrade ?? Number.NEGATIVE_INFINITY;
+      if (bv !== av) return bv - av;
+      return (a.classRank ?? Number.MAX_SAFE_INTEGER) - (b.classRank ?? Number.MAX_SAFE_INTEGER);
+    });
+  }
+
+  return copy.sort((a, b) => {
+    const bv = b.rookieGrade ?? Number.NEGATIVE_INFINITY;
+    const av = a.rookieGrade ?? Number.NEGATIVE_INFINITY;
+    if (bv !== av) return bv - av;
+    return (a.classRank ?? Number.MAX_SAFE_INTEGER) - (b.classRank ?? Number.MAX_SAFE_INTEGER);
+  });
+}
+
+export function filterRookieBoard(rows, { position = 'ALL' } = {}) {
+  return rows.filter((row) => position === 'ALL' || row.position === position);
+}

--- a/lib/rookies/deriveRookieTier.js
+++ b/lib/rookies/deriveRookieTier.js
@@ -1,0 +1,23 @@
+const TIER_RULES = [
+  { key: 'tier_1', label: 'Top cluster', minGrade: 75 },
+  { key: 'tier_2', label: 'Strong starter tier', minGrade: 70 },
+  { key: 'tier_3', label: 'Development tier', minGrade: 65 },
+  { key: 'tier_4', label: 'Swing tier', minGrade: Number.NEGATIVE_INFINITY },
+];
+
+export function deriveRookieTier(rookieGrade) {
+  if (rookieGrade == null) {
+    return { key: 'unscored', label: 'Unscored cluster', bucketOrder: 99 };
+  }
+
+  const matched = TIER_RULES.find((rule) => rookieGrade >= rule.minGrade) ?? TIER_RULES[TIER_RULES.length - 1];
+  return {
+    key: matched.key,
+    label: matched.label,
+    bucketOrder: TIER_RULES.findIndex((rule) => rule.key === matched.key),
+  };
+}
+
+export function getRookieTierRules() {
+  return TIER_RULES.map((rule) => ({ ...rule }));
+}

--- a/lib/rookies/groupRookiesByTier.js
+++ b/lib/rookies/groupRookiesByTier.js
@@ -1,0 +1,18 @@
+export function groupRookiesByTier(rows) {
+  const grouped = new Map();
+
+  rows.forEach((row) => {
+    const key = row.tier.key;
+    if (!grouped.has(key)) {
+      grouped.set(key, {
+        key,
+        label: row.tier.label,
+        bucketOrder: row.tier.bucketOrder,
+        rows: [],
+      });
+    }
+    grouped.get(key).rows.push(row);
+  });
+
+  return [...grouped.values()].sort((a, b) => a.bucketOrder - b.bucketOrder);
+}


### PR DESCRIPTION
### Motivation
- Surface a ranking-first rookie board so users can move from browsing to making draft-forward decisions without adding a fake ADP engine or draft simulator. 
- Expose honest tier/cliff information and simple controls to help spot edges and quickly jump into existing detail/compare flows.

### Description
- Add a new ranking-first route at `cards/rookies/board/index.html` and reframe `cards/rookies/index.html` as a browse-first gallery that links to the board. 
- Implement deterministic board helpers in `lib/rookies/`: `buildRookieBoardRows` (row shaping + `sortRookieBoard` + `filterRookieBoard`), `deriveRookieTier` (coarse score-band tier rules), and `groupRookiesByTier` (stable tier ordering). 
- Add reusable UI components `components/rookies/RookieBoard.js`, `RookieBoardRow.js`, and `RookieBoardControls.js` to render flat vs tiered views, restrained sort/position/view controls, and per-row quick actions (`Detail`, `Compare`). 
- Extend `components/rookies/rookieCardStyles.css` with dark, scan-friendly styles for board summary cards, tier breaks, responsive rows, and pill labels; update `docs/rookie-card-prototype.md` describing the new route, controls, tier logic, and quick-action wiring.

### Testing
- Ran unit/integration tests with `python -m pytest -q` which succeeded: `13 passed`. 
- Performed static checks with Node on new/changed modules using `node --check` for the board components and helpers which returned no syntax errors for `components/rookies/RookieBoard.js`, `RookieBoardRow.js`, `RookieBoardControls.js`, and `lib/rookies/*`.
- Manual smoke wiring validated that the board uses existing mapped card data (`getAllRookieCards`) and that rows link into the existing `player.html` and `compare/index.html` flows (no automated UI screenshot available in this environment).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4363506ac833291f327226b83cdd8)