### PR TITLE
Convert seeded 2026 big-board ranks to temporary draft-capital proxy bands

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,22 @@ Implemented formula:
 
 This is explicitly labeled `pre-draft v0` in export metadata.
 
+## 2026 temporary pre-draft draft-capital proxy conversion
+
+For the real 2026 seed pool, `draft_capital_proxy_0_100` is currently a temporary pre-draft proxy derived from seeded `big_board_rank` values (not true NFL draft capital outcomes).
+
+Deterministic conversion bands:
+
+- ranks `1–10` → `95`
+- ranks `11–20` → `85`
+- ranks `21–32` → `75`
+- ranks `33–50` → `65`
+- ranks `51–75` → `55`
+- ranks `76–100` → `45`
+- rank missing or out of range (`>100`) → `null`
+
+This conversion only applies where a seeded `big_board_rank` exists. Missing ranks remain missing for draft-capital proxy.
+
 ## Run producer pipeline
 
 ```bash

--- a/data/processed/2026_draft_capital_proxy.json
+++ b/data/processed/2026_draft_capital_proxy.json
@@ -1,26 +1,44 @@
 [
   {
-    "player_id": "rb-ashley-jennings",
-    "player_name": "Ashley Jennings",
+    "player_id": "qb-fernando-mendoza",
+    "player_name": "Fernando Mendoza",
+    "position": "QB",
+    "draft_capital_proxy_0_100": 95
+  },
+  {
+    "player_id": "qb-ty-simpson",
+    "player_name": "Ty Simpson",
+    "position": "QB",
+    "draft_capital_proxy_0_100": 85
+  },
+  {
+    "player_id": "rb-jeremiyah-love",
+    "player_name": "Jeremiyah Love",
     "position": "RB",
-    "draft_capital_proxy_0_100": 74.0
+    "draft_capital_proxy_0_100": 95
   },
   {
-    "player_id": "rb-darius-cole",
-    "player_name": "Darius Cole",
+    "player_id": "rb-jadarian-price",
+    "player_name": "Jadarian Price",
     "position": "RB",
-    "draft_capital_proxy_0_100": 67.5
+    "draft_capital_proxy_0_100": 65
   },
   {
-    "player_id": "wr-malik-ford",
-    "player_name": "Malik Ford",
+    "player_id": "wr-carnell-tate",
+    "player_name": "Carnell Tate",
     "position": "WR",
-    "draft_capital_proxy_0_100": 82.3
+    "draft_capital_proxy_0_100": 95
   },
   {
-    "player_id": "wr-keon-banks",
-    "player_name": "Keon Banks",
+    "player_id": "wr-jordyn-tyson",
+    "player_name": "Jordyn Tyson",
     "position": "WR",
-    "draft_capital_proxy_0_100": 64.8
+    "draft_capital_proxy_0_100": 95
+  },
+  {
+    "player_id": "te-kenyon-sadiq",
+    "player_name": "Kenyon Sadiq",
+    "position": "TE",
+    "draft_capital_proxy_0_100": 85
   }
 ]

--- a/data/raw/2026_real_seed_pool.json
+++ b/data/raw/2026_real_seed_pool.json
@@ -20,9 +20,9 @@
     "production_score_source": null,
     "big_board_rank": 1,
     "big_board_source": "FantasyPros consensus 2026 big board",
-    "draft_capital_proxy_0_100": null,
-    "draft_capital_proxy_source": null,
-    "draft_capital_proxy_pending_conversion": true,
+    "draft_capital_proxy_0_100": 95,
+    "draft_capital_proxy_source": "Temporary pre-draft proxy mapped from seeded big_board_rank bands (1-10=95,11-20=85,21-32=75,33-50=65,51-75=55,76-100=45)",
+    "draft_capital_proxy_pending_conversion": false,
     "notes": "2026 Heisman Trophy winner; consensus #1 overall prospect. Did not run forty at combine."
   },
   {
@@ -46,9 +46,9 @@
     "production_score_source": null,
     "big_board_rank": 19,
     "big_board_source": "Bleacher Report 2026 post-combine big board",
-    "draft_capital_proxy_0_100": null,
-    "draft_capital_proxy_source": null,
-    "draft_capital_proxy_pending_conversion": true,
+    "draft_capital_proxy_0_100": 85,
+    "draft_capital_proxy_source": "Temporary pre-draft proxy mapped from seeded big_board_rank bands (1-10=95,11-20=85,21-32=75,33-50=65,51-75=55,76-100=45)",
+    "draft_capital_proxy_pending_conversion": false,
     "notes": "15 career starts at Alabama; QB2 in class per multiple sources. Did not run forty at combine."
   },
   {
@@ -150,9 +150,9 @@
     "production_score_source": null,
     "big_board_rank": 2,
     "big_board_source": "Bleacher Report 2026 post-combine big board",
-    "draft_capital_proxy_0_100": null,
-    "draft_capital_proxy_source": null,
-    "draft_capital_proxy_pending_conversion": true,
+    "draft_capital_proxy_0_100": 95,
+    "draft_capital_proxy_source": "Temporary pre-draft proxy mapped from seeded big_board_rank bands (1-10=95,11-20=85,21-32=75,33-50=65,51-75=55,76-100=45)",
+    "draft_capital_proxy_pending_conversion": false,
     "notes": "Ran 4.36 at combine. 6.0 YPC in 2025 season at Notre Dame. Top RB in class by consensus."
   },
   {
@@ -176,9 +176,9 @@
     "production_score_source": null,
     "big_board_rank": 37,
     "big_board_source": "Bleacher Report 2026 post-combine big board",
-    "draft_capital_proxy_0_100": null,
-    "draft_capital_proxy_source": null,
-    "draft_capital_proxy_pending_conversion": true,
+    "draft_capital_proxy_0_100": 65,
+    "draft_capital_proxy_source": "Temporary pre-draft proxy mapped from seeded big_board_rank bands (1-10=95,11-20=85,21-32=75,33-50=65,51-75=55,76-100=45)",
+    "draft_capital_proxy_pending_conversion": false,
     "notes": "Complementary back to Jeremiyah Love at Notre Dame. Day 2 projection."
   },
   {
@@ -280,9 +280,9 @@
     "production_score_source": null,
     "big_board_rank": 6,
     "big_board_source": "FantasyPros consensus 2026 big board",
-    "draft_capital_proxy_0_100": null,
-    "draft_capital_proxy_source": null,
-    "draft_capital_proxy_pending_conversion": true,
+    "draft_capital_proxy_0_100": 95,
+    "draft_capital_proxy_source": "Temporary pre-draft proxy mapped from seeded big_board_rank bands (1-10=95,11-20=85,21-32=75,33-50=65,51-75=55,76-100=45)",
+    "draft_capital_proxy_pending_conversion": false,
     "notes": "Did not complete positional drills at combine. WR1 per ESPN Mel Kiper. Official forty 4.52; some sources report 4.53."
   },
   {
@@ -306,9 +306,9 @@
     "production_score_source": null,
     "big_board_rank": 6,
     "big_board_source": "NBC Sports Connor Rogers 2026 big board",
-    "draft_capital_proxy_0_100": null,
-    "draft_capital_proxy_source": null,
-    "draft_capital_proxy_pending_conversion": true,
+    "draft_capital_proxy_0_100": 95,
+    "draft_capital_proxy_source": "Temporary pre-draft proxy mapped from seeded big_board_rank bands (1-10=95,11-20=85,21-32=75,33-50=65,51-75=55,76-100=45)",
+    "draft_capital_proxy_pending_conversion": false,
     "notes": "Did not run forty due to hamstring injury at combine. Prior ACL injury history. WR1 per Bleacher Report post-combine."
   },
   {
@@ -514,9 +514,9 @@
     "production_score_source": null,
     "big_board_rank": 14,
     "big_board_source": "FantasyPros consensus 2026 big board",
-    "draft_capital_proxy_0_100": null,
-    "draft_capital_proxy_source": null,
-    "draft_capital_proxy_pending_conversion": true,
+    "draft_capital_proxy_0_100": 85,
+    "draft_capital_proxy_source": "Temporary pre-draft proxy mapped from seeded big_board_rank bands (1-10=95,11-20=85,21-32=75,33-50=65,51-75=55,76-100=45)",
+    "draft_capital_proxy_pending_conversion": false,
     "notes": "Set all-time TE 40-yard dash record (4.39) at 2026 NFL Combine. TE1 in class by consensus; first-round projection."
   },
   {

--- a/docs/export-contract.md
+++ b/docs/export-contract.md
@@ -104,6 +104,22 @@ Top-level fields:
 
 ## Standard production + validation sequence (2026)
 
+### 2026 temporary pre-draft draft-capital proxy rule
+
+For the real 2026 seed pool, `draft_capital_proxy_0_100` is a temporary pre-draft conversion from seeded `big_board_rank` values. It is explicitly not equivalent to realized NFL draft capital.
+
+Applied deterministic mapping:
+
+- `1–10` => `95`
+- `11–20` => `85`
+- `21–32` => `75`
+- `33–50` => `65`
+- `51–75` => `55`
+- `76–100` => `45`
+- missing or `>100` => `null`
+
+Only entries with a seeded `big_board_rank` are eligible for conversion.
+
 Run from repo root:
 
 ```bash

