### PR TITLE
PR12: Align docs with current producer + static rookie prototype scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,41 @@
 # TIBER-Rookies
 
-Standalone rookie grading lab for the **current implemented pre-draft Rookie Alpha model (v0)**.
+TIBER-Rookies is a **standalone Rookie Alpha producer lab** with a **static rookie intelligence prototype** layered on top of real promoted artifacts.
 
-## Why this repo exists
+It is intentionally not a full draft room or live backend service.
 
-This repository extracts the rookie scoring path out of TIBER-Fantasy into a minimal, honest handoff artifact pipeline:
+## Repository framing
 
-- no frontend
-- no Express routes
-- no Drizzle/Postgres dependency
-- no dependency on TIBER-Fantasy runtime services
+This repo currently has two aligned layers:
 
-Primary output is a **promoted export** that TIBER-Fantasy (or any consumer) can ingest later.
+1. **Producer layer (authoritative)**
+   - computes the pre-draft Rookie Alpha model (`v0`)
+   - emits promoted JSON/CSV plus a reproducibility manifest
+   - supports validation before downstream ingest
+2. **Static product-surface layer (prototype)**
+   - reads mapped artifact data into static HTML surfaces
+   - provides gallery, board, detail, compare, and browser-local shortlist queue flows
+   - exists to validate UX direction on top of real artifacts, not to replace downstream ingestion contracts
+
+## Current capabilities
+
+### Producer + contract capabilities
+
+- Standalone promoted export pipeline via `scripts/compute_rookie_alpha.py`
+- Promoted artifact set per season:
+  - `exports/promoted/rookie-alpha/{season}_rookie_alpha_predraft_v0.json`
+  - `exports/promoted/rookie-alpha/{season}_rookie_alpha_predraft_v0.csv`
+  - `exports/promoted/rookie-alpha/{season}_manifest.json`
+- Manifest + validation contract documented in `docs/export-contract.md`
+- Consumer ingest gate helper: `scripts/validate_promoted_export.py`
+
+### Static rookie prototype capabilities
+
+- Gallery route: `/cards/rookies/index.html`
+- Board route: `/cards/rookies/board/index.html`
+- Detail route: `/cards/rookies/player.html?slug=<player_id>`
+- Compare route: `/cards/rookies/compare/index.html?left=<slug>&right=<slug>`
+- Browser-local shortlist queue (`localStorage`) with add/remove/reorder and compare-side assignment
 
 ## Repository layout
 
@@ -19,43 +43,40 @@ Primary output is a **promoted export** that TIBER-Fantasy (or any consumer) can
 - `docs/`
   - `architecture.md`
   - `export-contract.md`
+  - `rookie-card-prototype.md`
   - `tiber-fantasy-consumer-contract.md`
 - `scripts/`
   - `compute_rookie_alpha.py`
   - `validate_promoted_export.py`
+- `lib/rookies/`
+  - mapping/adaptation and prototype helpers
+- `cards/rookies/`
+  - static gallery/board/detail/compare surfaces
 - `data/raw/`
   - combine inputs (example 2026 artifact)
 - `data/processed/`
-  - college production and draft-capital-proxy artifacts
+  - production and draft-capital-proxy artifacts
 - `exports/promoted/rookie-alpha/`
-  - generated promoted JSON + CSV outputs
+  - generated promoted outputs
 
 ## Current model implementation (pre-draft v0)
 
-The formula preserved in this standalone pipeline is:
+Implemented formula:
 
 - **RAS 35%**
 - **Production 45%**
 - **Draft capital proxy 20%**
-- **No age-at-entry support yet**
+- **Age-at-entry not implemented yet**
 
-This is explicitly labeled as `pre-draft v0` in export metadata.
+This is explicitly labeled `pre-draft v0` in export metadata.
 
-## Inputs
-
-By default, inputs are resolved from the `--season` flag (defaults to current UTC year):
-
-- `data/raw/{season}_combine_results.json`
-- `data/processed/{season}_college_production.json`
-- `data/processed/{season}_draft_capital_proxy.json`
-
-## Run
+## Run producer pipeline
 
 ```bash
 python3 scripts/compute_rookie_alpha.py
 ```
 
