### PR TITLE
Add talent_score, talent_rank, and draft_proxy_delta to Rookie Alpha exports

### DIFF
--- a/docs/export-contract.md
+++ b/docs/export-contract.md
@@ -49,6 +49,8 @@ Top-level fields:
 Player fields:
 
 - `rookie_alpha_rank`
+- `talent_rank`: rank within the promoted cohort by talent_score_0_100 descending; ties broken by player_id ascending
+- `draft_proxy_delta`: talent_rank minus rookie_alpha_rank; positive = draft capital suppressing score (potential value); negative = draft capital boosting score; zero = no ranking movement
 - `player_id`
 - `player_name`
 - `position`
@@ -56,6 +58,7 @@ Player fields:
   - `ras_0_100`
   - `production_0_100`
   - `draft_capital_proxy_0_100`
+  - `talent_score_0_100`: RAS and production blended without draft capital proxy (RAS weight 0.4375, production weight 0.5625); null inputs default to 50.0
   - `rookie_alpha_0_100`
 - `model_inputs_missing`: list of missing components (`ras`, `production`, `draft_capital_proxy`)
 
@@ -70,8 +73,11 @@ Columns:
 5. `ras_0_100`
 6. `production_0_100`
 7. `draft_capital_proxy_0_100`
-8. `rookie_alpha_0_100`
-9. `model_inputs_missing`
+8. `talent_score_0_100`
+9. `rookie_alpha_0_100`
+10. `talent_rank`
+11. `draft_proxy_delta`
+12. `model_inputs_missing`
 
 CSV is a flattened companion artifact for row-oriented ingestion.
 

