### PR TITLE
Add rookie stat export plumbing, season rows, and player radar chart

### DIFF
--- a/components/rookies/RookieCard.js
+++ b/components/rookies/RookieCard.js
@@ -24,6 +24,56 @@ function metricRow(metric) {
   return `<div class="metric-row"><div class="metric-header"><span>${esc(metric.evidenceLabel ?? metric.label)}</span><strong>${esc(metric.display)}</strong></div><div class="metric-track"><div class="metric-fill" style="width:${width}%"></div></div></div>`;
 }
 
+function pointForValue(centerX, centerY, radius, angle, value) {
+  const safeValue = value == null ? 0 : Math.max(0, Math.min(100, Number(value) || 0));
+  const scaledRadius = (safeValue / 100) * radius;
+  const x = centerX + (scaledRadius * Math.cos(angle));
+  const y = centerY + (scaledRadius * Math.sin(angle));
+  return `${x.toFixed(1)},${y.toFixed(1)}`;
+}
+
+function renderRadarChart(ras, production, draftCapital) {
+  const centerX = 100;
+  const centerY = 100;
+  const radius = 80;
+  const axes = [
+    { label: 'RAS', angle: -Math.PI / 2, value: ras },
+    { label: 'Production', angle: Math.PI / 6, value: production },
+    { label: 'Draft Capital', angle: (5 * Math.PI) / 6, value: draftCapital },
+  ];
+
+  const ringScales = [0.25, 0.5, 0.75];
+  const rings = ringScales.map((scale) => {
+    const points = axes.map((axis) => pointForValue(centerX, centerY, radius, axis.angle, scale * 100)).join(' ');
+    const isAverageRing = scale === 0.5;
+    return `<polygon points="${points}" fill="none" stroke="#6f8098" stroke-width="${isAverageRing ? 1.6 : 1}" ${isAverageRing ? 'stroke-dasharray="4 3"' : ''} />`;
+  }).join('');
+
+  const dataPoints = axes.map((axis) => pointForValue(centerX, centerY, radius, axis.angle, axis.value)).join(' ');
+  const axesLines = axes.map((axis) => {
+    const endpoint = pointForValue(centerX, centerY, radius, axis.angle, 100);
+    return `<line x1="${centerX}" y1="${centerY}" x2="${endpoint.split(',')[0]}" y2="${endpoint.split(',')[1]}" stroke="#516179" stroke-width="1" />`;
+  }).join('');
+
+  const labels = axes.map((axis) => {
+    const outer = pointForValue(centerX, centerY, radius + 16, axis.angle, 100).split(',');
+    const rendered = axis.value == null ? '0.0' : Number(axis.value).toFixed(1);
+    return `<text x="${outer[0]}" y="${outer[1]}" fill="#b5c7dd" font-size="11" text-anchor="middle">${esc(axis.label)} ${esc(rendered)}</text>`;
+  }).join('');
+
+  return `
+    <section class="metrics radar-section">
+      <div class="section-title">Model Input Radar</div>
+      <svg class="radar-chart" viewBox="0 0 200 200" role="img" aria-label="Radar chart for RAS, production, and draft capital scores">
+        ${rings}
+        ${axesLines}
+        <polygon points="${dataPoints}" fill="rgba(59, 130, 246, 0.25)" stroke="#3b82f6" stroke-width="2" />
+        ${labels}
+      </svg>
+    </section>
+  `;
+}
+
 export function renderRookieCard(container, card) {
   const heroScore = card.summary.rookieGrade == null ? 'N/A' : card.summary.rookieGrade.toFixed(1);
   const identityBits = [
@@ -65,6 +115,8 @@ export function renderRookieCard(container, card) {
       <section class="core-row">
         ${card.scores.map(scoreCell).join('')}
       </section>
+
+      ${renderRadarChart(card.scores[1]?.value, card.scores[2]?.value, card.scores[3]?.value)}
 
       <section class="metrics">
         <div class="section-title">Position-aware Evidence</div>

--- a/components/rookies/rookieCardStyles.css
+++ b/components/rookies/rookieCardStyles.css
@@ -41,6 +41,16 @@ body {
 .metric-header { display: flex; justify-content: space-between; font-size: 13px; margin-bottom: 4px; color: var(--muted); }
 .metric-track { height: 8px; background: #0b111b; border-radius: 999px; overflow: hidden; border: 1px solid var(--border); }
 .metric-fill { height: 100%; background: linear-gradient(90deg, #2a8cff, #45d5af); }
+
+.radar-section {
+  display: grid;
+  place-items: center;
+}
+.radar-chart {
+  width: 220px;
+  max-width: 100%;
+  margin-top: 8px;
+}
 .stats-table { width: 100%; border-collapse: collapse; margin-top: 8px; font-size: 13px; }
 .stats-table th, .stats-table td { border-bottom: 1px solid var(--border); padding: 8px 4px; text-align: left; }
 .tags, .compact-tags { display: flex; flex-wrap: wrap; gap: 8px; }

--- a/data/processed/2026_player_stats.json
+++ b/data/processed/2026_player_stats.json
@@ -1,0 +1,186 @@
+[
+  {
+    "player_id": "qb-fernando-mendoza",
+    "player_name": "Fernando Mendoza",
+    "position": "QB",
+    "school": "Indiana",
+    "season": 2025,
+    "stats": {}
+  },
+  {
+    "player_id": "qb-ty-simpson",
+    "player_name": "Ty Simpson",
+    "position": "QB",
+    "school": "Alabama",
+    "season": 2025,
+    "stats": {}
+  },
+  {
+    "player_id": "qb-carson-beck",
+    "player_name": "Carson Beck",
+    "position": "QB",
+    "school": "Miami (FL)",
+    "season": 2025,
+    "stats": {}
+  },
+  {
+    "player_id": "qb-drew-allar",
+    "player_name": "Drew Allar",
+    "position": "QB",
+    "school": "Penn State",
+    "season": 2025,
+    "stats": {}
+  },
+  {
+    "player_id": "qb-garrett-nussmeier",
+    "player_name": "Garrett Nussmeier",
+    "position": "QB",
+    "school": "LSU",
+    "season": 2025,
+    "stats": {}
+  },
+  {
+    "player_id": "rb-jeremiyah-love",
+    "player_name": "Jeremiyah Love",
+    "position": "RB",
+    "school": "Notre Dame",
+    "season": 2025,
+    "stats": {}
+  },
+  {
+    "player_id": "rb-jadarian-price",
+    "player_name": "Jadarian Price",
+    "position": "RB",
+    "school": "Notre Dame",
+    "season": 2025,
+    "stats": {}
+  },
+  {
+    "player_id": "rb-mike-washington-jr",
+    "player_name": "Mike Washington Jr.",
+    "position": "RB",
+    "school": "Arkansas",
+    "season": 2025,
+    "stats": {}
+  },
+  {
+    "player_id": "rb-nick-singleton",
+    "player_name": "Nick Singleton",
+    "position": "RB",
+    "school": "Penn State",
+    "season": 2025,
+    "stats": {}
+  },
+  {
+    "player_id": "rb-jonah-coleman",
+    "player_name": "Jonah Coleman",
+    "position": "RB",
+    "school": "Washington",
+    "season": 2025,
+    "stats": {}
+  },
+  {
+    "player_id": "wr-carnell-tate",
+    "player_name": "Carnell Tate",
+    "position": "WR",
+    "school": "Ohio State",
+    "season": 2025,
+    "stats": {}
+  },
+  {
+    "player_id": "wr-jordyn-tyson",
+    "player_name": "Jordyn Tyson",
+    "position": "WR",
+    "school": "Arizona State",
+    "season": 2025,
+    "stats": {}
+  },
+  {
+    "player_id": "wr-makai-lemon",
+    "player_name": "Makai Lemon",
+    "position": "WR",
+    "school": "USC",
+    "season": 2025,
+    "stats": {}
+  },
+  {
+    "player_id": "wr-kc-concepcion",
+    "player_name": "KC Concepcion",
+    "position": "WR",
+    "school": "Texas A&M",
+    "season": 2025,
+    "stats": {}
+  },
+  {
+    "player_id": "wr-brenen-thompson",
+    "player_name": "Brenen Thompson",
+    "position": "WR",
+    "school": "Mississippi State",
+    "season": 2025,
+    "stats": {}
+  },
+  {
+    "player_id": "wr-chris-brazzell-ii",
+    "player_name": "Chris Brazzell II",
+    "position": "WR",
+    "school": "Tennessee",
+    "season": 2025,
+    "stats": {}
+  },
+  {
+    "player_id": "wr-denzel-boston",
+    "player_name": "Denzel Boston",
+    "position": "WR",
+    "school": "Washington",
+    "season": 2025,
+    "stats": {}
+  },
+  {
+    "player_id": "wr-chris-bell",
+    "player_name": "Chris Bell",
+    "position": "WR",
+    "school": "Louisville",
+    "season": 2025,
+    "stats": {}
+  },
+  {
+    "player_id": "wr-elijah-sarratt",
+    "player_name": "Elijah Sarratt",
+    "position": "WR",
+    "school": "Indiana",
+    "season": 2025,
+    "stats": {}
+  },
+  {
+    "player_id": "te-kenyon-sadiq",
+    "player_name": "Kenyon Sadiq",
+    "position": "TE",
+    "school": "Oregon",
+    "season": 2025,
+    "stats": {}
+  },
+  {
+    "player_id": "te-max-klare",
+    "player_name": "Max Klare",
+    "position": "TE",
+    "school": "Ohio State",
+    "season": 2025,
+    "stats": {}
+  },
+  {
+    "player_id": "te-oscar-delp",
+    "player_name": "Oscar Delp",
+    "position": "TE",
+    "school": "Georgia",
+    "season": 2025,
+    "stats": {}
+  },
+  {
+    "player_id": "te-eli-stowers",
+    "player_name": "Eli Stowers",
+    "position": "TE",
+    "school": "Vanderbilt",
+    "season": 2025,
+    "stats": {}
+  }
+]

--- a/lib/rookies/getRookieCardData.js
+++ b/lib/rookies/getRookieCardData.js
@@ -15,16 +15,18 @@ function keyByPlayerId(rows) {
 }
 
 async function loadAllRookieCards() {
-  const [alphaExport, combineRows, productionRows, draftRows] = await Promise.all([
+  const [alphaExport, combineRows, productionRows, draftRows, statsRows] = await Promise.all([
     loadJson('/exports/promoted/rookie-alpha/2026_rookie_alpha_predraft_v0.json'),
     loadJson('/data/raw/2026_combine_results.json'),
     loadJson('/data/processed/2026_college_production.json'),
     loadJson('/data/processed/2026_draft_capital_proxy.json'),
+    loadJson('/data/processed/2026_player_stats.json'),
   ]);
 
   const combineById = keyByPlayerId(combineRows);
   const productionById = keyByPlayerId(productionRows);
   const draftById = keyByPlayerId(draftRows);
+  const statsById = keyByPlayerId(statsRows);
 
   return alphaExport.players.map((alphaPlayer, idx) => {
     const playerId = String(alphaPlayer.player_id ?? '').toLowerCase();
@@ -33,6 +35,7 @@ async function loadAllRookieCards() {
       combineRow: combineById.get(playerId),
       productionRow: productionById.get(playerId),
       draftRow: draftById.get(playerId),
+      statsRow: statsById.get(playerId),
       rank: alphaPlayer.rookie_alpha_rank ?? idx + 1,
     });
   });

--- a/lib/rookies/mapRookieToCard.js
+++ b/lib/rookies/mapRookieToCard.js
@@ -39,8 +39,19 @@ function withMetricMetadata(metric) {
   };
 }
 
+
+function buildSeasonRows(statsRow) {
+  if (!statsRow || !statsRow.stats || Object.keys(statsRow.stats).length === 0) return [];
+  return [{
+    season: statsRow.season,
+    team: statsRow.school,
+    games: null,
+    statLine: statsRow.stats,
+  }];
+}
+
 /** @returns {RookieCardData} */
-export function mapRookieToCard({ alphaPlayer, combineRow, productionRow, draftRow, rank }) {
+export function mapRookieToCard({ alphaPlayer, combineRow, productionRow, draftRow, statsRow, rank }) {
   const identity = normalizeRookieIdentity({ alphaPlayer, combineRow, productionRow, draftRow });
   const weight = combineRow?.weight_lb ? `${combineRow.weight_lb} lb` : null;
   const height = combineRow?.height_in ? `${Math.floor(combineRow.height_in / 12)}'${combineRow.height_in % 12}"` : null;
@@ -102,7 +113,7 @@ export function mapRookieToCard({ alphaPlayer, combineRow, productionRow, draftR
       { label: 'Draft Capital', value: draftCapital },
     ],
     metrics,
-    seasons: [],
+    seasons: buildSeasonRows(statsRow),
     tags,
     evidence: {
       availableCount: availableMetrics.length,

--- a/scripts/compute_production_scores.py
+++ b/scripts/compute_production_scores.py
@@ -20,6 +20,7 @@ CFBD_BASE_URL = "https://api.collegefootballdata.com"
 DEFAULT_SEED_INPUT = Path("data/raw/2026_real_seed_pool.json")
 DEFAULT_PRODUCTION_OUTPUT = Path("data/processed/2026_college_production.json")
 DEFAULT_SEED_OUTPUT = Path("data/raw/2026_real_seed_pool.json")
+DEFAULT_STATS_OUTPUT = Path("data/processed/2026_player_stats.json")
 
 POSITION_LIMITS = {
     "QB": 100.0,
@@ -82,6 +83,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--seed-input", type=Path, default=DEFAULT_SEED_INPUT)
     parser.add_argument("--production-output", type=Path, default=DEFAULT_PRODUCTION_OUTPUT)
     parser.add_argument("--seed-output", type=Path, default=DEFAULT_SEED_OUTPUT)
+    parser.add_argument("--stats-output", type=Path, default=DEFAULT_STATS_OUTPUT)
     return parser.parse_args()
 
 
@@ -425,6 +427,115 @@ def to_production_rows(seed_rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
     return output
 
 
+def rounded_stat(value: float) -> int | float:
+    if float(value).is_integer():
+        return int(value)
+    return round(value, 1)
+
+
+def add_stat(stats: dict[str, int | float], key: str, value: float | None) -> None:
+    if value is None:
+        return
+    stats[key] = rounded_stat(value)
+
+
+def build_stat_lines(
+    seed_rows: list[dict[str, Any]],
+    results: list[MatchResult],
+    passing_stats: dict[tuple[str, str], dict[str, Any]],
+    rushing_stats: dict[tuple[str, str], dict[str, Any]],
+    receiving_stats: dict[tuple[str, str], dict[str, Any]],
+    cfbd_year: int,
+) -> list[dict[str, Any]]:
+    populations: dict[str, list[PopulationPlayer]] = {
+        "QB": build_population("QB", passing_stats, rushing_stats, receiving_stats),
+        "RB": build_population("RB", passing_stats, rushing_stats, receiving_stats),
+        "WR": build_population("WR", passing_stats, rushing_stats, receiving_stats),
+        "TE": build_population("TE", passing_stats, rushing_stats, receiving_stats),
+    }
+    failed_ids = {result.player_id for result in results if result.match_mode == "failed"}
+    stat_lines: list[dict[str, Any]] = []
+
+    for row in seed_rows:
+        player_id = str(row.get("player_id", ""))
+        position = str(row.get("position", "")).upper()
+        stats: dict[str, int | float] = {}
+
+        if player_id not in failed_ids and populations.get(position):
+            matched, _ = match_seed_player(row, populations[position])
+            if matched is not None:
+                key = (normalize_identity(matched.name), normalize_identity(matched.school))
+
+                if position == "QB":
+                    passing = passing_stats.get(key, {}).get("stats", {})
+                    attempts = passing.get("ATT")
+                    completions = passing.get("COMPLETIONS")
+                    passing_yards = passing.get("YDS")
+                    passing_tds = passing.get("TD")
+                    interceptions = passing.get("INT")
+
+                    add_stat(stats, "completions", completions)
+                    add_stat(stats, "attempts", attempts)
+                    add_stat(
+                        stats,
+                        "completion_pct",
+                        safe_div(completions, attempts) * 100 if completions is not None and attempts is not None else None,
+                    )
+                    add_stat(stats, "passing_yards", passing_yards)
+                    add_stat(stats, "passing_tds", passing_tds)
+                    add_stat(stats, "interceptions", interceptions)
+                    add_stat(
+                        stats,
+                        "yards_per_attempt",
+                        safe_div(passing_yards, attempts) if passing_yards is not None and attempts is not None else None,
+                    )
+
+                elif position == "RB":
+                    rushing = rushing_stats.get(key, {}).get("stats", {})
+                    receiving = receiving_stats.get(key, {}).get("stats", {})
+                    rush_attempts = rushing.get("CAR")
+                    rush_yards = rushing.get("YDS")
+                    rush_tds = rushing.get("TD")
+
+                    add_stat(stats, "rush_attempts", rush_attempts)
+                    add_stat(stats, "rush_yards", rush_yards)
+                    add_stat(stats, "rush_tds", rush_tds)
+                    add_stat(
+                        stats,
+                        "yards_per_carry",
+                        safe_div(rush_yards, rush_attempts) if rush_yards is not None and rush_attempts is not None else None,
+                    )
+                    add_stat(stats, "receptions", receiving.get("REC"))
+                    add_stat(stats, "receiving_yards", receiving.get("YDS"))
+
+                elif position in {"WR", "TE"}:
+                    receiving = receiving_stats.get(key, {}).get("stats", {})
+                    receptions = receiving.get("REC")
+                    receiving_yards = receiving.get("YDS")
+
+                    add_stat(stats, "receptions", receptions)
+                    add_stat(stats, "receiving_yards", receiving_yards)
+                    add_stat(stats, "receiving_tds", receiving.get("TD"))
+                    add_stat(
+                        stats,
+                        "yards_per_reception",
+                        safe_div(receiving_yards, receptions) if receiving_yards is not None and receptions is not None else None,
+                    )
+
+        stat_lines.append(
+            {
+                "player_id": row.get("player_id"),
+                "player_name": row.get("player_name"),
+                "position": row.get("position"),
+                "school": row.get("school"),
+                "season": cfbd_year,
+                "stats": stats,
+            }
+        )
+
+    return stat_lines
+
+
 def print_summary(results: list[MatchResult]) -> None:
     print("=== CFBD match summary ===")
     primary = [r for r in results if r.match_mode == "primary"]
@@ -466,6 +577,8 @@ def main() -> int:
 
     write_json(args.seed_output, updated_seed)
     write_json(args.production_output, production_rows)
+    stat_lines = build_stat_lines(seed_rows, results, passing_stats, rushing_stats, receiving_stats, cfbd_year)
+    write_json(args.stats_output, stat_lines)
 
     print_summary(results)
     return 0

--- a/tests/test_compute_production_scores.py
+++ b/tests/test_compute_production_scores.py
@@ -2,6 +2,7 @@ import unittest
 
 from scripts.compute_production_scores import (
     apply_results,
+    build_stat_lines,
     compute_scores_for_seed,
     normalize_identity,
     pivot_stats,
@@ -68,6 +69,27 @@ class ComputeProductionScoresTests(unittest.TestCase):
         )
         self.assertIsNone(result_seed[0]["production_score_0_100"])
         self.assertIsNone(result_seed[0]["production_score_source"])
+
+    def test_build_stat_lines_qb_and_failed_player(self) -> None:
+        passing_rows = [
+            {"player": "QB One", "team": "Indiana", "statType": "ATT", "stat": "200"},
+            {"player": "QB One", "team": "Indiana", "statType": "COMPLETIONS", "stat": "140"},
+            {"player": "QB One", "team": "Indiana", "statType": "YDS", "stat": "2500"},
+            {"player": "QB One", "team": "Indiana", "statType": "TD", "stat": "24"},
+            {"player": "QB One", "team": "Indiana", "statType": "INT", "stat": "8"},
+        ]
+        seed_rows = [
+            {"player_id": "p1", "player_name": "QB One", "position": "QB", "school": "Indiana"},
+            {"player_id": "p2", "player_name": "QB Missing", "position": "QB", "school": "Nowhere"},
+        ]
+        results = compute_scores_for_seed(seed_rows, pivot_stats(passing_rows), {}, {})
+        stat_lines = build_stat_lines(seed_rows, results, pivot_stats(passing_rows), {}, {}, 2025)
+        self.assertEqual(len(stat_lines), 2)
+        self.assertEqual(stat_lines[0]["stats"]["completions"], 140)
+        self.assertEqual(stat_lines[0]["stats"]["completion_pct"], 70)
+        self.assertEqual(stat_lines[0]["stats"]["yards_per_attempt"], 12.5)
+        self.assertEqual(stat_lines[1]["stats"], {})
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Provide a machine-readable per-player season stat export from the CFBD-based production pipeline so UI cards can display season stat rows. 
- Surface model inputs (RAS, Production, Draft Capital) visually on the rookie card to help reviewers quickly compare profiles. 
- Keep exported stat values tidy (rounded / integer-preserving) and omit missing values for cleaner downstream consumption.

### Description
- Add `--stats-output` (default `data/processed/2026_player_stats.json`) to `scripts/compute_production_scores.py`, implement `build_stat_lines(...)` to extract QB/RB/WR/TE stat lines with `rounded_stat` and `add_stat`, and write the resulting player stat rows alongside the existing production export. 
- Seed `data/processed/2026_player_stats.json` with a 23-row scaffold (season + identity, empty `stats`) so the UI can be exercised without live CFBD access. 
- Wire the new stats export into the frontend by loading `/data/processed/2026_player_stats.json` in `lib/rookies/getRookieCardData.js` and passing a `statsRow` into `mapRookieToCard`. 
- Populate `card.seasons` in `lib/rookies/mapRookieToCard.js` via a new `buildSeasonRows(statsRow)` helper that yields an empty list when no stats are available. 
- Add a pure-SVG triangular radar section to `components/rookies/RookieCard.js` that plots `RAS`, `Production`, and `Draft Capital` with 25/50/75 reference rings and null-safe fallbacks, and include minimal layout styling in `components/rookies/rookieCardStyles.css`. 
- Extend unit tests by adding `test_build_stat_lines_qb_and_failed_player` in `tests/test_compute_production_scores.py` to validate stat extraction and failure handling.

### Testing
- Ran the Python unit test suite with `python3 -m pytest tests/` and all tests passed (`20 passed`).
- Ran the runtime smoke test with `node --test tests/runtime-server.smoke.test.cjs` and the smoke test passed. 
- Attempted to run the live ingestion (`python3 scripts/compute_production_scores.py --season 2026`) but CFBD API access failed in this environment due to an outbound tunnel restriction (`403 Forbidden`), so the committed scaffold file should be regenerated in a networked environment with CFBD access.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c85c2ff04c83328aa76b28ca187af6)