### PR TITLE
Add browser-local rookie queue import/export portability

### DIFF
--- a/cards/rookies/board/index.html
+++ b/cards/rookies/board/index.html
@@ -29,7 +29,7 @@
       import { renderRookieBoardControls } from '/components/rookies/RookieBoardControls.js';
       import { renderRookieBoard } from '/components/rookies/RookieBoard.js';
       import { renderRookieQueuePanel } from '/components/rookies/RookieQueuePanel.js';
-      import { addRookieToQueue, clearRookieQueue, isRookieQueued, loadRookieQueue, moveQueuedRookie, removeRookieFromQueue } from '/lib/rookies/rookieQueueStore.js';
+      import { addRookieToQueue, clearRookieQueue, importRookieQueue, isRookieQueued, loadRookieQueue, moveQueuedRookie, removeRookieFromQueue, serializeRookieQueue } from '/lib/rookies/rookieQueueStore.js';
 
       const summaryRoot = document.getElementById('board-summary');
       const controlsRoot = document.getElementById('board-controls-root');
@@ -40,6 +40,7 @@
       const VIEW_OPTIONS = new Set(['tiered', 'flat']);
       const state = { sort: 'grade', position: 'ALL', view: 'tiered' };
       const compareState = { left: null, right: null };
+      const portabilityState = { mode: 'replace', tone: 'info', message: '' };
 
       function hydrateStateFromUrl() {
         const params = new URLSearchParams(window.location.search);
@@ -75,6 +76,25 @@
           tierLabel: row.tier?.label,
           identityNote: row.profileSummary,
         };
+      }
+
+      function setPortabilityStatus(message, tone = 'info') {
+        portabilityState.message = message;
+        portabilityState.tone = tone;
+      }
+
+      function readFileAsText(file) {
+        return new Promise((resolve, reject) => {
+          const reader = new FileReader();
+          reader.onload = () => resolve(String(reader.result ?? ''));
+          reader.onerror = () => reject(new Error('Import failed: unable to read the selected file.'));
+          reader.readAsText(file);
+        });
+      }
+
+      function buildExportFilename() {
+        const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+        return `tiber-rookie-queue-${stamp}.json`;
       }
 
       function renderSummary(allRows, activeRows) {
@@ -162,6 +182,72 @@
             render(allRows);
           });
         }
+
+        const modeSelect = queueRoot.querySelector('[data-queue-import-mode]');
+        if (modeSelect) {
+          modeSelect.addEventListener('change', (event) => {
+            portabilityState.mode = event.target.value === 'merge' ? 'merge' : 'replace';
+            setPortabilityStatus(
+              portabilityState.mode === 'replace'
+                ? 'Import mode: Replace queue (default).'
+                : 'Import mode: Merge imported queue first, keep existing extras after.',
+              'info',
+            );
+            render(allRows);
+          });
+        }
+
+        const exportButton = queueRoot.querySelector('[data-queue-export]');
+        if (exportButton) {
+          exportButton.addEventListener('click', () => {
+            const payload = serializeRookieQueue();
+            const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' });
+            const url = URL.createObjectURL(blob);
+            const anchor = document.createElement('a');
+            anchor.href = url;
+            anchor.download = buildExportFilename();
+            anchor.click();
+            URL.revokeObjectURL(url);
+            setPortabilityStatus(`Exported ${payload.metadata.total_items} queue items to JSON.`, 'info');
+            render(allRows);
+          });
+        }
+
+        const importInput = queueRoot.querySelector('[data-queue-import-input]');
+        const importTrigger = queueRoot.querySelector('[data-queue-import-trigger]');
+        if (importInput && importTrigger) {
+          importTrigger.addEventListener('click', () => {
+            importInput.value = '';
+            importInput.click();
+          });
+
+          importInput.addEventListener('change', async (event) => {
+            const file = event.target.files?.[0];
+            if (!file) return;
+
+            try {
+              const mode = portabilityState.mode === 'merge' ? 'merge' : 'replace';
+              if (mode === 'replace' && loadRookieQueue().length > 0) {
+                if (!window.confirm('Replace your current local queue with this imported file?')) return;
+              }
+
+              const raw = await readFileAsText(file);
+              const importedQueue = importRookieQueue(raw, { mode });
+              const queueSlugs = new Set(importedQueue.map((player) => player.slug));
+              if (compareState.left && !queueSlugs.has(compareState.left)) compareState.left = null;
+              if (compareState.right && !queueSlugs.has(compareState.right)) compareState.right = null;
+
+              setPortabilityStatus(
+                `Imported ${importedQueue.length} queue items via ${mode} mode from ${file.name}.`,
+                'info',
+              );
+            } catch (error) {
+              setPortabilityStatus(error.message || 'Import failed for an unknown reason.', 'error');
+            }
+
+            render(allRows);
+          });
+        }
       }
 
       function render(allRows) {
@@ -178,7 +264,7 @@
           view: state.view,
           queueSlugs: new Set(queue.map((player) => player.slug)),
         });
