### PR TITLE
Backfill 2021 WR outcomes, add opt-out flag, and seed 2022 WR cohort

### DIFF
--- a/data/historical/README.md
+++ b/data/historical/README.md
@@ -19,6 +19,7 @@ WR now includes multiple real draft vintages (2020 + 2021) while QB/TE remain sa
   - `size_context_0_100` is a deterministic size percentile context signal built from listed pre-draft height/weight across WR rows in this artifact.
 - WR outcome rows for the seeded real cohort now include sourced PPR/G-based snapshots (`best_season_fantasy_ppg`, `years_1_to_3_summary`) plus deterministic label/band derivations.
 - WR `production_0_100` is currently `normalization_scope = "class-local"` min-max over sourced receiving-yards values for the draft class slice represented in this artifact.
+- Class-local min-max behavior means each represented WR class has a forced `production_0_100 = 0.0` floor at that slice's minimum raw-yardage row, even when the player's absolute production is still strong versus other classes.
 - WR `career_outcome_label` and `top_finish_band` are currently deterministic derivations from each player's sourced peak `FPTS/G` (not yet a fully league-ranked finish model).
 - The promoted comp artifact now exposes `effective_features_used` per comp row plus `comp_data_warnings` so partial feature overlap is visible in-artifact.
 - As a result, current WR similarity behavior is improved versus one-vintage/one-proxy, but remains partial and not UI-ready.

--- a/data/historical/historical_player_outcomes.sample.json
+++ b/data/historical/historical_player_outcomes.sample.json
@@ -114,7 +114,7 @@
     "years_1_to_3_summary": "2021-2023 PPR/G: 17.9, 20.2, 16.4; receiving line: 81/1455/13, 87/1046/9, 100/1216/7.",
     "source_name": "FantasyData player season fantasy stats (PPR scoring)",
     "source_url": "https://fantasydata.com/nfl/ja-marr-chase-fantasy/22564",