--- a/exports/promoted/rookie-alpha/2026_manifest.json
+++ b/exports/promoted/rookie-alpha/2026_manifest.json
@@ -1,8 +1,8 @@
 {
   "season": 2026,
   "model_version": "rookie-alpha-predraft-v0.1.0",
-  "generated_at": "2026-03-28T14:52:56+00:00",
-  "run_id": "rookie-alpha-2026-2026-03-28T14:52:56+00:00",
+  "generated_at": "2026-03-28T15:15:45+00:00",
+  "run_id": "rookie-alpha-2026-2026-03-28T15:15:45+00:00",
   "input_files": [
     {
       "path": "data/raw/2026_combine_results.json",
@@ -36,18 +36,18 @@
   "output_files": [
     {
       "path": "exports/promoted/rookie-alpha/2026_rookie_alpha_predraft_v0.json",
-      "sha256": "3d4e56203b5ff2326a6af9a0ef22797e3facdf9d06356a4c54c4736c5a043dce"
+      "sha256": "eb948975a14b5aaa08c3820544f9e67325dd9e2743112f4ab3d4b2bb0bbcaa09"
     },
     {
       "path": "exports/promoted/rookie-alpha/2026_rookie_alpha_predraft_v0.csv",
-      "sha256": "87bca0ea47a7812a3b473c37913d455916885caeaa864082da127156b290e408"
+      "sha256": "bdf5c28e7123319428aa76c0b115aa78ccb3551ec4f67f1d6f84ae6aeb73540f"
     }
   ],
   "export_metadata": {
     "season": 2026,
     "model_version": "rookie-alpha-predraft-v0.1.0",
-    "generated_at": "2026-03-28T14:52:56+00:00",
-    "run_id": "rookie-alpha-2026-2026-03-28T14:52:56+00:00",
+    "generated_at": "2026-03-28T15:15:45+00:00",
+    "run_id": "rookie-alpha-2026-2026-03-28T15:15:45+00:00",
     "coverage_summary": {
       "players_total": 7,
       "players_with_any_missing_input": 0,

--- a/exports/promoted/rookie-alpha/2026_rookie_alpha_predraft_v0.csv
+++ b/exports/promoted/rookie-alpha/2026_rookie_alpha_predraft_v0.csv
@@ -1,8 +1,8 @@
-rookie_alpha_rank,player_id,player_name,position,ras_0_100,production_0_100,draft_capital_proxy_0_100,rookie_alpha_0_100,model_inputs_missing
-1,qb-fernando-mendoza,Fernando Mendoza,QB,65.168,87.9,95.0,81.3638,
-2,rb-jeremiyah-love,Jeremiyah Love,RB,55.5775,93.1,95.0,80.3471,
-3,wr-jordyn-tyson,Jordyn Tyson,WR,54.657,82.9,95.0,75.4349,
-4,wr-carnell-tate,Carnell Tate,WR,34.6625,90.3,95.0,71.7669,
-5,qb-ty-simpson,Ty Simpson,QB,30.4966,87.7,85.0,67.1388,
-6,te-kenyon-sadiq,Kenyon Sadiq,TE,45.0286,73.8,85.0,65.97,
-7,rb-jadarian-price,Jadarian Price,RB,31.2399,78.6,65.0,59.304,
+rookie_alpha_rank,player_id,player_name,position,ras_0_100,production_0_100,draft_capital_proxy_0_100,talent_score_0_100,rookie_alpha_0_100,talent_rank,draft_proxy_delta,model_inputs_missing
+1,qb-fernando-mendoza,Fernando Mendoza,QB,65.168,87.9,95.0,77.9548,81.3638,1,0,
+2,rb-jeremiyah-love,Jeremiyah Love,RB,55.5775,93.1,95.0,76.6839,80.3471,2,0,
+3,wr-jordyn-tyson,Jordyn Tyson,WR,54.657,82.9,95.0,70.5437,75.4349,3,0,
+4,wr-carnell-tate,Carnell Tate,WR,34.6625,90.3,95.0,65.9586,71.7669,4,0,
+5,qb-ty-simpson,Ty Simpson,QB,30.4966,87.7,85.0,62.6735,67.1388,5,0,
+6,te-kenyon-sadiq,Kenyon Sadiq,TE,45.0286,73.8,85.0,61.2125,65.97,6,0,
+7,rb-jadarian-price,Jadarian Price,RB,31.2399,78.6,65.0,57.88,59.304,7,0,

--- a/exports/promoted/rookie-alpha/2026_rookie_alpha_predraft_v0.json
+++ b/exports/promoted/rookie-alpha/2026_rookie_alpha_predraft_v0.json
@@ -11,8 +11,8 @@
       "age_at_entry_supported": false
     }
   },
-  "generated_at": "2026-03-28T14:52:56+00:00",
-  "run_id": "rookie-alpha-2026-2026-03-28T14:52:56+00:00",
+  "generated_at": "2026-03-28T15:15:45+00:00",
+  "run_id": "rookie-alpha-2026-2026-03-28T15:15:45+00:00",
   "season": 2026,
   "coverage_summary": {
     "players_total": 7,
@@ -41,10 +41,13 @@
         "ras_0_100": 65.168,
         "production_0_100": 87.9,
         "draft_capital_proxy_0_100": 95.0,
+        "talent_score_0_100": 77.9548,
         "rookie_alpha_0_100": 81.3638
       },
       "model_inputs_missing": [],
-      "rookie_alpha_rank": 1
+      "rookie_alpha_rank": 1,
+      "talent_rank": 1,
+      "draft_proxy_delta": 0
     },
     {
       "player_id": "rb-jeremiyah-love",
@@ -54,10 +57,13 @@
         "ras_0_100": 55.5775,
         "production_0_100": 93.1,
         "draft_capital_proxy_0_100": 95.0,
+        "talent_score_0_100": 76.6839,
         "rookie_alpha_0_100": 80.3471
       },
       "model_inputs_missing": [],
-      "rookie_alpha_rank": 2
+      "rookie_alpha_rank": 2,
+      "talent_rank": 2,
+      "draft_proxy_delta": 0
     },
     {
       "player_id": "wr-jordyn-tyson",
@@ -67,10 +73,13 @@
         "ras_0_100": 54.657,
         "production_0_100": 82.9,
         "draft_capital_proxy_0_100": 95.0,
+        "talent_score_0_100": 70.5437,
         "rookie_alpha_0_100": 75.4349
       },
       "model_inputs_missing": [],
-      "rookie_alpha_rank": 3
+      "rookie_alpha_rank": 3,
+      "talent_rank": 3,
+      "draft_proxy_delta": 0
     },
     {
       "player_id": "wr-carnell-tate",
@@ -80,10 +89,13 @@
         "ras_0_100": 34.6625,
         "production_0_100": 90.3,
         "draft_capital_proxy_0_100": 95.0,
+        "talent_score_0_100": 65.9586,
         "rookie_alpha_0_100": 71.7669
       },
       "model_inputs_missing": [],