-Optional flags:
+Optional explicit inputs/outputs:
 
 ```bash
 python3 scripts/compute_rookie_alpha.py \
@@ -67,42 +88,7 @@ python3 scripts/compute_rookie_alpha.py \
   --output-csv exports/promoted/rookie-alpha/2026_rookie_alpha_predraft_v0.csv
 ```
 
-## Outputs (promoted contract)
-
-- `exports/promoted/rookie-alpha/{season}_rookie_alpha_predraft_v0.json`
-- `exports/promoted/rookie-alpha/{season}_rookie_alpha_predraft_v0.csv`
-- `exports/promoted/rookie-alpha/{season}_manifest.json`
-
-Export metadata includes:
-
-- `model_version`
-- `generated_at`
-- `run_id`
-- `season`
-- `coverage_summary`
-- `source_files_used`
-
-The manifest is a machine-readable reproducibility record that includes:
-
-- `season`, `model_version`, `generated_at`, `run_id`
-- input file paths + SHA-256 hashes + row counts
-- output file paths + SHA-256 hashes
-- coverage summary and export metadata mirror for consistency checks
-
-Full field-level contract is documented in `docs/export-contract.md`.
-
-## Downstream validation checklist
-
-Before ingesting a promoted export, downstream systems (such as TIBER-Fantasy) should:
-
-1. Confirm all three files exist for the season (`.json`, `.csv`, and `_manifest.json`).
-2. Recompute SHA-256 for each listed input/output file and verify hashes exactly match manifest values.
-3. Verify manifest and export metadata agree exactly (`season`, `model_version`, `generated_at`, and coverage/source-file metadata).
-4. Validate row/coverage expectations from `coverage_summary` before import.
-
-## Downstream consumption (TIBER-Fantasy readiness)
-
-Use the consumer validation helper to gate ingestion:
+## Validate promoted export before ingest
 
 ```bash
 python3 scripts/validate_promoted_export.py \
@@ -110,53 +96,30 @@ python3 scripts/validate_promoted_export.py \
   --manifest exports/promoted/rookie-alpha/2026_manifest.json
 ```
 
-Expected behavior:
+Validation checks field presence, metadata consistency, hashes, and row-count expectations.
 
-- exits `0` and prints `VALIDATION PASSED` when contract checks succeed
-- exits non-zero and prints each failure condition when checks fail
+## Current limitations
 
-Validation includes:
+- Model is still **pre-draft v0** (no landing-spot or NFL transition phase yet).
+- Queue is **browser-local only** (no auth, no multi-device sync, no league persistence).
+- Repo is **not** a full draft room or live service.
+- Surface richness depends on available promoted/source artifact fields.
+- Missing player identity/context fields can still produce deterministic fallback states.
 
-1. export/manifest required field checks
-2. cross-file metadata consistency checks
-3. output hash verification (`output_files`)
-4. input hash + row count verification (`input_files`)
+## Next likely steps
 
-For downstream flat ingestion, derive a normalized view from the authoritative export at ingest time (instead of checking in a static consumer snapshot).
+- Enrich promoted rookie identity/context fields in producer artifacts.
+- Improve mapped evidence inputs used by static surfaces.
+- Add queue portability (import/export) before any account-backed persistence.
+- Consider draft-room layering only after real auth/persistence boundaries exist.
 
-Authoritative contract and failure semantics are documented in:
+## TIBER-Fantasy handoff stance
 
+TIBER-Fantasy (or any downstream consumer) should ingest promoted exports as versioned artifacts. It should not treat this repository as a live runtime dependency.
+
+See:
+
+- `docs/architecture.md`
+- `docs/export-contract.md`
 - `docs/tiber-fantasy-consumer-contract.md`
