### PR TITLE
Promote 2026 real seed (Carnell Tate) into canonical inputs and regenerate rookie-alpha exports

### DIFF
--- a/data/processed/2026_college_production.json
+++ b/data/processed/2026_college_production.json
@@ -1,26 +1,11 @@
 [
   {
-    "player_id": "rb-ashley-jennings",
-    "player_name": "Ashley Jennings",
-    "position": "RB",
-    "production_score_0_100": 86.2
-  },
-  {
-    "player_id": "rb-darius-cole",
-    "player_name": "Darius Cole",
-    "position": "RB",
-    "production_score_0_100": 78.4
-  },
-  {
-    "player_id": "wr-malik-ford",
-    "player_name": "Malik Ford",
+    "player_id": "wr-carnell-tate",
+    "player_name": "Carnell Tate",
     "position": "WR",
-    "production_score_0_100": 88.1
-  },
-  {
-    "player_id": "wr-keon-banks",
-    "player_name": "Keon Banks",
-    "position": "WR",
-    "production_score_0_100": 73.9
+    "school": "Ohio State",
+    "production_score_0_100": null,
+    "production_source": null,
+    "notes": "Missing sourced production score in seed pool."
   }
 ]

--- a/data/processed/2026_draft_capital_proxy.json
+++ b/data/processed/2026_draft_capital_proxy.json
@@ -1,26 +1,13 @@
 [
   {
-    "player_id": "rb-ashley-jennings",
-    "player_name": "Ashley Jennings",
-    "position": "RB",
-    "draft_capital_proxy_0_100": 74.0
-  },
-  {
-    "player_id": "rb-darius-cole",
-    "player_name": "Darius Cole",
-    "position": "RB",
-    "draft_capital_proxy_0_100": 67.5
-  },
-  {
-    "player_id": "wr-malik-ford",
-    "player_name": "Malik Ford",
+    "player_id": "wr-carnell-tate",
+    "player_name": "Carnell Tate",
     "position": "WR",
-    "draft_capital_proxy_0_100": 82.3
-  },
-  {
-    "player_id": "wr-keon-banks",
-    "player_name": "Keon Banks",
-    "position": "WR",
-    "draft_capital_proxy_0_100": 64.8
+    "school": "Ohio State",
+    "draft_capital_proxy_0_100": null,
+    "big_board_rank": 6,
+    "big_board_source": "FantasyPros consensus 2026 big board",
+    "draft_proxy_source": null,
+    "notes": "Proxy score intentionally null until sourced conversion methodology is applied."
   }
 ]

--- a/data/raw/2026_combine_results.json
+++ b/data/raw/2026_combine_results.json
@@ -1,42 +1,15 @@
 [
   {
-    "player_id": "rb-ashley-jennings",
-    "player_name": "Ashley Jennings",
-    "position": "RB",
-    "height_in": 70,
-    "weight_lb": 212,
-    "forty": 4.45,
-    "vertical": 38.5,
-    "broad": 126
-  },
-  {
-    "player_id": "rb-darius-cole",
-    "player_name": "Darius Cole",
-    "position": "RB",
-    "height_in": 71,
-    "weight_lb": 220,
-    "forty": 4.53,
-    "vertical": 35,
-    "broad": 121
-  },
-  {
-    "player_id": "wr-malik-ford",
-    "player_name": "Malik Ford",
+    "player_id": "wr-carnell-tate",
+    "player_name": "Carnell Tate",
     "position": "WR",
-    "height_in": 73,
-    "weight_lb": 198,
-    "forty": 4.38,
-    "vertical": 39,
-    "broad": 129
-  },
-  {
-    "player_id": "wr-keon-banks",
-    "player_name": "Keon Banks",
-    "position": "WR",
-    "height_in": 74,
-    "weight_lb": 207,
-    "forty": 4.49,
-    "vertical": 36.5,
-    "broad": 123
+    "school": "Ohio State",
+    "height_in": null,
+    "weight_lb": null,
+    "forty": null,
+    "vertical": null,
+    "broad": null,
+    "combine_invited": true,
+    "measurement_source": null
   }
 ]

--- a/data/raw/2026_real_seed_pool.json
+++ b/data/raw/2026_real_seed_pool.json
@@ -1,0 +1,22 @@
+[
+  {
+    "player_id": "wr-carnell-tate",
+    "player_name": "Carnell Tate",
+    "position": "WR",
+    "school": "Ohio State",
+    "height_in": null,
+    "weight_lb": null,
+    "forty": null,
+    "vertical": null,
+    "broad": null,
+    "production_score_0_100": null,
+    "draft_capital_proxy_0_100": null,
+    "big_board_rank": 6,
+    "big_board_source": "FantasyPros consensus 2026 big board",
+    "combine_invited": true,
+    "measurement_source": null,
+    "production_source": null,
+    "draft_proxy_source": null,
+    "notes": "Real 2026 prospect; fill measurements/scores only from sourced public data."
+  }
+]