--- a/exports/promoted/rookie-alpha/2026_manifest.json
+++ b/exports/promoted/rookie-alpha/2026_manifest.json
@@ -1,8 +1,8 @@
 {
   "season": 2026,
   "model_version": "rookie-alpha-predraft-v0.1.0",
-  "generated_at": "2026-03-27T11:13:06+00:00",
-  "run_id": "rookie-alpha-2026-2026-03-27T11:13:06+00:00",
+  "generated_at": "2026-03-28T12:23:30+00:00",
+  "run_id": "rookie-alpha-2026-2026-03-28T12:23:30+00:00",
   "input_files": [
     {
       "path": "data/raw/2026_combine_results.json",
@@ -16,49 +16,49 @@
     },
     {
       "path": "data/processed/2026_draft_capital_proxy.json",
-      "sha256": "4090b7ac06d885b972ca4622b25abf2fb15d936e8a3de189426dba0e433f79f4",
-      "row_count": 4
+      "sha256": "08ec72c8f58758cf6a6ad412ecd4fd6a33487892b4e2dae6b18f4257b9ad2211",
+      "row_count": 7
     }
   ],
   "coverage_summary": {
-    "players_total": 4,
+    "players_total": 0,
     "players_with_any_missing_input": 0,
-    "players_with_full_inputs": 4,
+    "players_with_full_inputs": 0,
     "input_alignment": {
       "duplicate_rows_skipped": 0,
       "identity_conflicts_skipped": 0,
-      "missing_combine": 0,
-      "missing_production": 0,
-      "missing_draft_proxy": 0,
-      "total_excluded": 0
+      "missing_combine": 7,
+      "missing_production": 7,
+      "missing_draft_proxy": 4,
+      "total_excluded": 11
     }
   },
   "output_files": [
     {
       "path": "exports/promoted/rookie-alpha/2026_rookie_alpha_predraft_v0.json",
-      "sha256": "e36047ff3cf75ba4b1a372a1b558bff9df5367236480093cfc140e4443add3be"
+      "sha256": "b023077636ec8bf9f6b86011e1754543fafe7d40f80f7c4e4612033d3d153c9a"
     },
     {
       "path": "exports/promoted/rookie-alpha/2026_rookie_alpha_predraft_v0.csv",
-      "sha256": "e3ffcfdd5fd066564d8e94205415c64c96fd65b35db627fdec839c87eba0e56a"
+      "sha256": "3594637a2dbf2a8f93467e187b171f040e9f4d91fda5fee0b630da63d96a4752"
     }
   ],
   "export_metadata": {
     "season": 2026,
     "model_version": "rookie-alpha-predraft-v0.1.0",
-    "generated_at": "2026-03-27T11:13:06+00:00",
-    "run_id": "rookie-alpha-2026-2026-03-27T11:13:06+00:00",
+    "generated_at": "2026-03-28T12:23:30+00:00",
+    "run_id": "rookie-alpha-2026-2026-03-28T12:23:30+00:00",
     "coverage_summary": {
-      "players_total": 4,
+      "players_total": 0,
       "players_with_any_missing_input": 0,
-      "players_with_full_inputs": 4,
+      "players_with_full_inputs": 0,
       "input_alignment": {
         "duplicate_rows_skipped": 0,
         "identity_conflicts_skipped": 0,
-        "missing_combine": 0,
-        "missing_production": 0,
-        "missing_draft_proxy": 0,
-        "total_excluded": 0
+        "missing_combine": 7,
+        "missing_production": 7,
+        "missing_draft_proxy": 4,
+        "total_excluded": 11
       }
     },
     "source_files_used": [

--- a/exports/promoted/rookie-alpha/2026_rookie_alpha_predraft_v0.csv
+++ b/exports/promoted/rookie-alpha/2026_rookie_alpha_predraft_v0.csv
@@ -1,5 +1,1 @@
 rookie_alpha_rank,player_id,player_name,position,ras_0_100,production_0_100,draft_capital_proxy_0_100,rookie_alpha_0_100,model_inputs_missing
-1,wr-malik-ford,Malik Ford,WR,61.6667,88.1,82.3,77.6883,
-2,rb-ashley-jennings,Ashley Jennings,RB,61.6667,86.2,74.0,75.1733,
-3,rb-darius-cole,Darius Cole,RB,38.3333,78.4,67.5,62.1967,
-4,wr-keon-banks,Keon Banks,WR,38.3333,73.9,64.8,59.6317,

--- a/exports/promoted/rookie-alpha/2026_rookie_alpha_predraft_v0.json
+++ b/exports/promoted/rookie-alpha/2026_rookie_alpha_predraft_v0.json
@@ -11,20 +11,20 @@
       "age_at_entry_supported": false
     }
   },
-  "generated_at": "2026-03-27T11:13:06+00:00",
-  "run_id": "rookie-alpha-2026-2026-03-27T11:13:06+00:00",
+  "generated_at": "2026-03-28T12:23:30+00:00",
+  "run_id": "rookie-alpha-2026-2026-03-28T12:23:30+00:00",
   "season": 2026,
   "coverage_summary": {
-    "players_total": 4,
+    "players_total": 0,
     "players_with_any_missing_input": 0,
-    "players_with_full_inputs": 4,
+    "players_with_full_inputs": 0,
     "input_alignment": {
       "duplicate_rows_skipped": 0,
       "identity_conflicts_skipped": 0,
-      "missing_combine": 0,
-      "missing_production": 0,
-      "missing_draft_proxy": 0,
-      "total_excluded": 0
+      "missing_combine": 7,
+      "missing_production": 7,
+      "missing_draft_proxy": 4,
+      "total_excluded": 11
     }
   },
   "source_files_used": [
@@ -32,58 +32,5 @@
     "data/processed/2026_college_production.json",
     "data/processed/2026_draft_capital_proxy.json"
   ],
-  "players": [
-    {
-      "player_id": "wr-malik-ford",
-      "player_name": "Malik Ford",
-      "position": "WR",
-      "scores": {
-        "ras_0_100": 61.6667,
-        "production_0_100": 88.1,
-        "draft_capital_proxy_0_100": 82.3,
-        "rookie_alpha_0_100": 77.6883
-      },
-      "model_inputs_missing": [],
-      "rookie_alpha_rank": 1
-    },
-    {
-      "player_id": "rb-ashley-jennings",
-      "player_name": "Ashley Jennings",
-      "position": "RB",
-      "scores": {
-        "ras_0_100": 61.6667,
-        "production_0_100": 86.2,
-        "draft_capital_proxy_0_100": 74.0,
-        "rookie_alpha_0_100": 75.1733
-      },
-      "model_inputs_missing": [],
-      "rookie_alpha_rank": 2
-    },
-    {
-      "player_id": "rb-darius-cole",
-      "player_name": "Darius Cole",
-      "position": "RB",
-      "scores": {
-        "ras_0_100": 38.3333,
-        "production_0_100": 78.4,
-        "draft_capital_proxy_0_100": 67.5,
-        "rookie_alpha_0_100": 62.1967
-      },
-      "model_inputs_missing": [],
-      "rookie_alpha_rank": 3
-    },
-    {
-      "player_id": "wr-keon-banks",
-      "player_name": "Keon Banks",
-      "position": "WR",
-      "scores": {
-        "ras_0_100": 38.3333,
-        "production_0_100": 73.9,
-        "draft_capital_proxy_0_100": 64.8,
-        "rookie_alpha_0_100": 59.6317
-      },
-      "model_inputs_missing": [],
-      "rookie_alpha_rank": 4
-    }
-  ]
+  "players": []
 }