-
-## Known v0 caveats
-
-- Small-group positional samples (especially when very few prospects test) can distort relative RAS separation.
-- If any upstream input artifact changes, committed exports must be regenerated so promoted outputs remain in sync with source files.
-
-## How TIBER-Fantasy should consume this later
-
-TIBER-Fantasy should treat this repo as a producer and ingest the promoted JSON export as input data, not as a live service dependency.
-
-Recommended handoff pattern:
-
-1. Run this repo's pipeline for the season.
-2. Publish/version the promoted JSON artifact.
-3. TIBER-Fantasy import job reads the export and maps by `player_id`.
-4. Keep downstream UI/runtime logic separate from this model computation pipeline.
-
-## Future roadmap (not implemented yet)
-
-- Landing spot adjustment phase
-- NFL transition blending phase
-
-Those phases should extend the promoted artifact chain without breaking the pre-draft v0 contract.
-
-## Rookie card frontend prototype (2026)
-
-A small static product-surface prototype now exists to prove card rendering from real promoted data:
-
-- `cards/rookies/index.html`
-- `cards/rookies/player.html?slug=wr-malik-ford`
-- `cards/rookies/wr-malik-ford/index.html`
-
-Data is loaded directly from promoted/data artifacts and mapped via `lib/rookies/` adapters.
+- `docs/rookie-card-prototype.md`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,34 +1,88 @@
-# TIBER-Rookies Architecture Note
+# TIBER-Rookies Architecture
 
-## Scope now (implemented)
+## Current state of the repository
 
-This repo intentionally contains only a standalone pre-draft Rookie Alpha pipeline.
+TIBER-Rookies is currently a **dual-layer repository**:
 
-Implemented formula (honest current state):
+1. **Producer layer (authoritative contract surface)**
+2. **Static UI/product-surface layer (prototype consumer of mapped artifacts)**
 
-- RAS: 35%
-- College production: 45%
-- Draft capital proxy: 20%
-- Age-at-entry: **not yet implemented**
+This keeps model computation and downstream ingestion integrity intact while allowing fast UX iteration against real outputs.
 
-The pipeline consumes local artifacts only and writes promoted exports (JSON + CSV). There are no DB writes and no dependency on TIBER-Fantasy runtime services.
+## Layer 1: Producer layer (authoritative)
 
-## Known v0 caveats
+Core scripts:
 
-- Small positional cohorts can produce noisy or exaggerated RAS separation due to thin within-position samples.
-- Promoted exports are build artifacts and must be regenerated after any input artifact update.
+- `scripts/compute_rookie_alpha.py`
+- `scripts/validate_promoted_export.py`
 
-## Upstream conceptual lineage
+Producer responsibilities:
 
-This standalone flow ports the intent of the existing TIBER-Fantasy rookie scripts into a clean handoff shape:
+- compute pre-draft Rookie Alpha (`v0`) scores from local artifacts
+- emit promoted outputs (`json`, `csv`) and manifest (`*_manifest.json`)
+- maintain reproducibility and integrity metadata (hashes, row counts, run metadata)
 
-- RAS scoring
-- College production scoring
-- Rookie Alpha fusion/ranking
+Model formula currently implemented:
 
-## Future phases (not implemented yet)
+- RAS 35%
+- Production 45%
+- Draft capital proxy 20%
+- Age-at-entry not implemented yet
 
-1. Landing spot adjustment
-2. NFL transition blending
+Promoted artifacts are authoritative for downstream consumers.
 