--- a/exports/promoted/rookie-alpha/2026_manifest.json
+++ b/exports/promoted/rookie-alpha/2026_manifest.json
@@ -1,49 +1,49 @@
 {
   "season": 2026,
   "model_version": "rookie-alpha-predraft-v0.1.0",
-  "generated_at": "2026-03-25T01:46:12+00:00",
-  "run_id": "rookie-alpha-2026-2026-03-25T01:46:12+00:00",
+  "generated_at": "2026-03-27T13:24:33+00:00",
+  "run_id": "rookie-alpha-2026-2026-03-27T13:24:33+00:00",
   "input_files": [
     {
       "path": "data/raw/2026_combine_results.json",
-      "sha256": "3543ed62316b7970abe4ac4c59603fe1dc517728ae5ebe3fdeb7af4a51cc07d4",
-      "row_count": 4
+      "sha256": "8c093a0fdd4cbcb50733dff4be265dde7d8706b920d4c287efe6fb8ae189379d",
+      "row_count": 1
     },
     {
       "path": "data/processed/2026_college_production.json",
-      "sha256": "fc28e7e81acc2c75849fec7286951e7c8b74c8acc8518f345db7495fcd9572f9",
-      "row_count": 4
+      "sha256": "d7b75bf62d4928bd65e8806aa9b9dc16350170e5dc43202ef049e2a2f7e6227b",
+      "row_count": 1
     },
     {
       "path": "data/processed/2026_draft_capital_proxy.json",
-      "sha256": "4090b7ac06d885b972ca4622b25abf2fb15d936e8a3de189426dba0e433f79f4",
-      "row_count": 4
+      "sha256": "50259b37f2ad94e5f09e9db720efa0b21d3febe08aadd6673e5f60c8f9e0732d",
+      "row_count": 1
     }
   ],
   "coverage_summary": {
-    "players_total": 4,
-    "players_with_any_missing_input": 0,
-    "players_with_full_inputs": 4
+    "players_total": 1,
+    "players_with_any_missing_input": 1,
+    "players_with_full_inputs": 0
   },
   "output_files": [
     {
       "path": "exports/promoted/rookie-alpha/2026_rookie_alpha_predraft_v0.json",
-      "sha256": "1a8c32a24dbb5b5764c606cb9946e826de6707684dfe884ed1e89ec0ca89cda7"
+      "sha256": "359b5468640e4cd876912d0dbf017206dc086737c952fd18fbe5b9f0e3505ca3"
     },
     {
       "path": "exports/promoted/rookie-alpha/2026_rookie_alpha_predraft_v0.csv",
-      "sha256": "e3ffcfdd5fd066564d8e94205415c64c96fd65b35db627fdec839c87eba0e56a"
+      "sha256": "a46e49bae66890d07f1b8e9238de490ea53a5437864faf497fd59aa450e933c5"
     }
   ],
   "export_metadata": {
     "season": 2026,
     "model_version": "rookie-alpha-predraft-v0.1.0",
-    "generated_at": "2026-03-25T01:46:12+00:00",
-    "run_id": "rookie-alpha-2026-2026-03-25T01:46:12+00:00",
+    "generated_at": "2026-03-27T13:24:33+00:00",
+    "run_id": "rookie-alpha-2026-2026-03-27T13:24:33+00:00",
     "coverage_summary": {
-      "players_total": 4,
-      "players_with_any_missing_input": 0,
-      "players_with_full_inputs": 4
+      "players_total": 1,
+      "players_with_any_missing_input": 1,
+      "players_with_full_inputs": 0
     },
     "source_files_used": [
       "data/raw/2026_combine_results.json",

--- a/exports/promoted/rookie-alpha/2026_rookie_alpha_predraft_v0.csv
+++ b/exports/promoted/rookie-alpha/2026_rookie_alpha_predraft_v0.csv
@@ -1,5 +1,2 @@
 rookie_alpha_rank,player_id,player_name,position,ras_0_100,production_0_100,draft_capital_proxy_0_100,rookie_alpha_0_100,model_inputs_missing
-1,wr-malik-ford,Malik Ford,WR,61.6667,88.1,82.3,77.6883,
-2,rb-ashley-jennings,Ashley Jennings,RB,61.6667,86.2,74.0,75.1733,
-3,rb-darius-cole,Darius Cole,RB,38.3333,78.4,67.5,62.1967,
-4,wr-keon-banks,Keon Banks,WR,38.3333,73.9,64.8,59.6317,
+1,wr-carnell-tate,Carnell Tate,WR,50.0,50.0,50.0,50.0,"production,draft_capital_proxy"

--- a/exports/promoted/rookie-alpha/2026_rookie_alpha_predraft_v0.json
+++ b/exports/promoted/rookie-alpha/2026_rookie_alpha_predraft_v0.json
@@ -11,13 +11,13 @@
       "age_at_entry_supported": false
     }
   },
-  "generated_at": "2026-03-25T01:46:12+00:00",
-  "run_id": "rookie-alpha-2026-2026-03-25T01:46:12+00:00",
+  "generated_at": "2026-03-27T13:24:33+00:00",
+  "run_id": "rookie-alpha-2026-2026-03-27T13:24:33+00:00",
   "season": 2026,
   "coverage_summary": {
-    "players_total": 4,
-    "players_with_any_missing_input": 0,
-    "players_with_full_inputs": 4
+    "players_total": 1,
+    "players_with_any_missing_input": 1,
+    "players_with_full_inputs": 0
   },
   "source_files_used": [
     "data/raw/2026_combine_results.json",
@@ -26,56 +26,20 @@
   ],
   "players": [
     {
-      "player_id": "wr-malik-ford",
-      "player_name": "Malik Ford",
+      "player_id": "wr-carnell-tate",
+      "player_name": "Carnell Tate",
       "position": "WR",
       "scores": {
-        "ras_0_100": 61.6667,
-        "production_0_100": 88.1,
-        "draft_capital_proxy_0_100": 82.3,
-        "rookie_alpha_0_100": 77.6883
+        "ras_0_100": 50.0,
+        "production_0_100": 50.0,
+        "draft_capital_proxy_0_100": 50.0,
+        "rookie_alpha_0_100": 50.0
       },
-      "model_inputs_missing": [],
+      "model_inputs_missing": [
+        "production",
+        "draft_capital_proxy"
+      ],
       "rookie_alpha_rank": 1
-    },
-    {
-      "player_id": "rb-ashley-jennings",
-      "player_name": "Ashley Jennings",
-      "position": "RB",
-      "scores": {
-        "ras_0_100": 61.6667,
-        "production_0_100": 86.2,
-        "draft_capital_proxy_0_100": 74.0,
-        "rookie_alpha_0_100": 75.1733
-      },
-      "model_inputs_missing": [],
-      "rookie_alpha_rank": 2
-    },
-    {
-      "player_id": "rb-darius-cole",
-      "player_name": "Darius Cole",
-      "position": "RB",
-      "scores": {
-        "ras_0_100": 38.3333,
-        "production_0_100": 78.4,
-        "draft_capital_proxy_0_100": 67.5,
-        "rookie_alpha_0_100": 62.1967
-      },
-      "model_inputs_missing": [],
-      "rookie_alpha_rank": 3
-    },
-    {
-      "player_id": "wr-keon-banks",
-      "player_name": "Keon Banks",
-      "position": "WR",
-      "scores": {
-        "ras_0_100": 38.3333,
-        "production_0_100": 73.9,
-        "draft_capital_proxy_0_100": 64.8,
-        "rookie_alpha_0_100": 59.6317
-      },
-      "model_inputs_missing": [],
-      "rookie_alpha_rank": 4
     }
   ]
 }