-        queueRoot.innerHTML = renderRookieQueuePanel(queue, compareState);
+        queueRoot.innerHTML = renderRookieQueuePanel(queue, compareState, portabilityState);
         syncUrlState();
 
         controlsRoot.querySelectorAll('select[data-board-control]').forEach((el) => {

--- a/components/rookies/RookieQueuePanel.js
+++ b/components/rookies/RookieQueuePanel.js
@@ -27,9 +27,12 @@ function findHighestRanked(queue) {
   return ranked[0] ?? null;
 }
 
-export function renderRookieQueuePanel(queue, compareState = {}) {
+export function renderRookieQueuePanel(queue, compareState = {}, portabilityState = {}) {
   const highestRanked = findHighestRanked(queue);
   const canCompare = compareState.left && compareState.right && compareState.left !== compareState.right;
+  const importMode = portabilityState.mode === 'merge' ? 'merge' : 'replace';
+  const statusTone = portabilityState.tone === 'error' ? 'error' : 'info';
+  const statusMessage = portabilityState.message ?? 'Export to a JSON file, then import on another browser/device.';
 
   return `
     <section class="queue-panel">
@@ -44,6 +47,17 @@ export function renderRookieQueuePanel(queue, compareState = {}) {
         <a class="nav-link ${canCompare ? '' : 'is-disabled'}" href="${canCompare ? `/cards/rookies/compare/index.html?left=${encodeURIComponent(compareState.left)}&right=${encodeURIComponent(compareState.right)}` : '#'}">Compare selected pair →</a>
         <button type="button" class="queue-clear" data-queue-clear ${queue.length ? '' : 'disabled'}>Clear queue</button>
       </div>
+      <div class="queue-toolbar" style="margin-top: 10px; align-items: center; gap: 8px; flex-wrap: wrap;">
+        <button type="button" class="queue-action" data-queue-export ${queue.length ? '' : 'disabled'}>Export queue JSON</button>
+        <label class="meta" for="queue-import-mode">Import mode</label>
+        <select id="queue-import-mode" data-queue-import-mode>
+          <option value="replace" ${importMode === 'replace' ? 'selected' : ''}>Replace queue</option>
+          <option value="merge" ${importMode === 'merge' ? 'selected' : ''}>Merge imported first</option>
+        </select>
+        <button type="button" class="queue-action" data-queue-import-trigger>Import queue JSON</button>
+        <input type="file" data-queue-import-input accept="application/json,.json" style="display: none" />
+      </div>
+      <div class="meta" data-queue-import-status="${statusTone}" style="${statusTone === 'error' ? 'color: #ff8f8f;' : ''}">${esc(statusMessage)}</div>
 
       <div class="queue-list">
         ${queue.length

--- a/docs/rookie-card-prototype.md
+++ b/docs/rookie-card-prototype.md
@@ -63,6 +63,7 @@ Storage model:
 - key: `tiber-rookie-queue-v1`
 - local browser profile only
 - no server writes, no auth, no cross-device sync
+- portability is file-based JSON export/import (manual, not synced)
 
 Supported queue operations:
 
@@ -72,6 +73,40 @@ Supported queue operations:
 - `moveQueuedRookie(slug, 'up' | 'down')`
 - `clearRookieQueue()`
 - `isRookieQueued(slug)`
+- `serializeRookieQueue()`
+- `importRookieQueue(payload, { mode: 'replace' | 'merge' })`
+
+### Queue portability (PR14)
+
+Queue portability is intentionally a **local workflow tool**, not a platform feature.
+
+- Export action downloads JSON from current browser-local queue state.
+- Import action validates JSON before writing to local storage.
+- Default import mode is **Replace queue** (with confirmation when queue is non-empty).
+- Optional import mode **Merge imported first** keeps imported order, dedupes by `slug`, and appends existing non-imported players after imported items.
+- Malformed/incompatible files fail with visible, concise errors and do not partially mutate queue state.
+
+Export payload shape (v1):
+
+- `version` (currently `1`)
+- `exported_at` (ISO timestamp)
+- `source` (surface note)
+- `queue` (array of queue entries)
+- `metadata` (lightweight context such as `total_items` and storage note)
+
+Validation/version rules:
+
+- Top-level value must be an object.
+- `version` must be exactly `1`.
+- `queue` must be an array.
+- each queue item must include a valid `slug`.
+- optional fields are normalized through queue-store fallbacks.
+
+Boundary note:
+
+- this JSON is a **portability artifact for static UI state**
+- it is **not** part of the producer/export contracts in `docs/export-contract.md`
+- it does **not** imply auth/account identity or cloud persistence
 
 
 ## Mapped identity/context enrichment

--- a/lib/rookies/rookieQueueStore.js
+++ b/lib/rookies/rookieQueueStore.js
@@ -1,4 +1,5 @@
 const STORAGE_KEY = 'tiber-rookie-queue-v1';
+const PORTABILITY_VERSION = 1;
 
 function canUseStorage() {
   return typeof window !== 'undefined' && typeof window.localStorage !== 'undefined';
@@ -18,6 +19,15 @@ function normalizeItem(item) {
   };
 }
 
+function dedupeQueueBySlug(queue) {
+  const seen = new Set();
+  return queue.filter((item) => {
+    if (seen.has(item.slug)) return false;
+    seen.add(item.slug);
+    return true;
+  });
+}
+
 export function loadRookieQueue() {
   if (!canUseStorage()) return [];
 
@@ -34,7 +44,8 @@ export function loadRookieQueue() {
 
 function persistRookieQueue(queue) {
   if (!canUseStorage()) return;
-  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(queue.map(normalizeItem).filter(Boolean)));
+  const normalized = queue.map(normalizeItem).filter(Boolean);
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(dedupeQueueBySlug(normalized)));
 }
 
 export function addRookieToQueue(item) {
@@ -78,4 +89,79 @@ export function moveQueuedRookie(slug, direction) {
 export function clearRookieQueue() {
   persistRookieQueue([]);
   return [];
+}
+
+export function serializeRookieQueue() {
+  const queue = loadRookieQueue();
+  return {
+    version: PORTABILITY_VERSION,
+    exported_at: new Date().toISOString(),
+    source: 'Prometheus-Frameworks/TIBER-Rookies rookie board queue',
+    queue,
+    metadata: {
+      total_items: queue.length,
+      storage_key: STORAGE_KEY,
+      note: 'Browser-local portability artifact only. Not account/cloud sync.',
+    },
+  };
+}
+
+export function parseImportedRookieQueue(rawPayload) {
+  let payload = rawPayload;
+  if (typeof rawPayload === 'string') {
+    try {
+      payload = JSON.parse(rawPayload);
+    } catch {
+      throw new Error('Import failed: file is not valid JSON.');
+    }
+  }
+
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    throw new Error('Import failed: expected a top-level JSON object.');
+  }
+
+  if (payload.version !== PORTABILITY_VERSION) {
+    throw new Error(`Import failed: unsupported queue export version (${payload.version ?? 'missing'}).`);
+  }
+
+  if (!Array.isArray(payload.queue)) {
+    throw new Error('Import failed: expected "queue" to be an array.');
+  }
+
+  const normalized = payload.queue.map((item, index) => {
+    const next = normalizeItem(item);
+    if (!next) {
+      throw new Error(`Import failed: queue item ${index + 1} is missing a valid slug.`);
+    }
+    return next;
+  });
+
+  return {
+    queue: dedupeQueueBySlug(normalized),
+    metadata: payload.metadata && typeof payload.metadata === 'object' ? payload.metadata : {},
+  };
+}
+
+export function replaceRookieQueue(queue) {
+  persistRookieQueue(queue);
+  return loadRookieQueue();
+}
+
+export function mergeImportedRookieQueue(importedQueue) {
+  const existing = loadRookieQueue();
+  const importedSlugs = new Set(importedQueue.map((item) => item.slug));
+  const existingNotImported = existing.filter((item) => !importedSlugs.has(item.slug));
+  const next = [...importedQueue, ...existingNotImported];
+  persistRookieQueue(next);
+  return loadRookieQueue();
+}
+
+export function importRookieQueue(rawPayload, options = {}) {
+  const { mode = 'replace' } = options;
+  const parsed = parseImportedRookieQueue(rawPayload);
+
+  if (mode === 'replace') return replaceRookieQueue(parsed.queue);
+  if (mode === 'merge') return mergeImportedRookieQueue(parsed.queue);
+
+  throw new Error(`Import failed: unsupported import mode "${mode}".`);
 }


### PR DESCRIPTION
### Motivation
- Enable practical portability of the existing browser-local rookie shortlist so users can move/share their queue across browsers/devices without adding auth, accounts, or server persistence.  
- Provide a simple, honest JSON-based import/export flow that validates payloads, dedupes by `slug`, and keeps all queue persistence local.  
- Keep UX lightweight and deterministic (clear status/errors, replace-by-default semantics, optional merge mode).  

### Description
- Extended the queue store (`lib/rookies/rookieQueueStore.js`) with a portability layer including `PORTABILITY_VERSION`, `serializeRookieQueue()`, `parseImportedRookieQueue()`, `replaceRookieQueue()`, `mergeImportedRookieQueue()`, and `importRookieQueue(rawPayload, { mode })`, plus a `dedupeQueueBySlug()` helper and normalized persist behavior.  
- Validation enforces a top-level object, supported `version`, `queue` array presence, and per-item `slug` requirement; imported items are normalized and deduped before writing to localStorage.  
- Added lightweight UI controls to the queue panel (`components/rookies/RookieQueuePanel.js`) and board wiring (`cards/rookies/board/index.html`) including an `Export queue JSON` button, `Import queue JSON` trigger with hidden file input, an import mode selector (`replace` default / `merge`), confirmation for replace when queue is non-empty, and a concise import/export status line; compare selections are cleaned up when imports remove selected slugs.  
- Documented the feature and payload shape in `docs/rookie-card-prototype.md`, including example export fields (`version`, `exported_at`, `source`, `queue`, `metadata`) and explicit boundary notes that this is a local portability artifact (no cloud/auth).  

### Testing
- Ran syntax/type checks with `node --check lib/rookies/rookieQueueStore.js` which completed without errors.  
- Ran `node --check components/rookies/RookieQueuePanel.js` which completed without errors.  
- Ran `python -m unittest -q` where the repository currently reports `0` discovered tests and the command exited successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c48c74ad848332bc58b7be59f396a1)