-These later phases should layer on top of the promoted pre-draft export rather than coupling this repository back to runtime services.
+## Layer 2: Mapping/adaptation layer
+
+Core adaptation helpers live under `lib/rookies/`.
+
+Responsibilities:
+
+- map promoted/source artifacts into display-ready rookie card and board shapes
+- normalize/fallback incomplete fields into deterministic UI-safe values
+- provide compare and queue-supporting helpers without changing producer contract authority
+
+This layer intentionally sits between raw exports and static UI so prototype surfaces do not drift into a second model source of truth.
+
+## Layer 3: Static UI/product-surface layer (prototype)
+
+Static HTML routes under `cards/rookies/` currently include:
+
+- gallery: `/cards/rookies/index.html`
+- board: `/cards/rookies/board/index.html`
+- detail: `/cards/rookies/player.html?slug=<player_id>`
+- compare: `/cards/rookies/compare/index.html?left=<slug>&right=<slug>`
+- direct player page example: `/cards/rookies/wr-malik-ford/index.html`
+
+Behavioral scope today:
+
+- browse and inspect rookie cards/rows from mapped real artifacts
+- compare two rookies via query-param routing
+- maintain browser-local shortlist queue state (`localStorage`)
+
+This is a static prototype surface, not a draft-room service.
+
+## Downstream consumer boundary (TIBER-Fantasy and others)
+
+Downstream systems should consume **promoted exports** and validate them using the manifest contract before ingest.
+
+Boundary rule:
+
+- downstream consumers should ingest versioned exports
+- downstream consumers should not depend on this repository as a live backend
+
+See `docs/tiber-fantasy-consumer-contract.md` for ingest-gate requirements.
+
+## Limitations and intended evolution
+
+Current limitations:
+
+- pre-draft v0 only (no landing-spot/NFL transition layers)
+- static UI with browser-local queue only
+- surfaced richness constrained by available promoted/source fields
+
+Intended near-term direction:
+
+- enrich promoted identity/context fields
+- improve evidence mapping quality
+- add queue import/export portability before account-backed persistence
+- only layer true draft-room capabilities when auth/persistence boundaries are real

--- a/docs/export-contract.md
+++ b/docs/export-contract.md
@@ -1,10 +1,14 @@
-# Promoted Export Contract: Rookie Alpha (2026 pre-draft v0)
+# Promoted Export Contract: Rookie Alpha (pre-draft v0)
 
-This repository's primary artifact is a promoted export under:
+The promoted export contract is the authoritative producer output of this repository.
+
+Primary artifact set (example season `2026`):
 
 - `exports/promoted/rookie-alpha/2026_rookie_alpha_predraft_v0.json`
 - `exports/promoted/rookie-alpha/2026_rookie_alpha_predraft_v0.csv`
 - `exports/promoted/rookie-alpha/2026_manifest.json`
+
+Static rookie prototype routes in this repo may read mapped data derived from these artifacts, but they do not replace this contract as system-of-record output.
 
 ## JSON contract
 
@@ -22,7 +26,7 @@ Top-level fields:
     - `age_at_entry_supported` (false in v0)
 - `generated_at`: ISO-8601 UTC timestamp
 - `run_id`: run identifier shared with manifest
-- `season`: integer season, e.g. `2026`
+- `season`: integer season (example: `2026`)
 - `coverage_summary`
   - `players_total`
   - `players_with_any_missing_input`
@@ -57,7 +61,7 @@ Columns:
 8. `rookie_alpha_0_100`
 9. `model_inputs_missing`
 
-CSV is a flattened companion artifact for simpler downstream ingestion.
+CSV is a flattened companion artifact for row-oriented ingestion.
 
 ## Manifest contract (`*_manifest.json`)
 
@@ -78,7 +82,7 @@ Top-level fields:
 - `output_files`: list of
   - `path`
   - `sha256`
-- `export_metadata` (must match exactly)
+- `export_metadata` (must match export metadata exactly)
   - `season`
   - `model_version`
   - `generated_at`
@@ -91,8 +95,8 @@ Top-level fields:
 Consumers should reject an export if any of the following fail:
 
 1. Missing companion files (`.json`, `.csv`, manifest).
-2. Any input/output file hash mismatch against manifest.
+2. Input/output hash mismatch against manifest.
 3. `export_metadata` mismatch with manifest top-level metadata.
 4. Coverage counts outside expected operating thresholds.
 
-For TIBER-Fantasy specific ingestion gates and CLI validation workflow, see `docs/tiber-fantasy-consumer-contract.md`.
+For TIBER-Fantasy-specific ingest gates and CLI workflow, see `docs/tiber-fantasy-consumer-contract.md`.

--- a/docs/rookie-card-prototype.md
+++ b/docs/rookie-card-prototype.md
@@ -1,121 +1,96 @@
-# Rookie Card Prototype Handoff (2026 class)
+# Rookie Intelligence Prototype (static surfaces)
 
-## PR11 update summary (URL state + compare-side quick actions)
+## Purpose and maturity
 