-    "notes": "best_season_fantasy_ppg uses max season FPTS/G from cited table; top_finish_band derived deterministically from that max using fixed bands: >=20 WR1, >=15 WR2, >=12 WR3, <12 depth."
+    "notes": "best_season_fantasy_ppg uses max season FPTS/G from cited table (23.7 in 2024 season); top_finish_band derived deterministically from that max using fixed bands: >=20 WR1, >=15 WR2, >=12 WR3, <12 depth."
   },
   {
     "player_id": "wr-jaylen-waddle-2021",
@@ -199,9 +199,9 @@
     "player_name": "Chris Olave",
     "position": "WR",
     "draft_year": 2022,
-    "career_outcome_label": "wr2_peak",
-    "best_season_fantasy_ppg": 16.8,
-    "top_finish_band": "WR2 (15.0-19.9 PPR/G peak)",
+    "career_outcome_label": "wr3_peak",
+    "best_season_fantasy_ppg": 14.5,
+    "top_finish_band": "WR3 (12.0-14.9 PPR/G peak)",
     "years_1_to_3_summary": "2022-2024 PPR/G: 13.2, 14.5, 9.6; receiving line: 72/1042/4, 87/1123/5, 32/400/1.",
     "source_name": "FantasyData player season fantasy stats (PPR scoring)",
     "source_url": "https://fantasydata.com/nfl/chris-olave-fantasy/22565",

--- a/data/historical/historical_prospect_features.sample.json
+++ b/data/historical/historical_prospect_features.sample.json
@@ -217,12 +217,12 @@
     "source_season": 2021,
     "ras_0_100": null,
     "production_0_100": 19.18,
-    "draft_capital_proxy_0_100": 85.0,
+    "draft_capital_proxy_0_100": 95.0,
     "size_context_0_100": 44.44,
     "normalization_scope": "class-local",
     "source_name": "FantasyData player page + Wikipedia player page + 2022 WR RAS roundup (Steelers Depot citing ras.football)",
     "source_url": "https://en.wikipedia.org/wiki/Garrett_Wilson",
-    "notes": "2021 receiving yards sourced as 1058 (Wikipedia college stats). 2022 WR production_0_100 uses class-local min-max on raw 2021 receiving yards across this 5-player slice: min 936 (Olave), max 1572 (Williams). size_context_0_100 is deterministic percentile composite of listed height, weight, and forty time across this 5-player slice; speed input unavailable for some rows and treated as neutral (50th percentile) in the composite. ras_0_100 left null because an exact player-level RAS value was not cleanly sourced in this pass."
+    "notes": "2021 receiving yards sourced as 1058 (Wikipedia college stats). Draft capital proxy updated for top-10 selection (band 1-10 => 95.0). 2022 WR production_0_100 uses class-local min-max on raw 2021 receiving yards across this 5-player slice: min 936 (Olave), max 1572 (Williams). size_context_0_100 is deterministic percentile composite of listed height, weight, and forty time across this 5-player slice; speed input unavailable for some rows and treated as neutral (50th percentile) in the composite. ras_0_100 left null because an exact player-level RAS value was not cleanly sourced in this pass."
   },
   {
     "player_id": "wr-drake-london-2022",
@@ -233,12 +233,12 @@
     "source_season": 2021,
     "ras_0_100": null,
     "production_0_100": 23.27,
-    "draft_capital_proxy_0_100": 85.0,
+    "draft_capital_proxy_0_100": 95.0,
     "size_context_0_100": 70.0,
     "normalization_scope": "class-local",
     "source_name": "FantasyData player page + Wikipedia player page + 2022 WR RAS roundup (Steelers Depot citing ras.football)",
     "source_url": "https://en.wikipedia.org/wiki/Drake_London",
-    "notes": "2021 receiving yards sourced as 1084 (Wikipedia college stats). 2022 WR production_0_100 uses class-local min-max on raw 2021 receiving yards across this 5-player slice: min 936 (Olave), max 1572 (Williams). size_context_0_100 is deterministic percentile composite of listed height, weight, and forty time across this 5-player slice; speed input unavailable for this row and treated as neutral (50th percentile) in the composite. ras_0_100 left null because an exact player-level RAS value was not cleanly sourced in this pass."
+    "notes": "2021 receiving yards sourced as 1084 (Wikipedia college stats). Draft capital proxy updated for top-10 selection (band 1-10 => 95.0). 2022 WR production_0_100 uses class-local min-max on raw 2021 receiving yards across this 5-player slice: min 936 (Olave), max 1572 (Williams). size_context_0_100 is deterministic percentile composite of listed height, weight, and forty time across this 5-player slice; speed input unavailable for this row and treated as neutral (50th percentile) in the composite. ras_0_100 left null because an exact player-level RAS value was not cleanly sourced in this pass."
   },
   {
     "player_id": "wr-chris-olave-2022",

--- a/exports/promoted/historical-comps/2026_historical_comps_v0.json
+++ b/exports/promoted/historical-comps/2026_historical_comps_v0.json
@@ -11,7 +11,7 @@
     },
     "notes": "v0 emits talent_comp by default; market_comp support is scaffolded and optional."
   },