### PR DESCRIPTION
### Motivation
- Populate `draft_capital_proxy_0_100` for the real 2026 seed pool where a seeded `big_board_rank` already exists using a deterministic temporary mapping, while preserving nulls everywhere else. 
- Keep production normalization, model weights, and player identities unchanged so this change only addresses the draft-capital proxy gap blocking promoted artifact generation.

### Description
- Updated `data/raw/2026_real_seed_pool.json` to set `draft_capital_proxy_0_100`, `draft_capital_proxy_source`, and `draft_capital_proxy_pending_conversion` for rows with seeded `big_board_rank` and left other rows null/false per schema. 
- Rebuilt `data/processed/2026_draft_capital_proxy.json` from the converted seed rows so the processed proxy input reflects the seed-derived proxies (7 rows populated). 
- Regenerated promoted artifacts `exports/promoted/rookie-alpha/2026_rookie_alpha_predraft_v0.json`, `..._v0.csv`, and `2026_manifest.json` without changing model code or production methodology. 
- Documented the temporary rule in `README.md` and `docs/export-contract.md` as: `1–10 => 95`, `11–20 => 85`, `21–32 => 75`, `33–50 => 65`, `51–75 => 55`, `76–100 => 45`, and missing/>100 => `null`.

### Testing
- Ran artifact generation with `python3 scripts/compute_rookie_alpha.py ... --draft-proxy-input data/processed/2026_draft_capital_proxy.json` and the command completed successfully. 
- Ran validation with `python3 scripts/validate_promoted_export.py --export-json exports/promoted/rookie-alpha/2026_rookie_alpha_predraft_v0.json --manifest exports/promoted/rookie-alpha/2026_manifest.json` and the validator returned `VALIDATION PASSED`. 
- Quick data checks after the run show: total promoted players `0`, players with populated draft-capital proxy `7`, players still missing production `23`, and players all-null apart from identity/provenance `0`. 
- No changes were made to `scripts/compute_rookie_alpha.py`, model weights/formula, production methodology, or tests behavior beyond updating docs/inputs and regenerated artifacts.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7c8009650833293dff2884e52667d)