-- Added URL query-param persistence for board control state (`sort`, `position`, `view`) so board links retain context.
-- Added `Set Left` / `Set Right` direct-nav actions on each board row, replacing the generic `Compare` link.
-- Added position validation guard in `render()` so a stale URL position param that falls outside the available class is reset to `ALL` rather than producing an empty board.
+This prototype demonstrates rookie browsing/inspection flows on top of real promoted artifacts from the Rookie Alpha producer pipeline.
 
-## PR10 update summary (first honest rookie shortlist queue)
+It is intentionally:
 
-- Added a local rookie shortlist queue workflow on top of the rookie board route.
-- Added queue controls on board rows (`Add to queue` / `Queued`) with duplicate prevention and visible queued state.
-- Added queue actions on detail cards and compact gallery cards for quick shortlist updates from inspect surfaces.
-- Added a dedicated queue panel on the board page with:
-  - queue summary strip
-  - queued player context rows (rank, name, position, school, Rookie Grade, tier, identity note)
-  - remove actions
-  - move up / move down ordering
-  - compare pairing controls (set left / set right) + quick compare launch
-- Added browser-local persistence through `localStorage` (no auth, no backend, no league sync implied).
-- Added a clear queue action with explicit confirmation prompt.
+- static (no backend service)
+- local-state-driven for shortlist queue behavior
+- scoped as a prototype surface, not a production draft room
 
-## Routes
+## Current routes and surfaces
 
-- `/cards/rookies/index.html` (browse-first compact card gallery)
-- `/cards/rookies/board/index.html` (ranking-first rookie board + local shortlist queue panel)
-- `/cards/rookies/player.html?slug=<player_id>` (full detail route + shortlist action)
-- `/cards/rookies/compare/index.html?left=<slug>&right=<slug>` (two-player compare surface)
-- `/cards/rookies/wr-malik-ford/index.html` (direct single-player entry for one real rookie)
+- `/cards/rookies/index.html`
+  - compact gallery for browse-first discovery
+- `/cards/rookies/board/index.html`
+  - ranking-first board with filters/sort/view controls and queue panel
+- `/cards/rookies/player.html?slug=<player_id>`
+  - detail view for a single rookie
+- `/cards/rookies/compare/index.html?left=<slug>&right=<slug>`
+  - two-player compare view
+- `/cards/rookies/wr-malik-ford/index.html`
+  - direct single-player entry example
 
-## Source data used (unchanged)
+## Data sources
+
+Surface data is mapped from repository artifacts, including:
 
 - `exports/promoted/rookie-alpha/2026_rookie_alpha_predraft_v0.json`
 - `data/raw/2026_combine_results.json`
 - `data/processed/2026_college_production.json`
 - `data/processed/2026_draft_capital_proxy.json`
 
-## Board URL state
+Mapping/adaptation helpers live in `lib/rookies/`.
+
+## Board flow and URL state
 
 Board route: `/cards/rookies/board/index.html`
 
-Board control state syncs to URL params on every render via `replaceState`:
+Board control state syncs to URL params via `replaceState`:
 
 - `sort=grade|rank|position`
 - `position=ALL|QB|RB|WR|TE|…`
 - `view=tiered|flat`
 
-State is hydrated from URL on initial load. Unknown sort/view values are ignored; unknown position values are reset to `ALL` at render time.
+State is hydrated from URL on initial load. Unknown sort/view values are ignored; invalid position values are reset to `ALL`.
 
-## Board row quick actions
+## Compare flow
 
-Board row actions reinforce the `board → inspect → compare` flow:
+Board and queue actions set compare sides and route to:
 
-- `Detail` links to `/cards/rookies/player.html?slug=<slug>`
-- `Set Left` links to `/cards/rookies/compare/index.html?left=<slug>`
-- `Set Right` links to `/cards/rookies/compare/index.html?right=<slug>`
-- `Add to queue` / `Queued` toggles local shortlist membership
+- `/cards/rookies/compare/index.html?left=<slug>&right=<slug>`
 
-## Queue state + persistence
+This is route-level glue to the existing compare surface; no separate compare backend or model variant is introduced.
 
-Helper: `lib/rookies/rookieQueueStore.js`
+## Shortlist queue behavior (browser-local)
 