### PR DESCRIPTION
### Motivation
- Replace prior synthetic 2026 inputs with the provided manually-sourced seed snapshot while strictly preserving only sourced values and leaving unsourced fields null.
- Provide canonical combine/production/draft-proxy inputs derived from the authoritative seed so downstream artifacts and validation reflect real seed coverage.
- Track missing measurements/scores explicitly rather than backfilling fabricated placeholders to keep data provenance clear.

### Description
- Added `data/raw/2026_real_seed_pool.json` containing the sourced Carnell Tate seed entry with unspecified measurements and scores set to `null` and provenance notes.
- Rewrote the three canonical inputs (`data/raw/2026_combine_results.json`, `data/processed/2026_college_production.json`, `data/processed/2026_draft_capital_proxy.json`) to include only the sourced identity fields plus `null` for unsourced measurements and score fields, and added explanatory `notes` fields where appropriate.
- Regenerated promoted artifacts `exports/promoted/rookie-alpha/2026_rookie_alpha_predraft_v0.json`, `exports/promoted/rookie-alpha/2026_rookie_alpha_predraft_v0.csv`, and `exports/promoted/rookie-alpha/2026_manifest.json` from the updated canonical inputs.
- Ensured no fabricated values were introduced and preserved the seed rule that real player names come first and unsourced numeric fields remain `null`.

### Testing
- Ran the standalone pipeline with `python3 scripts/compute_rookie_alpha.py --season 2026 --combine-input data/raw/2026_combine_results.json --production-input data/processed/2026_college_production.json --draft-proxy-input data/processed/2026_draft_capital_proxy.json --output-json exports/promoted/rookie-alpha/2026_rookie_alpha_predraft_v0.json --output-csv exports/promoted/rookie-alpha/2026_rookie_alpha_predraft_v0.csv --output-manifest exports/promoted/rookie-alpha/2026_manifest.json` and the run completed with an expected warning about missing inputs defaulting to 50.0.
- Validated the promoted export and manifest with `python3 scripts/validate_promoted_export.py --export-json exports/promoted/rookie-alpha/2026_rookie_alpha_predraft_v0.json --manifest exports/promoted/rookie-alpha/2026_manifest.json` and the validation passed.
- Confirmed coverage summary in the generated export shows `players_total: 1`, `players_with_any_missing_input: 1`, and `players_with_full_inputs: 0`, and reported included = 1 and excluded = 0.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c684d0bc6c833290c07035db5321df)