-  "generated_at": "2026-03-29T15:17:53+00:00",
+  "generated_at": "2026-03-29T16:17:21+00:00",
   "season": 2026,
   "source_files_used": [
     "exports/promoted/rookie-alpha/2026_rookie_alpha_predraft_v0.json",
@@ -40,7 +40,8 @@
             "production_0_100": 72.0,
             "draft_capital_proxy_0_100": 70.0,
             "size_context_0_100": 66.0,
-            "normalization_scope": "cohort-local"
+            "normalization_scope": "cohort-local",
+            "opt_out_season_flag": false
           },
           "effective_features_used": [
             "ras_0_100",
@@ -65,7 +66,8 @@
             "production_0_100": 80.0,
             "draft_capital_proxy_0_100": 88.0,
             "size_context_0_100": 71.0,
-            "normalization_scope": "cohort-local"
+            "normalization_scope": "cohort-local",
+            "opt_out_season_flag": false
           },
           "effective_features_used": [
             "ras_0_100",
@@ -98,7 +100,8 @@
             "production_0_100": 72.0,
             "draft_capital_proxy_0_100": 70.0,
             "size_context_0_100": 66.0,
-            "normalization_scope": "cohort-local"
+            "normalization_scope": "cohort-local",
+            "opt_out_season_flag": false
           },
           "effective_features_used": [
             "ras_0_100",
@@ -123,7 +126,8 @@
             "production_0_100": 80.0,
             "draft_capital_proxy_0_100": 88.0,
             "size_context_0_100": 71.0,
-            "normalization_scope": "cohort-local"
+            "normalization_scope": "cohort-local",
+            "opt_out_season_flag": false
           },
           "effective_features_used": [
             "ras_0_100",
@@ -156,7 +160,8 @@
             "production_0_100": 80.0,
             "draft_capital_proxy_0_100": 88.0,
             "size_context_0_100": 71.0,
-            "normalization_scope": "cohort-local"
+            "normalization_scope": "cohort-local",
+            "opt_out_season_flag": false
           },
           "effective_features_used": [
             "ras_0_100",
@@ -181,7 +186,8 @@
             "production_0_100": 72.0,
             "draft_capital_proxy_0_100": 70.0,
             "size_context_0_100": 66.0,
-            "normalization_scope": "cohort-local"
+            "normalization_scope": "cohort-local",
+            "opt_out_season_flag": false
           },
           "effective_features_used": [
             "ras_0_100",
@@ -214,7 +220,8 @@
             "production_0_100": 72.0,
             "draft_capital_proxy_0_100": 70.0,
             "size_context_0_100": 66.0,
-            "normalization_scope": "cohort-local"
+            "normalization_scope": "cohort-local",
+            "opt_out_season_flag": false
           },
           "effective_features_used": [
             "ras_0_100",
@@ -239,7 +246,8 @@
             "production_0_100": 80.0,
             "draft_capital_proxy_0_100": 88.0,
             "size_context_0_100": 71.0,
-            "normalization_scope": "cohort-local"
+            "normalization_scope": "cohort-local",
+            "opt_out_season_flag": false
           },
           "effective_features_used": [
             "ras_0_100",
@@ -272,7 +280,8 @@
             "production_0_100": 72.0,
             "draft_capital_proxy_0_100": 70.0,
             "size_context_0_100": 66.0,
-            "normalization_scope": "cohort-local"
+            "normalization_scope": "cohort-local",
+            "opt_out_season_flag": false
           },
           "effective_features_used": [
             "ras_0_100",
@@ -297,7 +306,8 @@
             "production_0_100": 80.0,
             "draft_capital_proxy_0_100": 88.0,
             "size_context_0_100": 71.0,
-            "normalization_scope": "cohort-local"
+            "normalization_scope": "cohort-local",
+            "opt_out_season_flag": false
           },
           "effective_features_used": [
             "ras_0_100",
@@ -358,7 +368,8 @@
             "production_0_100": 69.0,
             "draft_capital_proxy_0_100": 58.0,
             "size_context_0_100": 77.0,
-            "normalization_scope": "cohort-local"
+            "normalization_scope": "cohort-local",
+            "opt_out_season_flag": false
           },
           "effective_features_used": [
             "production_0_100"
@@ -390,7 +401,8 @@
             "production_0_100": 69.0,
             "draft_capital_proxy_0_100": 58.0,
             "size_context_0_100": 77.0,
-            "normalization_scope": "cohort-local"
+            "normalization_scope": "cohort-local",
+            "opt_out_season_flag": false
           },
           "effective_features_used": [
             "production_0_100"
@@ -422,7 +434,8 @@
             "production_0_100": 69.0,
             "draft_capital_proxy_0_100": 58.0,
             "size_context_0_100": 77.0,
-            "normalization_scope": "cohort-local"
+            "normalization_scope": "cohort-local",
+            "opt_out_season_flag": false
           },
           "effective_features_used": [
             "production_0_100"
@@ -454,7 +467,8 @@
             "production_0_100": 43.5,
             "draft_capital_proxy_0_100": 85.0,
             "size_context_0_100": 75.0,
-            "normalization_scope": "class-local"
+            "normalization_scope": "class-local",
+            "opt_out_season_flag": false
           },
           "effective_features_used": [
             "ras_0_100",
@@ -479,7 +493,8 @@
             "production_0_100": 26.42,
             "draft_capital_proxy_0_100": 85.0,
             "size_context_0_100": 58.89,
-            "normalization_scope": "class-local"
+            "normalization_scope": "class-local",
+            "opt_out_season_flag": false
           },
           "effective_features_used": [
             "ras_0_100",
@@ -504,7 +519,8 @@
             "production_0_100": 53.02,
             "draft_capital_proxy_0_100": 75.0,
             "size_context_0_100": 20.0,
-            "normalization_scope": "class-local"
+            "normalization_scope": "class-local",
+            "opt_out_season_flag": false
           },
           "effective_features_used": [
             "ras_0_100",
@@ -529,7 +545,8 @@
             "production_0_100": 25.43,
             "draft_capital_proxy_0_100": 80.0,
             "size_context_0_100": 55.0,
-            "normalization_scope": "class-local"
+            "normalization_scope": "class-local",
+            "opt_out_season_flag": false
           },
           "effective_features_used": [
             "ras_0_100",
@@ -554,7 +571,8 @@
             "production_0_100": 100.0,
             "draft_capital_proxy_0_100": 75.0,
             "size_context_0_100": 45.0,
-            "normalization_scope": "class-local"
+            "normalization_scope": "class-local",
+            "opt_out_season_flag": false
           },
           "effective_features_used": [
             "ras_0_100",
@@ -587,7 +605,8 @@
             "production_0_100": 43.5,
             "draft_capital_proxy_0_100": 85.0,
             "size_context_0_100": 75.0,
-            "normalization_scope": "class-local"
+            "normalization_scope": "class-local",
+            "opt_out_season_flag": false
           },
           "effective_features_used": [
             "ras_0_100",
@@ -612,7 +631,8 @@
             "production_0_100": 53.02,
             "draft_capital_proxy_0_100": 75.0,
             "size_context_0_100": 20.0,
-            "normalization_scope": "class-local"
+            "normalization_scope": "class-local",
+            "opt_out_season_flag": false
           },
           "effective_features_used": [
             "ras_0_100",
@@ -637,7 +657,8 @@
             "production_0_100": 26.42,
             "draft_capital_proxy_0_100": 85.0,
             "size_context_0_100": 58.89,
-            "normalization_scope": "class-local"
+            "normalization_scope": "class-local",
+            "opt_out_season_flag": false
           },
           "effective_features_used": [
             "ras_0_100",
@@ -662,7 +683,8 @@
             "production_0_100": 25.43,
             "draft_capital_proxy_0_100": 80.0,
             "size_context_0_100": 55.0,
-            "normalization_scope": "class-local"
+            "normalization_scope": "class-local",
+            "opt_out_season_flag": false
           },
           "effective_features_used": [
             "ras_0_100",
@@ -687,7 +709,8 @@
             "production_0_100": 100.0,
             "draft_capital_proxy_0_100": 75.0,
             "size_context_0_100": 45.0,
-            "normalization_scope": "class-local"
+            "normalization_scope": "class-local",
+            "opt_out_season_flag": false
           },
           "effective_features_used": [
             "ras_0_100",
@@ -720,7 +743,8 @@
             "production_0_100": 43.5,
             "draft_capital_proxy_0_100": 85.0,
             "size_context_0_100": 75.0,
-            "normalization_scope": "class-local"
+            "normalization_scope": "class-local",
+            "opt_out_season_flag": false
           },
           "effective_features_used": [
             "ras_0_100",
@@ -745,7 +769,8 @@
             "production_0_100": 53.02,
             "draft_capital_proxy_0_100": 75.0,
             "size_context_0_100": 20.0,
-            "normalization_scope": "class-local"
+            "normalization_scope": "class-local",
+            "opt_out_season_flag": false
           },
           "effective_features_used": [
             "ras_0_100",
@@ -770,7 +795,8 @@
             "production_0_100": 26.42,
             "draft_capital_proxy_0_100": 85.0,
             "size_context_0_100": 58.89,
-            "normalization_scope": "class-local"
+            "normalization_scope": "class-local",
+            "opt_out_season_flag": false
           },
           "effective_features_used": [
             "ras_0_100",
@@ -795,7 +821,8 @@
             "production_0_100": 100.0,
             "draft_capital_proxy_0_100": 75.0,
             "size_context_0_100": 45.0,
-            "normalization_scope": "class-local"
+            "normalization_scope": "class-local",
+            "opt_out_season_flag": false
           },
           "effective_features_used": [
             "ras_0_100",
@@ -820,7 +847,8 @@
             "production_0_100": 25.43,
             "draft_capital_proxy_0_100": 80.0,
             "size_context_0_100": 55.0,
-            "normalization_scope": "class-local"
+            "normalization_scope": "class-local",
+            "opt_out_season_flag": false
           },
           "effective_features_used": [
             "ras_0_100",
@@ -853,7 +881,8 @@
             "production_0_100": 43.5,
             "draft_capital_proxy_0_100": 85.0,
             "size_context_0_100": 75.0,
-            "normalization_scope": "class-local"
+            "normalization_scope": "class-local",
+            "opt_out_season_flag": false
           },
           "effective_features_used": [
             "ras_0_100",
@@ -878,7 +907,8 @@
             "production_0_100": 53.02,
             "draft_capital_proxy_0_100": 75.0,
             "size_context_0_100": 20.0,
-            "normalization_scope": "class-local"
+            "normalization_scope": "class-local",
+            "opt_out_season_flag": false
           },
           "effective_features_used": [
             "ras_0_100",
@@ -903,7 +933,8 @@
             "production_0_100": 26.42,
             "draft_capital_proxy_0_100": 85.0,
             "size_context_0_100": 58.89,
-            "normalization_scope": "class-local"
+            "normalization_scope": "class-local",
+            "opt_out_season_flag": false
           },
           "effective_features_used": [
             "ras_0_100",
@@ -928,7 +959,8 @@
             "production_0_100": 25.43,
             "draft_capital_proxy_0_100": 80.0,
             "size_context_0_100": 55.0,
-            "normalization_scope": "class-local"
+            "normalization_scope": "class-local",
+            "opt_out_season_flag": false
           },
           "effective_features_used": [
             "ras_0_100",
@@ -953,7 +985,8 @@
             "production_0_100": 100.0,
             "draft_capital_proxy_0_100": 75.0,
             "size_context_0_100": 45.0,
-            "normalization_scope": "class-local"
+            "normalization_scope": "class-local",
+            "opt_out_season_flag": false
           },
           "effective_features_used": [
             "ras_0_100",
@@ -986,7 +1019,8 @@
             "production_0_100": 43.5,
             "draft_capital_proxy_0_100": 85.0,
             "size_context_0_100": 75.0,
-            "normalization_scope": "class-local"
+            "normalization_scope": "class-local",
+            "opt_out_season_flag": false
           },
           "effective_features_used": [
             "ras_0_100",
@@ -1011,7 +1045,8 @@
             "production_0_100": 53.02,
             "draft_capital_proxy_0_100": 75.0,
             "size_context_0_100": 20.0,
-            "normalization_scope": "class-local"
+            "normalization_scope": "class-local",
+            "opt_out_season_flag": false
           },
           "effective_features_used": [
             "ras_0_100",
@@ -1036,7 +1071,8 @@
             "production_0_100": 26.42,
             "draft_capital_proxy_0_100": 85.0,
             "size_context_0_100": 58.89,
-            "normalization_scope": "class-local"
+            "normalization_scope": "class-local",
+            "opt_out_season_flag": false
           },
           "effective_features_used": [
             "ras_0_100",
@@ -1061,7 +1097,8 @@
             "production_0_100": 25.43,
             "draft_capital_proxy_0_100": 80.0,
             "size_context_0_100": 55.0,
-            "normalization_scope": "class-local"
+            "normalization_scope": "class-local",
+            "opt_out_season_flag": false
           },
           "effective_features_used": [
             "ras_0_100",
@@ -1086,7 +1123,8 @@
             "production_0_100": 100.0,
             "draft_capital_proxy_0_100": 75.0,
             "size_context_0_100": 45.0,
-            "normalization_scope": "class-local"
+            "normalization_scope": "class-local",
+            "opt_out_season_flag": false
           },
           "effective_features_used": [
             "ras_0_100",
@@ -1119,7 +1157,8 @@
             "production_0_100": 43.5,
             "draft_capital_proxy_0_100": 85.0,
             "size_context_0_100": 75.0,
-            "normalization_scope": "class-local"
+            "normalization_scope": "class-local",
+            "opt_out_season_flag": false
           },
           "effective_features_used": [
             "ras_0_100",
@@ -1144,7 +1183,8 @@
             "production_0_100": 26.42,
             "draft_capital_proxy_0_100": 85.0,
             "size_context_0_100": 58.89,
-            "normalization_scope": "class-local"
+            "normalization_scope": "class-local",
+            "opt_out_season_flag": false
           },
           "effective_features_used": [
             "ras_0_100",
@@ -1169,7 +1209,8 @@
             "production_0_100": 53.02,
             "draft_capital_proxy_0_100": 75.0,
             "size_context_0_100": 20.0,
-            "normalization_scope": "class-local"
+            "normalization_scope": "class-local",
+            "opt_out_season_flag": false
           },
           "effective_features_used": [
             "ras_0_100",
@@ -1194,7 +1235,8 @@
             "production_0_100": 25.43,
             "draft_capital_proxy_0_100": 80.0,
             "size_context_0_100": 55.0,
-            "normalization_scope": "class-local"
+            "normalization_scope": "class-local",
+            "opt_out_season_flag": false
           },
           "effective_features_used": [
             "ras_0_100",
@@ -1219,7 +1261,8 @@
             "production_0_100": 1.06,
             "draft_capital_proxy_0_100": 65.0,
             "size_context_0_100": 50.0,
-            "normalization_scope": "class-local"
+            "normalization_scope": "class-local",
+            "opt_out_season_flag": false
           },
           "effective_features_used": [
             "ras_0_100",
@@ -1252,7 +1295,8 @@
             "production_0_100": 43.5,
             "draft_capital_proxy_0_100": 85.0,
             "size_context_0_100": 75.0,
-            "normalization_scope": "class-local"
+            "normalization_scope": "class-local",
+            "opt_out_season_flag": false
           },
           "effective_features_used": [
             "ras_0_100",
@@ -1277,7 +1321,8 @@
             "production_0_100": 26.42,
             "draft_capital_proxy_0_100": 85.0,
             "size_context_0_100": 58.89,
-            "normalization_scope": "class-local"
+            "normalization_scope": "class-local",
+            "opt_out_season_flag": false
           },
           "effective_features_used": [
             "ras_0_100",
@@ -1302,7 +1347,8 @@
             "production_0_100": 53.02,
             "draft_capital_proxy_0_100": 75.0,
             "size_context_0_100": 20.0,
-            "normalization_scope": "class-local"
+            "normalization_scope": "class-local",
+            "opt_out_season_flag": false
           },
           "effective_features_used": [
             "ras_0_100",
@@ -1327,7 +1373,8 @@
             "production_0_100": 25.43,
             "draft_capital_proxy_0_100": 80.0,
             "size_context_0_100": 55.0,
-            "normalization_scope": "class-local"
+            "normalization_scope": "class-local",
+            "opt_out_season_flag": false
           },
           "effective_features_used": [
             "ras_0_100",
@@ -1352,7 +1399,8 @@
             "production_0_100": 100.0,
             "draft_capital_proxy_0_100": 75.0,
             "size_context_0_100": 45.0,
-            "normalization_scope": "class-local"
+            "normalization_scope": "class-local",
+            "opt_out_season_flag": false
           },
           "effective_features_used": [
             "ras_0_100",
@@ -1385,7 +1433,8 @@
             "production_0_100": 43.5,
             "draft_capital_proxy_0_100": 85.0,
             "size_context_0_100": 75.0,
-            "normalization_scope": "class-local"
+            "normalization_scope": "class-local",
+            "opt_out_season_flag": false
           },
           "effective_features_used": [
             "ras_0_100",
@@ -1410,7 +1459,8 @@
             "production_0_100": 26.42,
             "draft_capital_proxy_0_100": 85.0,
             "size_context_0_100": 58.89,
-            "normalization_scope": "class-local"
+            "normalization_scope": "class-local",
+            "opt_out_season_flag": false
           },
           "effective_features_used": [
             "ras_0_100",
@@ -1435,7 +1485,8 @@
             "production_0_100": 53.02,
             "draft_capital_proxy_0_100": 75.0,
             "size_context_0_100": 20.0,
-            "normalization_scope": "class-local"
+            "normalization_scope": "class-local",
+            "opt_out_season_flag": false
           },
           "effective_features_used": [
             "ras_0_100",
@@ -1460,7 +1511,8 @@
             "production_0_100": 25.43,
             "draft_capital_proxy_0_100": 80.0,
             "size_context_0_100": 55.0,
-            "normalization_scope": "class-local"
+            "normalization_scope": "class-local",
+            "opt_out_season_flag": false
           },
           "effective_features_used": [
             "ras_0_100",
@@ -1485,7 +1537,8 @@
             "production_0_100": 100.0,
             "draft_capital_proxy_0_100": 75.0,
             "size_context_0_100": 45.0,
-            "normalization_scope": "class-local"
+            "normalization_scope": "class-local",
+            "opt_out_season_flag": false
           },
           "effective_features_used": [
             "ras_0_100",

--- a/scripts/compute_historical_comps.py
+++ b/scripts/compute_historical_comps.py
@@ -77,6 +77,13 @@ def normalize_historical_feature_rows(rows: list[dict[str, Any]]) -> list[dict[s
     validate_required_fields(rows, REQUIRED_HISTORICAL_FEATURE_FIELDS, "historical features")
     normalized: list[dict[str, Any]] = []
     for row in rows:
+        production_value = coerce_float_or_none(row.get("production_0_100"))
+        opt_out_season_flag = bool(row.get("opt_out_season_flag", False))
+        if opt_out_season_flag:
+            # Treat opt-out years as unavailable production context so distance math does not
+            # penalize the profile as a literal zero-production season.
+            production_value = None
+
         normalized.append(
             {
                 "player_id": str(row["player_id"]),
@@ -86,12 +93,13 @@ def normalize_historical_feature_rows(rows: list[dict[str, Any]]) -> list[dict[s
                 "draft_year": row.get("draft_year"),
                 "source_season": row.get("source_season"),
                 "ras_0_100": coerce_float_or_none(row.get("ras_0_100")),
-                "production_0_100": coerce_float_or_none(row.get("production_0_100")),
+                "production_0_100": production_value,
                 "draft_capital_proxy_0_100": coerce_float_or_none(row.get("draft_capital_proxy_0_100")),
                 "size_context_0_100": coerce_float_or_none(row.get("size_context_0_100")),
                 "source_name": row.get("source_name"),
                 "source_url": row.get("source_url"),
                 "normalization_scope": row.get("normalization_scope"),
+                "opt_out_season_flag": opt_out_season_flag,
             }
         )
     return normalized
@@ -218,6 +226,7 @@ def build_comp_candidates(
                     "draft_capital_proxy_0_100": row.get("draft_capital_proxy_0_100"),
                     "size_context_0_100": row.get("size_context_0_100"),
                     "normalization_scope": row.get("normalization_scope"),
+                "opt_out_season_flag": bool(row.get("opt_out_season_flag", False)),
                 },
                 "effective_features_used": effective_features_used,
                 "outcome_snapshot": None


### PR DESCRIPTION
### Motivation
- Populate missing WR historical outcomes and expand WR vintage coverage so comps use real-sourced outcome signals rather than placeholders.
- Distinguish Ja'Marr Chase's 2020 COVID opt-out from a zero production value to avoid misinterpretation in similarity calculations. 
- Seed the 2022 WR cohort (features + outcomes) to improve cross-vintage differentiation while preserving deterministic, sourced row contracts.

### Description
- Backfilled five 2021 WR outcome rows (`wr-jamarr-chase-2021`, `wr-jaylen-waddle-2021`, `wr-devonta-smith-2021`, `wr-kadarius-toney-2021`, `wr-rashod-bateman-2021`) with `best_season_fantasy_ppg`, deterministically derived `top_finish_band`, `years_1_to_3_summary`, `career_outcome_label`, and `source_name`/`source_url` citing FantasyData; used `null` only where sourcing was unavailable. 
- Added `opt_out_season_flag: true` to Ja'Marr Chase's feature row in `data/historical/historical_prospect_features.sample.json` and appended an explanatory note to that row; did not change `historical_prospect_features.schema.md`.
- Seeded five 2022 WR feature rows (`wr-garrett-wilson-2022`, `wr-drake-london-2022`, `wr-chris-olave-2022`, `wr-jameson-williams-2022`, `wr-treylon-burks-2022`) with `normalization_scope: "class-local"`, `production_0_100` anchors (class-local min/max documented in notes), `draft_capital_proxy_0_100`, `size_context_0_100` composite percentiles, `ras_0_100` where clean sourcing was available and `null` where not, plus `source_name`/`source_url`/`notes` documenting provenance and methodology. 
- Added matching 2022 outcome rows (same deterministic band/label logic and FantasyData citations) to `data/historical/historical_player_outcomes.sample.json` and updated 2021 outcome placeholders to filled values.
- Regenerated the promoted artifact at `exports/promoted/historical-comps/2026_historical_comps_v0.json` by running the comp producer and surfaced the existing WR concentration warning rather than fabricating data to suppress it.
- Documented the persistent WR top-1 concentration in `scripts/compute_historical_comps.py` (code comment) and in `data/historical/README.md` explaining the cause (sparse RAS coverage and class-local normalization compression).

### Testing
- Ran the historical comp producer to regenerate the promoted artifact with `python scripts/compute_historical_comps.py --rookie-export exports/promoted/rookie-alpha/2026_rookie_alpha_predraft_v0.json --historical-features data/historical/historical_prospect_features.sample.json --historical-outcomes data/historical/historical_player_outcomes.sample.json --output-json exports/promoted/historical-comps/2026_historical_comps_v0.json` and the script completed successfully and wrote `exports/promoted/historical-comps/2026_historical_comps_v0.json`.
- Verified the artifact contains the updated `comp_data_warnings` showing the WR lane concentration (warning remains) by loading the generated JSON with a short validation script, which executed successfully and returned the expected warning message.
- Ran quick JSON checks to confirm presence of five new 2022 WR feature rows, the `opt_out_season_flag` on Chase, and populated 2021 WR outcome fields using small Python inspection commands, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c941609c108332b6f33fc6124e01b9)