-Queue state is intentionally small and browser-local:
+Queue helper: `lib/rookies/rookieQueueStore.js`
 
-- Storage key: `tiber-rookie-queue-v1`
-- Stored record fields:
-  - `slug`
-  - `name`
-  - `position`
-  - `school`
-  - `rookieGrade`
-  - `classRank`
-  - `tierLabel`
-  - `identityNote`
+Storage model:
 
-Supported store operations:
+- key: `tiber-rookie-queue-v1`
+- local browser profile only
+- no server writes, no auth, no cross-device sync
+
+Supported queue operations:
 
 - `loadRookieQueue()`
-- `addRookieToQueue(item)` (deduped by `slug`)
+- `addRookieToQueue(item)`
 - `removeRookieFromQueue(slug)`
 - `moveQueuedRookie(slug, 'up' | 'down')`
 - `clearRookieQueue()`
 - `isRookieQueued(slug)`
 
-No server writes are introduced. Queue is scoped to the current browser profile.
+## Missing-data and fallback behavior
 
-## Board + queue behavior
+Surfaces retain deterministic fallbacks where artifacts are incomplete:
 
-- Board rows include queue action controls alongside Set Left / Set Right in the action column.
-- Queued rows receive a subtle visual highlight.
-- Queue panel appears below the board with a jump link above the board rows.
-- Summary strip includes:
-  - total queued players
-  - position mix
-  - highest-ranked queued player
-  - explicit local-storage disclaimer
-- Each queued row includes rank, player identity, rookie grade + tier, identity note, detail jump link, remove action, move up/down actions, and compare side assignment actions.
+- school may render as `School N/A`
+- profile summary falls back to available archetype/projection/tag data
+- missing Rookie Grade renders as `N/A`
+- queue rows use fallback labels for unavailable fields
 
-## Compare-from-queue behavior
+## Current limitations
 
-- Queue rows support `Set Left` and `Set Right` markers.
-- Queue toolbar exposes `Compare selected pair` when both sides are set and distinct.
-- Compare launch reuses existing compare route/query model:
-  - `/cards/rookies/compare/index.html?left=<slug>&right=<slug>`
+- Prototype reads from current artifact coverage; richer identity/context depends on producer-field expansion.
+- Queue is local-only and should not be interpreted as shared draft state.
+- Surface interactions are static-route UX scaffolding, not league workflow infrastructure.
 
-No new compare engine is added; this is routing glue into the existing compare page.
+## Next likely steps (grounded)
 
-## Missing data handling
-
-- School remains honest to current artifact scope: board shows `School N/A` where not in promoted data.
-- Profile summary falls back deterministically: archetype → projection → first tag → `Profile still forming`.
-- Missing Rookie Grade renders as `N/A` and routes to `Unscored cluster`.
-- Queue entries: missing school → `School N/A`, missing grade → `N/A`, missing notes → `Profile note unavailable`, missing tier → `Tier N/A`.
-
-## Next likely expansion path (toward draft-room)
-
-1. Add optional queue notes (short deterministic text only) per queued rookie in local state.
-2. Add lightweight import/export for queue JSON so users can move shortlist state between browsers.
-3. Expand promoted profile artifact with school/bio and position-native evidence so board rows can surface richer but still honest scouting signals.
-4. Add account-backed persistence only when draft-room auth and tenancy boundaries are real (not simulated in prototype).
-5. Layer in draft-room interactions (queue, targets, notes) on top of this board rather than replacing this deterministic board foundation.
+1. Enrich promoted rookie identity/context fields upstream.
+2. Improve mapped evidence inputs for board/detail/compare clarity.
+3. Add queue import/export portability for local workflows.
+4. Consider account-backed draft-room features only when auth/persistence boundaries exist.

--- a/docs/tiber-fantasy-consumer-contract.md
+++ b/docs/tiber-fantasy-consumer-contract.md
@@ -1,10 +1,16 @@
 # TIBER-Fantasy Consumer Contract (Rookie Alpha promoted export)
 