-      "rookie_alpha_rank": 4
+      "rookie_alpha_rank": 4,
+      "talent_rank": 4,
+      "draft_proxy_delta": 0
     },
     {
       "player_id": "qb-ty-simpson",
@@ -93,10 +105,13 @@
         "ras_0_100": 30.4966,
         "production_0_100": 87.7,
         "draft_capital_proxy_0_100": 85.0,
+        "talent_score_0_100": 62.6735,
         "rookie_alpha_0_100": 67.1388
       },
       "model_inputs_missing": [],
-      "rookie_alpha_rank": 5
+      "rookie_alpha_rank": 5,
+      "talent_rank": 5,
+      "draft_proxy_delta": 0
     },
     {
       "player_id": "te-kenyon-sadiq",
@@ -106,10 +121,13 @@
         "ras_0_100": 45.0286,
         "production_0_100": 73.8,
         "draft_capital_proxy_0_100": 85.0,
+        "talent_score_0_100": 61.2125,
         "rookie_alpha_0_100": 65.97
       },
       "model_inputs_missing": [],
-      "rookie_alpha_rank": 6
+      "rookie_alpha_rank": 6,
+      "talent_rank": 6,
+      "draft_proxy_delta": 0
     },
     {
       "player_id": "rb-jadarian-price",
@@ -119,10 +137,13 @@
         "ras_0_100": 31.2399,
         "production_0_100": 78.6,
         "draft_capital_proxy_0_100": 65.0,
+        "talent_score_0_100": 57.88,
         "rookie_alpha_0_100": 59.304
       },
       "model_inputs_missing": [],
-      "rookie_alpha_rank": 7
+      "rookie_alpha_rank": 7,
+      "talent_rank": 7,
+      "draft_proxy_delta": 0
     }
   ]
 }

--- a/scripts/compute_rookie_alpha.py
+++ b/scripts/compute_rookie_alpha.py
@@ -369,6 +369,17 @@ def rookie_alpha_score(player: PlayerInputs) -> float:
     return clamp_0_100((0.35 * ras) + (0.45 * production) + (0.20 * draft))
 
 
