### PR TITLE
Fix four RookieBoard regressions introduced in PR15

### DIFF
--- a/components/rookies/RookieBoard.js
+++ b/components/rookies/RookieBoard.js
@@ -2,15 +2,19 @@ import { renderRookieBoardRow } from '/components/rookies/RookieBoardRow.js';
 import { groupRookiesByTier } from '/lib/rookies/groupRookiesByTier.js';
 
 export function renderRookieBoard(rows, { view = 'tiered', queueSlugs = new Set(), queueAnnotations = new Map() } = {}) {
+  if (!rows.length) {
+    return '<article class="rookie-card"><div class="meta">No rookies matched this board filter.</div></article>';
+  }
+
   const header = `
-    <div class="board-header">
-      <div>#</div>
-      <div>Player</div>
-      <div>Pos</div>
-      <div>School</div>
-      <div>Grade</div>
-      <div>Tier</div>
-      <div>Actions</div>
+    <div class="board-row board-header">
+      <div class="board-cell">#</div>
+      <div class="board-cell">Player</div>
+      <div class="board-cell">Pos</div>
+      <div class="board-cell">School</div>
+      <div class="board-cell">Grade</div>
+      <div class="board-cell">Tier</div>
+      <div class="board-cell">Actions</div>
     </div>
   `;
 
@@ -27,7 +31,7 @@ export function renderRookieBoard(rows, { view = 'tiered', queueSlugs = new Set(
         .map(
           (group) => `
             <div class="tier-group">
-              <div class="tier-header">${group.label} · ${group.range} · ${group.rows.length} players</div>
+              <div class="tier-header">${group.label} · ${group.rows.length} players</div>
               ${header}
               ${group.rows
                 .map((row) => renderRookieBoardRow(row, { isQueued: queueSlugs.has(row.slug), queueAnnotation: queueAnnotations.get(row.slug) ?? null }))

--- a/components/rookies/rookieCardStyles.css
+++ b/components/rookies/rookieCardStyles.css
@@ -323,6 +323,18 @@ body {
   .queue-item-actions { justify-content: flex-start; }
 }
 
+.tier-group { border-top: 1px solid var(--border); }
+.tier-group:first-child { border-top: none; }
+.tier-header {
+  background: rgba(19, 30, 45, 0.85);
+  padding: 10px 12px;
+  font-size: 12px;
+  letter-spacing: .1em;
+  text-transform: uppercase;
+  color: #c6d7ef;
+  font-weight: 700;
+}
+
 .queue-tag-pill {
   display: inline-block;
   border: 1px solid rgba(130, 170, 255, 0.45);


### PR DESCRIPTION
- Restore empty-board fallback message when no rows match the filter
- Restore board-row class on header div so column grid layout applies
- Remove group.range (field doesn't exist on groupRookiesByTier output)
- Add missing CSS for .tier-group and .tier-header replacing old
  .board-tier-break / .board-tier-title classes

https://claude.ai/code/session_0198HcjfapM7EQu3hvFy8Mus