-This document defines the **ingestion gate** for TIBER-Fantasy before importing a promoted Rookie Alpha artifact.
+This document defines the ingestion gate TIBER-Fantasy should enforce before importing a promoted Rookie Alpha artifact.
+
+## Boundary statement
+
+TIBER-Fantasy should consume promoted exports as versioned artifacts.
+
+It should **not** depend on this repository's static rookie prototype routes (`gallery`, `board`, `detail`, `compare`, local queue) as a runtime service boundary.
 
 ## Required files
 
-For a season (example `2026`), TIBER-Fantasy ingestion requires all artifacts below from `exports/promoted/rookie-alpha/`:
+For a season (example `2026`), ingestion requires all artifacts from `exports/promoted/rookie-alpha/`:
 
 1. `{season}_rookie_alpha_predraft_v0.json` (authoritative model export)
 2. `{season}_rookie_alpha_predraft_v0.csv` (flat companion)
@@ -45,23 +51,21 @@ The following values must be identical across export and manifest:
 
 Treat any condition below as a hard ingest failure:
 
-- Missing required files
-- Export/manifest parse errors
-- Required field omissions
+- missing required files
+- export/manifest parse errors
+- required field omissions
 - `export_metadata` mismatch
-- Input hash mismatch
-- Output hash mismatch
-- Input `row_count` mismatch
+- input hash mismatch
+- output hash mismatch
+- input `row_count` mismatch
 
-Suggested downstream behavior: reject ingest, log full validation errors, and request a regenerated promoted export.
+Suggested downstream behavior: reject ingest, log full validation errors, request regenerated promoted export.
 
 ## Consumer-ready normalized view (optional, derived)
 
-The promoted JSON is authoritative but nests scores under `players[].scores`, which can be awkward for consumers that want row-oriented ingestion.
+Promoted JSON is authoritative but nests score fields under `players[].scores`. Consumers may derive a normalized row shape at ingest time rather than relying on committed snapshot files.
 
-To avoid stale committed snapshots, consumers should derive a normalized view at ingest time (or in their own pipeline) rather than relying on a checked-in `.consumer_view.json` file.
-
-Recommended normalized row shape:
+Example normalized row shape:
 
 ```json
 {


### PR DESCRIPTION
### Motivation

- Reduce narrative drift by making the repository story match the current implemented shape: an authoritative producer pipeline plus a static prototype UI on top of real promoted artifacts. 
- Make it obvious to downstream teams how to consume artifacts and what surfaces actually exist today so the repo is usable for handoff without reconstructing PR history.

### Description

- Reframed top-level documentation in `README.md` to describe the dual-layer repo (producer layer + static product-surface prototype), added a concise `Current capabilities` section, `Current limitations`, and grounded `Next likely steps`, and clarified the TIBER-Fantasy handoff stance. 
- Added a clear architecture/state-of-repo note in `docs/architecture.md` with the requested layering: Producer → Mapping/Adaptation → Static UI → Downstream consumer boundary, and documented responsibilities for each layer. 
- Tightened the promoted export contract in `docs/export-contract.md` to reaffirm that promoted artifacts are authoritative while acknowledging that static surfaces read mapped data. 
- Rewrote and aligned the prototype handoff doc at `docs/rookie-card-prototype.md` to inventory routes (`gallery`, `board`, `detail`, `compare`), describe queue behavior and fallback rules, and call out limitations and next steps. 
- Reinforced ingestion/validation boundaries in `docs/tiber-fantasy-consumer-contract.md` so consumers validate and ingest promoted exports rather than depending on static prototype routes. 
- Files changed: `README.md`, `docs/architecture.md`, `docs/export-contract.md`, `docs/rookie-card-prototype.md`, `docs/tiber-fantasy-consumer-contract.md` (documentation-only adjustments; no feature or contract weakening). 

### Testing

- Ran the promoted export validation helper: `python3 scripts/validate_promoted_export.py --export-json exports/promoted/rookie-alpha/2026_rookie_alpha_predraft_v0.json --manifest exports/promoted/rookie-alpha/2026_manifest.json`, and it printed `VALIDATION PASSED` (exit code 0).
- No other automated tests were required or changed because this PR contains documentation and minor narrative alignment only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c46f6ceaec83329147d3d3e92cefee)