+def talent_score(player: PlayerInputs) -> float:
+    """RAS + production only, renormalized to sum to 1.0.
+
+    Weights derived from rookie_alpha formula: 0.35 / 0.80 = 0.4375 (RAS),
+    0.45 / 0.80 = 0.5625 (production). Null inputs default to 50.0.
+    """
+    ras = player.ras_score_0_100 if player.ras_score_0_100 is not None else 50.0
+    production = player.production_score_0_100 if player.production_score_0_100 is not None else 50.0
+    return clamp_0_100((0.4375 * ras) + (0.5625 * production))
+
+
 def write_outputs(
     players: list[PlayerInputs],
     merge_diagnostics: MergeDiagnostics,
@@ -387,6 +398,7 @@ def write_outputs(
     missing_any = 0
     for p in players:
         alpha = rookie_alpha_score(p)
+        ts = talent_score(p)
         missing_components = [
             key
             for key, value in {
@@ -419,15 +431,24 @@ def write_outputs(
                         p.draft_capital_proxy_0_100 if p.draft_capital_proxy_0_100 is not None else 50.0,
                         4,
                     ),
+                    "talent_score_0_100": round(ts, 4),
                     "rookie_alpha_0_100": round(alpha, 4),
                 },
                 "model_inputs_missing": missing_components,
             }
         )
 
-    ranked.sort(key=lambda r: r["scores"]["rookie_alpha_0_100"], reverse=True)
+    ranked.sort(key=lambda r: (-r["scores"]["rookie_alpha_0_100"], r["player_id"]))
     for i, row in enumerate(ranked, start=1):
         row["rookie_alpha_rank"] = i
+
+    talent_sorted = sorted(ranked, key=lambda r: (-r["scores"]["talent_score_0_100"], r["player_id"]))
+    talent_rank_map = {row["player_id"]: i for i, row in enumerate(talent_sorted, start=1)}
+    for row in ranked:
+        row["talent_rank"] = talent_rank_map[row["player_id"]]
+
+    for row in ranked:
+        row["draft_proxy_delta"] = row["talent_rank"] - row["rookie_alpha_rank"]
 
     payload = {
         "model": {
@@ -481,7 +502,10 @@ def write_outputs(
                 "ras_0_100",
                 "production_0_100",
                 "draft_capital_proxy_0_100",
+                "talent_score_0_100",
                 "rookie_alpha_0_100",
+                "talent_rank",
+                "draft_proxy_delta",
                 "model_inputs_missing",
             ],
         )
@@ -496,7 +520,10 @@ def write_outputs(
                     "ras_0_100": row["scores"]["ras_0_100"],
                     "production_0_100": row["scores"]["production_0_100"],
                     "draft_capital_proxy_0_100": row["scores"]["draft_capital_proxy_0_100"],
+                    "talent_score_0_100": row["scores"]["talent_score_0_100"],
                     "rookie_alpha_0_100": row["scores"]["rookie_alpha_0_100"],
+                    "talent_rank": row["talent_rank"],
+                    "draft_proxy_delta": row["draft_proxy_delta"],
                     "model_inputs_missing": ",".join(row["model_inputs_missing"]),
                 }
             )


### PR DESCRIPTION
### Motivation
- Provide a draft-capital-independent view of player talent by exposing a blended RAS+production `talent_score` and compare it to existing `rookie_alpha` rankings. 
- Surface ranking displacement driven by the `draft_capital_proxy` as `draft_proxy_delta` so downstream consumers can identify players whose draft capital materially changes ordering.

### Description
- Added a new function `talent_score(player: PlayerInputs)` in `scripts/compute_rookie_alpha.py` that blends RAS + production using renormalized weights (RAS 0.4375, production 0.5625) with null inputs defaulting to `50.0`.
- Included `talent_score_0_100` in each player `scores` entry and computed a deterministic `talent_rank` (ties broken by `player_id`) and `draft_proxy_delta = talent_rank - rookie_alpha_rank` for all promoted players.
- Made `rookie_alpha` ranking deterministic by tie-breaking on `player_id` when sorting, and added the new fields to CSV export field order and JSON payload.
- Updated `docs/export-contract.md` to document `talent_score_0_100`, `talent_rank`, and `draft_proxy_delta`, and regenerated promoted artifacts in `exports/promoted/rookie-alpha/` for season 2026 (JSON, CSV, manifest updated).

### Testing
- Ran the exporter end-to-end with `python3 scripts/compute_rookie_alpha.py --season 2026 --combine-input data/raw/2026_combine_results.json --production-input data/processed/2026_college_production.json --draft-proxy-input data/processed/2026_draft_capital_proxy.json --output-json exports/promoted/rookie-alpha/2026_rookie_alpha_predraft_v0.json --output-csv exports/promoted/rookie-alpha/2026_rookie_alpha_predraft_v0.csv --output-manifest exports/promoted/rookie-alpha/2026_manifest.json` and then validated with `python3 scripts/validate_promoted_export.py --export-json exports/promoted/rookie-alpha/2026_rookie_alpha_predraft_v0.json --manifest exports/promoted/rookie-alpha/2026_manifest.json` which produced `VALIDATION PASSED`.
- Ran unit tests with `python3 -m pytest tests/test_compute_rookie_alpha.py tests/test_validate_promoted_export.py` and all tests passed (`14 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7f059d4cc833283ac556f228d80cd)