### PR TITLE
Rebuild WR production normalization to cross-class-wr-v0

### DIFF
--- a/data/historical/README.md
+++ b/data/historical/README.md
@@ -18,14 +18,14 @@ WR now includes multiple real draft vintages (2020 + 2021) while QB/TE remain sa
   - Some added WR rows still have `ras_0_100 = null` where clean sourcing was not available in this pass.
   - `size_context_0_100` is a deterministic size percentile context signal built from listed pre-draft height/weight across WR rows in this artifact.
 - WR outcome rows for the seeded real cohort now include sourced PPR/G-based snapshots (`best_season_fantasy_ppg`, `years_1_to_3_summary`) plus deterministic label/band derivations.
-- WR `production_0_100` is currently `normalization_scope = "class-local"` min-max over sourced receiving-yards values for the draft class slice represented in this artifact.
-- Class-local min-max behavior means each represented WR class has a forced `production_0_100 = 0.0` floor at that slice's minimum raw-yardage row, even when the player's absolute production is still strong versus other classes.
+- WR `production_0_100` is currently `normalization_scope = "cross-class-wr-v0"` min-max over raw pre-draft receiving-yards values pooled across all current WR historical rows in this artifact.
+- `cross-class-wr-v0` uses raw pre-draft receiving yards pooled across all current WR historical rows; it is not yet calibrated against the 2026 prospect `production_0_100` methodology, which is a multi-signal score.
 - WR `career_outcome_label` and `top_finish_band` are currently deterministic derivations from each player's sourced peak `FPTS/G` (not yet a fully league-ranked finish model).
 - The promoted comp artifact now exposes `effective_features_used` per comp row plus `comp_data_warnings` so partial feature overlap is visible in-artifact.
 - As a result, current WR similarity behavior is improved versus one-vintage/one-proxy, but remains partial and not UI-ready.
 
 
-- Current 2026 repro still emits a WR comp-data warning: one historical WR can remain the #1 comp for all eight 2026 WR prospects. This is currently driven by sparse WR RAS coverage and class-local normalization compression across partial vintages; do not fabricate rows or synthetic deltas to suppress this warning.
+- Current 2026 repro still emits a WR comp-data warning: one historical WR can remain the #1 comp for all eight 2026 WR prospects. This is currently driven by sparse WR RAS coverage and remaining feature-shape compression across partial vintages; do not fabricate rows or synthetic deltas to suppress this warning.
 
 ## Intentional posture
 

--- a/data/historical/historical_prospect_features.sample.json
+++ b/data/historical/historical_prospect_features.sample.json
@@ -55,13 +55,19 @@
     "draft_year": 2020,
     "source_season": 2019,
     "ras_0_100": 74.5,
-    "production_0_100": 43.5,
+    "production_0_100": 71.5,
     "draft_capital_proxy_0_100": 85.0,
     "size_context_0_100": 75.0,
-    "normalization_scope": "class-local",
+    "normalization_scope": "cross-class-wr-v0",
     "source_name": "Wikipedia player page + Pro Football Network 2020 RAS table",
     "source_url": "https://www.profootballnetwork.com/nfl-draft-relative-athletic-scores-math-bomb/",
-    "notes": "2019 receiving yards sourced as 1327; production_0_100 is class-local min-max within drafted WR rows included for the 2020 class. size_context_0_100 is deterministic cohort percentile average of listed pre-draft height/weight among WR rows currently in this artifact. ras_0_100 sourced from Pro Football Network 2020 RAS table (MathBomb compilation)."
+    "notes": "pre-draft receiving yards: 1327; production_0_100 cross-class min-max across all 15 WR historical rows (min 0 yds / max 1856 yds).",
+    "normalization_anchor": {
+      "min_player": "wr-jamarr-chase-2021",
+      "min_yards": 0,
+      "max_player": "wr-devonta-smith-2021",
+      "max_yards": 1856
+    }
   },
   {
     "player_id": "wr-jerry-jeudy-2020",
@@ -71,13 +77,19 @@
     "draft_year": 2020,
     "source_season": 2019,
     "ras_0_100": 67.8,
-    "production_0_100": 0.0,
+    "production_0_100": 62.66,
     "draft_capital_proxy_0_100": 85.0,
     "size_context_0_100": 65.0,
-    "normalization_scope": "class-local",
+    "normalization_scope": "cross-class-wr-v0",
     "source_name": "Wikipedia player page + Pro Football Network 2020 RAS table",
     "source_url": "https://www.profootballnetwork.com/nfl-draft-relative-athletic-scores-math-bomb/",
-    "notes": "2019 receiving yards sourced as 1163; production_0_100 is class-local min-max within drafted WR rows included for the 2020 class. size_context_0_100 is deterministic cohort percentile average of listed pre-draft height/weight among WR rows currently in this artifact. ras_0_100 sourced from Pro Football Network 2020 RAS table (MathBomb compilation)."
+    "notes": "pre-draft receiving yards: 1163; production_0_100 cross-class min-max across all 15 WR historical rows (min 0 yds / max 1856 yds).",
+    "normalization_anchor": {
+      "min_player": "wr-jamarr-chase-2021",
+      "min_yards": 0,
+      "max_player": "wr-devonta-smith-2021",
+      "max_yards": 1856
+    }
   },
   {
     "player_id": "wr-justin-jefferson-2020",
@@ -87,13 +99,19 @@
     "draft_year": 2020,
     "source_season": 2019,
     "ras_0_100": 96.9,
-    "production_0_100": 100.0,
+    "production_0_100": 82.97,
     "draft_capital_proxy_0_100": 75.0,
     "size_context_0_100": 45.0,
-    "normalization_scope": "class-local",
+    "normalization_scope": "cross-class-wr-v0",
     "source_name": "Wikipedia player page + Pro Football Network 2020 RAS table",
     "source_url": "https://www.profootballnetwork.com/nfl-draft-relative-athletic-scores-math-bomb/",
-    "notes": "2019 receiving yards sourced as 1540; production_0_100 is class-local min-max within drafted WR rows included for the 2020 class. size_context_0_100 is deterministic cohort percentile average of listed pre-draft height/weight among WR rows currently in this artifact. ras_0_100 sourced from Pro Football Network 2020 RAS table (MathBomb compilation)."
+    "notes": "pre-draft receiving yards: 1540; production_0_100 cross-class min-max across all 15 WR historical rows (min 0 yds / max 1856 yds).",
+    "normalization_anchor": {
+      "min_player": "wr-jamarr-chase-2021",
+      "min_yards": 0,
+      "max_player": "wr-devonta-smith-2021",
+      "max_yards": 1856
+    }
   },
   {
     "player_id": "wr-brandon-aiyuk-2020",
@@ -103,13 +121,19 @@
     "draft_year": 2020,
     "source_season": 2019,
     "ras_0_100": 84.6,
-    "production_0_100": 7.69,
+    "production_0_100": 64.22,
     "draft_capital_proxy_0_100": 75.0,
     "size_context_0_100": 30.0,
-    "normalization_scope": "class-local",
+    "normalization_scope": "cross-class-wr-v0",
     "source_name": "Wikipedia player page + Pro Football Network 2020 RAS table",
     "source_url": "https://www.profootballnetwork.com/nfl-draft-relative-athletic-scores-math-bomb/",
-    "notes": "2019 receiving yards sourced as 1192; production_0_100 is class-local min-max within drafted WR rows included for the 2020 class. size_context_0_100 is deterministic cohort percentile average of listed pre-draft height/weight among WR rows currently in this artifact. ras_0_100 sourced from Pro Football Network 2020 RAS table (MathBomb compilation)."
+    "notes": "pre-draft receiving yards: 1192; production_0_100 cross-class min-max across all 15 WR historical rows (min 0 yds / max 1856 yds).",
+    "normalization_anchor": {
+      "min_player": "wr-jamarr-chase-2021",
+      "min_yards": 0,
+      "max_player": "wr-devonta-smith-2021",
+      "max_yards": 1856
+    }
   },
   {
     "player_id": "wr-tee-higgins-2020",
@@ -119,13 +143,19 @@
     "draft_year": 2020,
     "source_season": 2019,
     "ras_0_100": 41.6,
-    "production_0_100": 1.06,
+    "production_0_100": 62.88,
     "draft_capital_proxy_0_100": 65.0,
     "size_context_0_100": 50.0,
-    "normalization_scope": "class-local",
+    "normalization_scope": "cross-class-wr-v0",
     "source_name": "Wikipedia player page + Pro Football Network 2020 RAS table",
     "source_url": "https://www.profootballnetwork.com/nfl-draft-relative-athletic-scores-math-bomb/",
-    "notes": "2019 receiving yards sourced as 1167; production_0_100 is class-local min-max within drafted WR rows included for the 2020 class. size_context_0_100 is deterministic cohort percentile average of listed pre-draft height/weight among WR rows currently in this artifact. ras_0_100 sourced from Pro Football Network 2020 RAS table (MathBomb compilation)."
+    "notes": "pre-draft receiving yards: 1167; production_0_100 cross-class min-max across all 15 WR historical rows (min 0 yds / max 1856 yds).",
+    "normalization_anchor": {
+      "min_player": "wr-jamarr-chase-2021",
+      "min_yards": 0,
+      "max_player": "wr-devonta-smith-2021",
+      "max_yards": 1856
+    }
   },
   {
     "player_id": "wr-jamarr-chase-2021",
@@ -138,11 +168,17 @@
     "production_0_100": 0.0,
     "draft_capital_proxy_0_100": 95.0,
     "size_context_0_100": 65.0,
-    "normalization_scope": "class-local",
+    "normalization_scope": "cross-class-wr-v0",
     "source_name": "Wikipedia player page + RAS.football team/pro-bowl tables",
     "source_url": "https://ras.football/2025-initial-pro-bowl-roster/",
-    "notes": "2020 receiving yards sourced as 0; production_0_100 is class-local min-max within drafted WR rows included for the 2021 class. size_context_0_100 is deterministic cohort percentile average of listed pre-draft height/weight among WR rows currently in this artifact. ras_0_100 sourced from RAS.football table snippets for this player; scaled to 0-100 from 0-10 RAS. Added opt_out_season_flag=true to distinguish 2020 COVID opt-out from production failure.",
-    "opt_out_season_flag": true
+    "notes": "pre-draft receiving yards: 0; production_0_100 cross-class min-max across all 15 WR historical rows (min 0 yds / max 1856 yds).",
+    "opt_out_season_flag": true,
+    "normalization_anchor": {
+      "min_player": "wr-jamarr-chase-2021",
+      "min_yards": 0,
+      "max_player": "wr-devonta-smith-2021",
+      "max_yards": 1856
+    }
   },
   {
     "player_id": "wr-jaylen-waddle-2021",
@@ -155,10 +191,16 @@
     "production_0_100": 30.01,
     "draft_capital_proxy_0_100": 90.0,
     "size_context_0_100": 45.0,
-    "normalization_scope": "class-local",
+    "normalization_scope": "cross-class-wr-v0",
     "source_name": "Wikipedia player page (college receiving stats + pre-draft measurables + draft pick)",
     "source_url": "https://en.wikipedia.org/wiki/Jaylen_Waddle",
-    "notes": "2020 receiving yards sourced as 557; production_0_100 is class-local min-max within drafted WR rows included for the 2021 class. size_context_0_100 is deterministic cohort percentile average of listed pre-draft height/weight among WR rows currently in this artifact. ras_0_100 left null because a clean, in-repo-citable RAS value was not sourced for this row in this pass."
+    "notes": "pre-draft receiving yards: 557; production_0_100 cross-class min-max across all 15 WR historical rows (min 0 yds / max 1856 yds).",
+    "normalization_anchor": {
+      "min_player": "wr-jamarr-chase-2021",
+      "min_yards": 0,
+      "max_player": "wr-devonta-smith-2021",
+      "max_yards": 1856
+    }
   },
   {
     "player_id": "wr-devonta-smith-2021",
@@ -171,10 +213,16 @@
     "production_0_100": 100.0,
     "draft_capital_proxy_0_100": 85.0,
     "size_context_0_100": 50.0,
-    "normalization_scope": "class-local",
+    "normalization_scope": "cross-class-wr-v0",
     "source_name": "Wikipedia player page (college receiving stats + pre-draft measurables + draft pick)",
     "source_url": "https://en.wikipedia.org/wiki/DeVonta_Smith",
-    "notes": "2020 receiving yards sourced as 1856; production_0_100 is class-local min-max within drafted WR rows included for the 2021 class. size_context_0_100 is deterministic cohort percentile average of listed pre-draft height/weight among WR rows currently in this artifact. ras_0_100 left null because a clean, in-repo-citable RAS value was not sourced for this row in this pass."
+    "notes": "pre-draft receiving yards: 1856; production_0_100 cross-class min-max across all 15 WR historical rows (min 0 yds / max 1856 yds).",
+    "normalization_anchor": {
+      "min_player": "wr-jamarr-chase-2021",
+      "min_yards": 0,
+      "max_player": "wr-devonta-smith-2021",
+      "max_yards": 1856
+    }
   },
   {
     "player_id": "wr-kadarius-toney-2021",
@@ -187,10 +235,16 @@
     "production_0_100": 53.02,
     "draft_capital_proxy_0_100": 75.0,
     "size_context_0_100": 20.0,
-    "normalization_scope": "class-local",
+    "normalization_scope": "cross-class-wr-v0",
     "source_name": "Wikipedia player page + RAS.football team/pro-bowl tables",
     "source_url": "https://ras.football/new-york-giants-ras-team-page/",
-    "notes": "2020 receiving yards sourced as 984; production_0_100 is class-local min-max within drafted WR rows included for the 2021 class. size_context_0_100 is deterministic cohort percentile average of listed pre-draft height/weight among WR rows currently in this artifact. ras_0_100 sourced from RAS.football table snippets for this player; scaled to 0-100 from 0-10 RAS."
+    "notes": "pre-draft receiving yards: 984; production_0_100 cross-class min-max across all 15 WR historical rows (min 0 yds / max 1856 yds).",
+    "normalization_anchor": {
+      "min_player": "wr-jamarr-chase-2021",
+      "min_yards": 0,
+      "max_player": "wr-devonta-smith-2021",
+      "max_yards": 1856
+    }
   },
   {
     "player_id": "wr-rashod-bateman-2021",
@@ -203,10 +257,16 @@
     "production_0_100": 25.43,
     "draft_capital_proxy_0_100": 80.0,
     "size_context_0_100": 55.0,
-    "normalization_scope": "class-local",
+    "normalization_scope": "cross-class-wr-v0",
     "source_name": "Wikipedia player page + RAS.football team/pro-bowl tables",
     "source_url": "https://ras.football/baltimore-ravens-ras-team-page/",
-    "notes": "2020 receiving yards sourced as 472; production_0_100 is class-local min-max within drafted WR rows included for the 2021 class. size_context_0_100 is deterministic cohort percentile average of listed pre-draft height/weight among WR rows currently in this artifact. ras_0_100 sourced from RAS.football table snippets for this player; scaled to 0-100 from 0-10 RAS."
+    "notes": "pre-draft receiving yards: 472; production_0_100 cross-class min-max across all 15 WR historical rows (min 0 yds / max 1856 yds).",
+    "normalization_anchor": {
+      "min_player": "wr-jamarr-chase-2021",
+      "min_yards": 0,
+      "max_player": "wr-devonta-smith-2021",
+      "max_yards": 1856
+    }
   },
   {
     "player_id": "wr-garrett-wilson-2022",
@@ -216,13 +276,19 @@
     "draft_year": 2022,
     "source_season": 2021,
     "ras_0_100": null,
-    "production_0_100": 19.18,
+    "production_0_100": 57.0,
     "draft_capital_proxy_0_100": 95.0,
     "size_context_0_100": 44.44,
-    "normalization_scope": "class-local",
+    "normalization_scope": "cross-class-wr-v0",
     "source_name": "FantasyData player page + Wikipedia player page + 2022 WR RAS roundup (Steelers Depot citing ras.football)",
     "source_url": "https://en.wikipedia.org/wiki/Garrett_Wilson",
-    "notes": "2021 receiving yards sourced as 1058 (Wikipedia college stats). Draft capital proxy updated for top-10 selection (band 1-10 => 95.0). 2022 WR production_0_100 uses class-local min-max on raw 2021 receiving yards across this 5-player slice: min 936 (Olave), max 1572 (Williams). size_context_0_100 is deterministic percentile composite of listed height, weight, and forty time across this 5-player slice; speed input unavailable for some rows and treated as neutral (50th percentile) in the composite. ras_0_100 left null because an exact player-level RAS value was not cleanly sourced in this pass."
+    "notes": "pre-draft receiving yards: 1058; production_0_100 cross-class min-max across all 15 WR historical rows (min 0 yds / max 1856 yds).",
+    "normalization_anchor": {
+      "min_player": "wr-jamarr-chase-2021",
+      "min_yards": 0,
+      "max_player": "wr-devonta-smith-2021",
+      "max_yards": 1856
+    }
   },
   {
     "player_id": "wr-drake-london-2022",
@@ -232,13 +298,19 @@
     "draft_year": 2022,
     "source_season": 2021,
     "ras_0_100": null,
-    "production_0_100": 23.27,
+    "production_0_100": 58.41,
     "draft_capital_proxy_0_100": 95.0,
     "size_context_0_100": 70.0,
-    "normalization_scope": "class-local",
+    "normalization_scope": "cross-class-wr-v0",
     "source_name": "FantasyData player page + Wikipedia player page + 2022 WR RAS roundup (Steelers Depot citing ras.football)",
     "source_url": "https://en.wikipedia.org/wiki/Drake_London",
-    "notes": "2021 receiving yards sourced as 1084 (Wikipedia college stats). Draft capital proxy updated for top-10 selection (band 1-10 => 95.0). 2022 WR production_0_100 uses class-local min-max on raw 2021 receiving yards across this 5-player slice: min 936 (Olave), max 1572 (Williams). size_context_0_100 is deterministic percentile composite of listed height, weight, and forty time across this 5-player slice; speed input unavailable for this row and treated as neutral (50th percentile) in the composite. ras_0_100 left null because an exact player-level RAS value was not cleanly sourced in this pass."
+    "notes": "pre-draft receiving yards: 1084; production_0_100 cross-class min-max across all 15 WR historical rows (min 0 yds / max 1856 yds).",
+    "normalization_anchor": {
+      "min_player": "wr-jamarr-chase-2021",
+      "min_yards": 0,
+      "max_player": "wr-devonta-smith-2021",
+      "max_yards": 1856
+    }
   },
   {
     "player_id": "wr-chris-olave-2022",
@@ -248,13 +320,19 @@
     "draft_year": 2022,
     "source_season": 2021,
     "ras_0_100": 86.4,
-    "production_0_100": 0.0,
+    "production_0_100": 50.43,
     "draft_capital_proxy_0_100": 85.0,
     "size_context_0_100": 40.0,
-    "normalization_scope": "class-local",
+    "normalization_scope": "cross-class-wr-v0",
     "source_name": "FantasyData player page + Wikipedia player page + public RAS references",
     "source_url": "https://en.wikipedia.org/wiki/Chris_Olave",
-    "notes": "2021 receiving yards sourced as 936 (Wikipedia college stats). 2022 WR production_0_100 uses class-local min-max on raw 2021 receiving yards across this 5-player slice: min 936 (Olave), max 1572 (Williams). size_context_0_100 is deterministic percentile composite of listed height, weight, and forty time across this 5-player slice. ras_0_100 uses publicly cited RAS ~8.64 scaled to 0-100."
+    "notes": "pre-draft receiving yards: 936; production_0_100 cross-class min-max across all 15 WR historical rows (min 0 yds / max 1856 yds).",
+    "normalization_anchor": {
+      "min_player": "wr-jamarr-chase-2021",
+      "min_yards": 0,
+      "max_player": "wr-devonta-smith-2021",
+      "max_yards": 1856
+    }
   },
   {
     "player_id": "wr-jameson-williams-2022",
@@ -264,13 +342,19 @@
     "draft_year": 2022,
     "source_season": 2021,
     "ras_0_100": null,
-    "production_0_100": 100.0,
+    "production_0_100": 84.7,
     "draft_capital_proxy_0_100": 85.0,
     "size_context_0_100": 36.67,
-    "normalization_scope": "class-local",
+    "normalization_scope": "cross-class-wr-v0",
     "source_name": "FantasyData player page + Wikipedia player page + public RAS references",
     "source_url": "https://en.wikipedia.org/wiki/Jameson_Williams",
-    "notes": "2021 receiving yards sourced as 1572 (Wikipedia college stats). 2022 WR production_0_100 uses class-local min-max on raw 2021 receiving yards across this 5-player slice: min 936 (Olave), max 1572 (Williams). size_context_0_100 is deterministic percentile composite of listed height, weight, and forty time across this 5-player slice; speed input unavailable for this row and treated as neutral (50th percentile) in the composite. ras_0_100 left null because the player did not post a full official pre-draft test profile for a stable RAS value in this pass."
+    "notes": "pre-draft receiving yards: 1572; production_0_100 cross-class min-max across all 15 WR historical rows (min 0 yds / max 1856 yds).",
+    "normalization_anchor": {
+      "min_player": "wr-jamarr-chase-2021",
+      "min_yards": 0,
+      "max_player": "wr-devonta-smith-2021",
+      "max_yards": 1856
+    }
   },
   {
     "player_id": "wr-treylon-burks-2022",
@@ -280,12 +364,18 @@
     "draft_year": 2022,
     "source_season": 2021,
     "ras_0_100": 57.8,
-    "production_0_100": 26.42,
+    "production_0_100": 59.48,
     "draft_capital_proxy_0_100": 85.0,
     "size_context_0_100": 58.89,
-    "normalization_scope": "class-local",
+    "normalization_scope": "cross-class-wr-v0",
     "source_name": "FantasyData player page + Wikipedia player page + public RAS references",
     "source_url": "https://en.wikipedia.org/wiki/Treylon_Burks",
-    "notes": "2021 receiving yards sourced as 1104 (Wikipedia college stats). 2022 WR production_0_100 uses class-local min-max on raw 2021 receiving yards across this 5-player slice: min 936 (Olave), max 1572 (Williams). size_context_0_100 is deterministic percentile composite of listed height, weight, and forty time across this 5-player slice. ras_0_100 uses publicly cited RAS ~5.78 scaled to 0-100."
+    "notes": "pre-draft receiving yards: 1104; production_0_100 cross-class min-max across all 15 WR historical rows (min 0 yds / max 1856 yds).",
+    "normalization_anchor": {
+      "min_player": "wr-jamarr-chase-2021",
+      "min_yards": 0,
+      "max_player": "wr-devonta-smith-2021",
+      "max_yards": 1856
+    }
   }
 ]

--- a/data/historical/historical_prospect_features.schema.md
+++ b/data/historical/historical_prospect_features.schema.md
@@ -18,6 +18,7 @@ Each row represents one historical drafted prospect candidate used for nearest-n
 ## Optional fields
 
 - `size_context_0_100` (number | null): optional size/context signal for talent-profile tie-breaking.
+- `normalization_anchor` (object | null): optional explicit min/max anchor metadata for the current `production_0_100` normalization regime (e.g., min/max player id and raw production values).
 - `source_name` (string | null): human-readable provenance source label.
 - `source_url` (string | null): provenance URL.
 - `notes` (string | null): operator note if useful.

--- a/exports/promoted/historical-comps/2026_historical_comps_v0.json
+++ b/exports/promoted/historical-comps/2026_historical_comps_v0.json
@@ -11,7 +11,7 @@
     },
     "notes": "v0 emits talent_comp by default; market_comp support is scaffolded and optional."
   },
-  "generated_at": "2026-03-29T16:17:21+00:00",
+  "generated_at": "2026-03-29T17:53:56+00:00",
   "season": 2026,
   "source_files_used": [
     "exports/promoted/rookie-alpha/2026_rookie_alpha_predraft_v0.json",
@@ -19,7 +19,7 @@
     "data/historical/historical_player_outcomes.sample.json"
   ],
   "comp_data_warnings": {
-    "WR": "WR lane remains insufficiently differentiated for UI use: at least one historical WR is the #1 comp for 8 prospects (>3 threshold). Similarities remain directional only."
+    "WR": "WR lane remains insufficiently differentiated for UI use: at least one historical WR is the #1 comp for 4 prospects (>3 threshold). Similarities remain directional only."
   },
   "players": [
     {
@@ -456,18 +456,18 @@
       "comp_mode": "talent_comp",
       "comps": [
         {
-          "historical_player_id": "wr-ceedee-lamb-2020",
-          "player_name": "CeeDee Lamb",
+          "historical_player_id": "wr-tee-higgins-2020",
+          "player_name": "Tee Higgins",
           "draft_year": 2020,
           "position": "WR",
-          "similarity_score": 64.6513,
-          "distance": 0.353487,
+          "similarity_score": 90.9115,
+          "distance": 0.090885,
           "feature_snapshot": {
-            "ras_0_100": 74.5,
-            "production_0_100": 43.5,
-            "draft_capital_proxy_0_100": 85.0,
-            "size_context_0_100": 75.0,
-            "normalization_scope": "class-local",
+            "ras_0_100": 41.6,
+            "production_0_100": 62.88,
+            "draft_capital_proxy_0_100": 65.0,
+            "size_context_0_100": 50.0,
+            "normalization_scope": "cross-class-wr-v0",
             "opt_out_season_flag": false
           },
           "effective_features_used": [
@@ -475,10 +475,10 @@
             "production_0_100"
           ],
           "outcome_snapshot": {
-            "career_outcome_label": "wr1_peak",
-            "best_season_fantasy_ppg": 23.7,
-            "top_finish_band": "WR1 (>=20.0 PPR/G peak)",
-            "years_1_to_3_summary": "2020-2022 PPR/G: 13.2, 14.6, 17.7; receiving line: 74/935/5, 79/1102/6, 107/1359/9."
+            "career_outcome_label": "wr2_peak",
+            "best_season_fantasy_ppg": 18.5,
+            "top_finish_band": "WR2 (15.0-19.9 PPR/G peak)",
+            "years_1_to_3_summary": "2020-2022 PPR/G: 12.2, 15.7, 13.8; receiving line: 67/908/6, 74/1091/6, 74/1029/7."
           }
         },
         {
@@ -486,14 +486,14 @@
           "player_name": "Treylon Burks",
           "draft_year": 2022,
           "position": "WR",
-          "similarity_score": 62.7794,
-          "distance": 0.372206,
+          "similarity_score": 80.7965,
+          "distance": 0.192035,
           "feature_snapshot": {
             "ras_0_100": 57.8,
-            "production_0_100": 26.42,
+            "production_0_100": 59.48,
             "draft_capital_proxy_0_100": 85.0,
             "size_context_0_100": 58.89,
-            "normalization_scope": "class-local",
+            "normalization_scope": "cross-class-wr-v0",
             "opt_out_season_flag": false
           },
           "effective_features_used": [
@@ -508,70 +508,44 @@
           }
         },
         {
-          "historical_player_id": "wr-kadarius-toney-2021",
-          "player_name": "Kadarius Toney",
-          "draft_year": 2021,
-          "position": "WR",
-          "similarity_score": 58.2936,
-          "distance": 0.417064,
-          "feature_snapshot": {
-            "ras_0_100": 89.9,
-            "production_0_100": 53.02,
-            "draft_capital_proxy_0_100": 75.0,
-            "size_context_0_100": 20.0,
-            "normalization_scope": "class-local",
-            "opt_out_season_flag": false
-          },
-          "effective_features_used": [
-            "ras_0_100",
-            "production_0_100"
-          ],
-          "outcome_snapshot": {
-            "career_outcome_label": "depth_peak",
-            "best_season_fantasy_ppg": 8.2,
-            "top_finish_band": "Depth (<12.0 PPR/G peak)",
-            "years_1_to_3_summary": "2021-2023 PPR/G: 8.2, 6.4, 4.1; receiving line: 39/420/0, 16/171/2, 27/169/1."
-          }
-        },
-        {
-          "historical_player_id": "wr-rashod-bateman-2021",
-          "player_name": "Rashod Bateman",
-          "draft_year": 2021,
-          "position": "WR",
-          "similarity_score": 52.9792,
-          "distance": 0.470208,
-          "feature_snapshot": {
-            "ras_0_100": 80.4,
-            "production_0_100": 25.43,
-            "draft_capital_proxy_0_100": 80.0,
-            "size_context_0_100": 55.0,
-            "normalization_scope": "class-local",
-            "opt_out_season_flag": false
-          },
-          "effective_features_used": [
-            "ras_0_100",
-            "production_0_100"
-          ],
-          "outcome_snapshot": {
-            "career_outcome_label": "depth_peak",
-            "best_season_fantasy_ppg": 10.3,
-            "top_finish_band": "Depth (<12.0 PPR/G peak)",
-            "years_1_to_3_summary": "2021-2023 PPR/G: 8.6, 8.9, 4.8; receiving line: 46/515/1, 15/285/2, 32/367/1."
-          }
-        },
-        {
-          "historical_player_id": "wr-justin-jefferson-2020",
-          "player_name": "Justin Jefferson",
+          "historical_player_id": "wr-jerry-jeudy-2020",
+          "player_name": "Jerry Jeudy",
           "draft_year": 2020,
           "position": "WR",
-          "similarity_score": 52.2235,
-          "distance": 0.477765,
+          "similarity_score": 75.3021,
+          "distance": 0.246979,
           "feature_snapshot": {
-            "ras_0_100": 96.9,
-            "production_0_100": 100.0,
-            "draft_capital_proxy_0_100": 75.0,
-            "size_context_0_100": 45.0,
-            "normalization_scope": "class-local",
+            "ras_0_100": 67.8,
+            "production_0_100": 62.66,
+            "draft_capital_proxy_0_100": 85.0,
+            "size_context_0_100": 65.0,
+            "normalization_scope": "cross-class-wr-v0",
+            "opt_out_season_flag": false
+          },
+          "effective_features_used": [
+            "ras_0_100",
+            "production_0_100"
+          ],
+          "outcome_snapshot": {
+            "career_outcome_label": "wr3_peak",
+            "best_season_fantasy_ppg": 14.2,
+            "top_finish_band": "WR3 (12.0-14.9 PPR/G peak)",
+            "years_1_to_3_summary": "2020-2022 PPR/G: 9.8, 8.5, 13.6; receiving line: 52/856/3, 38/467/0, 67/972/6."
+          }
+        },
+        {
+          "historical_player_id": "wr-ceedee-lamb-2020",
+          "player_name": "CeeDee Lamb",
+          "draft_year": 2020,
+          "position": "WR",
+          "similarity_score": 71.7877,
+          "distance": 0.282123,
+          "feature_snapshot": {
+            "ras_0_100": 74.5,
+            "production_0_100": 71.5,
+            "draft_capital_proxy_0_100": 85.0,
+            "size_context_0_100": 75.0,
+            "normalization_scope": "cross-class-wr-v0",
             "opt_out_season_flag": false
           },
           "effective_features_used": [
@@ -580,9 +554,35 @@
           ],
           "outcome_snapshot": {
             "career_outcome_label": "wr1_peak",
-            "best_season_fantasy_ppg": 21.7,
+            "best_season_fantasy_ppg": 23.7,
             "top_finish_band": "WR1 (>=20.0 PPR/G peak)",
-            "years_1_to_3_summary": "2020-2022 PPR/G: 17.1, 19.4, 21.7; receiving line: 88/1400/7, 108/1616/10, 128/1809/8."
+            "years_1_to_3_summary": "2020-2022 PPR/G: 13.2, 14.6, 17.7; receiving line: 74/935/5, 79/1102/6, 107/1359/9."
+          }
+        },
+        {
+          "historical_player_id": "wr-brandon-aiyuk-2020",
+          "player_name": "Brandon Aiyuk",
+          "draft_year": 2020,
+          "position": "WR",
+          "similarity_score": 64.0582,
+          "distance": 0.359418,
+          "feature_snapshot": {
+            "ras_0_100": 84.6,
+            "production_0_100": 64.22,
+            "draft_capital_proxy_0_100": 75.0,
+            "size_context_0_100": 30.0,
+            "normalization_scope": "cross-class-wr-v0",
+            "opt_out_season_flag": false
+          },
+          "effective_features_used": [
+            "ras_0_100",
+            "production_0_100"
+          ],
+          "outcome_snapshot": {
+            "career_outcome_label": "wr2_peak",
+            "best_season_fantasy_ppg": 15.6,
+            "top_finish_band": "WR2 (15.0-19.9 PPR/G peak)",
+            "years_1_to_3_summary": "2020-2022 PPR/G: 15.4, 10.0, 13.4; receiving line: 60/748/5, 56/826/5, 78/1015/8."
           }
         }
       ]
@@ -594,18 +594,18 @@
       "comp_mode": "talent_comp",
       "comps": [
         {
-          "historical_player_id": "wr-ceedee-lamb-2020",
-          "player_name": "CeeDee Lamb",
+          "historical_player_id": "wr-jerry-jeudy-2020",
+          "player_name": "Jerry Jeudy",
           "draft_year": 2020,
           "position": "WR",
-          "similarity_score": 85.9502,
-          "distance": 0.140498,
+          "similarity_score": 97.1779,
+          "distance": 0.028221,
           "feature_snapshot": {
-            "ras_0_100": 74.5,
-            "production_0_100": 43.5,
+            "ras_0_100": 67.8,
+            "production_0_100": 62.66,
             "draft_capital_proxy_0_100": 85.0,
-            "size_context_0_100": 75.0,
-            "normalization_scope": "class-local",
+            "size_context_0_100": 65.0,
+            "normalization_scope": "cross-class-wr-v0",
             "opt_out_season_flag": false
           },
           "effective_features_used": [
@@ -613,36 +613,10 @@
             "production_0_100"
           ],
           "outcome_snapshot": {
-            "career_outcome_label": "wr1_peak",
-            "best_season_fantasy_ppg": 23.7,
-            "top_finish_band": "WR1 (>=20.0 PPR/G peak)",
-            "years_1_to_3_summary": "2020-2022 PPR/G: 13.2, 14.6, 17.7; receiving line: 74/935/5, 79/1102/6, 107/1359/9."
-          }
-        },
-        {
-          "historical_player_id": "wr-kadarius-toney-2021",
-          "player_name": "Kadarius Toney",
-          "draft_year": 2021,
-          "position": "WR",
-          "similarity_score": 81.1765,
-          "distance": 0.188235,
-          "feature_snapshot": {
-            "ras_0_100": 89.9,
-            "production_0_100": 53.02,
-            "draft_capital_proxy_0_100": 75.0,
-            "size_context_0_100": 20.0,
-            "normalization_scope": "class-local",
-            "opt_out_season_flag": false
-          },
-          "effective_features_used": [
-            "ras_0_100",
-            "production_0_100"
-          ],
-          "outcome_snapshot": {
-            "career_outcome_label": "depth_peak",
-            "best_season_fantasy_ppg": 8.2,
-            "top_finish_band": "Depth (<12.0 PPR/G peak)",
-            "years_1_to_3_summary": "2021-2023 PPR/G: 8.2, 6.4, 4.1; receiving line: 39/420/0, 16/171/2, 27/169/1."
+            "career_outcome_label": "wr3_peak",
+            "best_season_fantasy_ppg": 14.2,
+            "top_finish_band": "WR3 (12.0-14.9 PPR/G peak)",
+            "years_1_to_3_summary": "2020-2022 PPR/G: 9.8, 8.5, 13.6; receiving line: 52/856/3, 38/467/0, 67/972/6."
           }
         },
         {
@@ -650,14 +624,14 @@
           "player_name": "Treylon Burks",
           "draft_year": 2022,
           "position": "WR",
-          "similarity_score": 75.3871,
-          "distance": 0.246129,
+          "similarity_score": 95.2792,
+          "distance": 0.047208,
           "feature_snapshot": {
             "ras_0_100": 57.8,
-            "production_0_100": 26.42,
+            "production_0_100": 59.48,
             "draft_capital_proxy_0_100": 85.0,
             "size_context_0_100": 58.89,
-            "normalization_scope": "class-local",
+            "normalization_scope": "cross-class-wr-v0",
             "opt_out_season_flag": false
           },
           "effective_features_used": [
@@ -672,78 +646,18 @@
           }
         },
         {
-          "historical_player_id": "wr-rashod-bateman-2021",
-          "player_name": "Rashod Bateman",
-          "draft_year": 2021,
-          "position": "WR",
-          "similarity_score": 72.6731,
-          "distance": 0.273269,
-          "feature_snapshot": {
-            "ras_0_100": 80.4,
-            "production_0_100": 25.43,
-            "draft_capital_proxy_0_100": 80.0,
-            "size_context_0_100": 55.0,
-            "normalization_scope": "class-local",
-            "opt_out_season_flag": false
-          },
-          "effective_features_used": [
-            "ras_0_100",
-            "production_0_100"
-          ],
-          "outcome_snapshot": {
-            "career_outcome_label": "depth_peak",
-            "best_season_fantasy_ppg": 10.3,
-            "top_finish_band": "Depth (<12.0 PPR/G peak)",
-            "years_1_to_3_summary": "2021-2023 PPR/G: 8.6, 8.9, 4.8; receiving line: 46/515/1, 15/285/2, 32/367/1."
-          }
-        },
-        {
-          "historical_player_id": "wr-justin-jefferson-2020",
-          "player_name": "Justin Jefferson",
-          "draft_year": 2020,
-          "position": "WR",
-          "similarity_score": 63.8766,
-          "distance": 0.361234,
-          "feature_snapshot": {
-            "ras_0_100": 96.9,
-            "production_0_100": 100.0,
-            "draft_capital_proxy_0_100": 75.0,
-            "size_context_0_100": 45.0,
-            "normalization_scope": "class-local",
-            "opt_out_season_flag": false
-          },
-          "effective_features_used": [
-            "ras_0_100",
-            "production_0_100"
-          ],
-          "outcome_snapshot": {
-            "career_outcome_label": "wr1_peak",
-            "best_season_fantasy_ppg": 21.7,
-            "top_finish_band": "WR1 (>=20.0 PPR/G peak)",
-            "years_1_to_3_summary": "2020-2022 PPR/G: 17.1, 19.4, 21.7; receiving line: 88/1400/7, 108/1616/10, 128/1809/8."
-          }
-        }
-      ]
-    },
-    {
-      "player_id": "wr-chris-brazzell-ii",
-      "player_name": "Chris Brazzell II",
-      "position": "WR",
-      "comp_mode": "talent_comp",
-      "comps": [
-        {
           "historical_player_id": "wr-ceedee-lamb-2020",
           "player_name": "CeeDee Lamb",
           "draft_year": 2020,
           "position": "WR",
-          "similarity_score": 74.5028,
-          "distance": 0.254972,
+          "similarity_score": 89.4835,
+          "distance": 0.105165,
           "feature_snapshot": {
             "ras_0_100": 74.5,
-            "production_0_100": 43.5,
+            "production_0_100": 71.5,
             "draft_capital_proxy_0_100": 85.0,
             "size_context_0_100": 75.0,
-            "normalization_scope": "class-local",
+            "normalization_scope": "cross-class-wr-v0",
             "opt_out_season_flag": false
           },
           "effective_features_used": [
@@ -758,70 +672,18 @@
           }
         },
         {
-          "historical_player_id": "wr-kadarius-toney-2021",
-          "player_name": "Kadarius Toney",
-          "draft_year": 2021,
-          "position": "WR",
-          "similarity_score": 71.0219,
-          "distance": 0.289781,
-          "feature_snapshot": {
-            "ras_0_100": 89.9,
-            "production_0_100": 53.02,
-            "draft_capital_proxy_0_100": 75.0,
-            "size_context_0_100": 20.0,
-            "normalization_scope": "class-local",
-            "opt_out_season_flag": false
-          },
-          "effective_features_used": [
-            "ras_0_100",
-            "production_0_100"
-          ],
-          "outcome_snapshot": {
-            "career_outcome_label": "depth_peak",
-            "best_season_fantasy_ppg": 8.2,
-            "top_finish_band": "Depth (<12.0 PPR/G peak)",
-            "years_1_to_3_summary": "2021-2023 PPR/G: 8.2, 6.4, 4.1; receiving line: 39/420/0, 16/171/2, 27/169/1."
-          }
-        },
-        {
-          "historical_player_id": "wr-treylon-burks-2022",
-          "player_name": "Treylon Burks",
-          "draft_year": 2022,
-          "position": "WR",
-          "similarity_score": 66.6904,
-          "distance": 0.333096,
-          "feature_snapshot": {
-            "ras_0_100": 57.8,
-            "production_0_100": 26.42,
-            "draft_capital_proxy_0_100": 85.0,
-            "size_context_0_100": 58.89,
-            "normalization_scope": "class-local",
-            "opt_out_season_flag": false
-          },
-          "effective_features_used": [
-            "ras_0_100",
-            "production_0_100"
-          ],
-          "outcome_snapshot": {
-            "career_outcome_label": "depth_peak",
-            "best_season_fantasy_ppg": 8.6,
-            "top_finish_band": "Depth (<12.0 PPR/G peak)",
-            "years_1_to_3_summary": "2022-2024 PPR/G: 8.6, 3.6, 1.5; receiving line: 33/444/1, 16/221/0, 4/34/0."
-          }
-        },
-        {
-          "historical_player_id": "wr-justin-jefferson-2020",
-          "player_name": "Justin Jefferson",
+          "historical_player_id": "wr-brandon-aiyuk-2020",
+          "player_name": "Brandon Aiyuk",
           "draft_year": 2020,
           "position": "WR",
-          "similarity_score": 64.5145,
-          "distance": 0.354855,
+          "similarity_score": 85.4761,
+          "distance": 0.145239,
           "feature_snapshot": {
-            "ras_0_100": 96.9,
-            "production_0_100": 100.0,
+            "ras_0_100": 84.6,
+            "production_0_100": 64.22,
             "draft_capital_proxy_0_100": 75.0,
-            "size_context_0_100": 45.0,
-            "normalization_scope": "class-local",
+            "size_context_0_100": 30.0,
+            "normalization_scope": "cross-class-wr-v0",
             "opt_out_season_flag": false
           },
           "effective_features_used": [
@@ -829,424 +691,10 @@
             "production_0_100"
           ],
           "outcome_snapshot": {
-            "career_outcome_label": "wr1_peak",
-            "best_season_fantasy_ppg": 21.7,
-            "top_finish_band": "WR1 (>=20.0 PPR/G peak)",
-            "years_1_to_3_summary": "2020-2022 PPR/G: 17.1, 19.4, 21.7; receiving line: 88/1400/7, 108/1616/10, 128/1809/8."
-          }
-        },
-        {
-          "historical_player_id": "wr-rashod-bateman-2021",
-          "player_name": "Rashod Bateman",
-          "draft_year": 2021,
-          "position": "WR",
-          "similarity_score": 61.3998,
-          "distance": 0.386002,
-          "feature_snapshot": {
-            "ras_0_100": 80.4,
-            "production_0_100": 25.43,
-            "draft_capital_proxy_0_100": 80.0,
-            "size_context_0_100": 55.0,
-            "normalization_scope": "class-local",
-            "opt_out_season_flag": false
-          },
-          "effective_features_used": [
-            "ras_0_100",
-            "production_0_100"
-          ],
-          "outcome_snapshot": {
-            "career_outcome_label": "depth_peak",
-            "best_season_fantasy_ppg": 10.3,
-            "top_finish_band": "Depth (<12.0 PPR/G peak)",
-            "years_1_to_3_summary": "2021-2023 PPR/G: 8.6, 8.9, 4.8; receiving line: 46/515/1, 15/285/2, 32/367/1."
-          }
-        }
-      ]
-    },
-    {
-      "player_id": "wr-denzel-boston",
-      "player_name": "Denzel Boston",
-      "position": "WR",
-      "comp_mode": "talent_comp",
-      "comps": [
-        {
-          "historical_player_id": "wr-ceedee-lamb-2020",
-          "player_name": "CeeDee Lamb",
-          "draft_year": 2020,
-          "position": "WR",
-          "similarity_score": 78.1865,
-          "distance": 0.218135,
-          "feature_snapshot": {
-            "ras_0_100": 74.5,
-            "production_0_100": 43.5,
-            "draft_capital_proxy_0_100": 85.0,
-            "size_context_0_100": 75.0,
-            "normalization_scope": "class-local",
-            "opt_out_season_flag": false
-          },
-          "effective_features_used": [
-            "ras_0_100",
-            "production_0_100"
-          ],
-          "outcome_snapshot": {
-            "career_outcome_label": "wr1_peak",
-            "best_season_fantasy_ppg": 23.7,
-            "top_finish_band": "WR1 (>=20.0 PPR/G peak)",
-            "years_1_to_3_summary": "2020-2022 PPR/G: 13.2, 14.6, 17.7; receiving line: 74/935/5, 79/1102/6, 107/1359/9."
-          }
-        },
-        {
-          "historical_player_id": "wr-kadarius-toney-2021",
-          "player_name": "Kadarius Toney",
-          "draft_year": 2021,
-          "position": "WR",
-          "similarity_score": 73.9221,
-          "distance": 0.260779,
-          "feature_snapshot": {
-            "ras_0_100": 89.9,
-            "production_0_100": 53.02,
-            "draft_capital_proxy_0_100": 75.0,
-            "size_context_0_100": 20.0,
-            "normalization_scope": "class-local",
-            "opt_out_season_flag": false
-          },
-          "effective_features_used": [
-            "ras_0_100",
-            "production_0_100"
-          ],
-          "outcome_snapshot": {
-            "career_outcome_label": "depth_peak",
-            "best_season_fantasy_ppg": 8.2,
-            "top_finish_band": "Depth (<12.0 PPR/G peak)",
-            "years_1_to_3_summary": "2021-2023 PPR/G: 8.2, 6.4, 4.1; receiving line: 39/420/0, 16/171/2, 27/169/1."
-          }
-        },
-        {
-          "historical_player_id": "wr-treylon-burks-2022",
-          "player_name": "Treylon Burks",
-          "draft_year": 2022,
-          "position": "WR",
-          "similarity_score": 70.2291,
-          "distance": 0.297709,
-          "feature_snapshot": {
-            "ras_0_100": 57.8,
-            "production_0_100": 26.42,
-            "draft_capital_proxy_0_100": 85.0,
-            "size_context_0_100": 58.89,
-            "normalization_scope": "class-local",
-            "opt_out_season_flag": false
-          },
-          "effective_features_used": [
-            "ras_0_100",
-            "production_0_100"
-          ],
-          "outcome_snapshot": {
-            "career_outcome_label": "depth_peak",
-            "best_season_fantasy_ppg": 8.6,
-            "top_finish_band": "Depth (<12.0 PPR/G peak)",
-            "years_1_to_3_summary": "2022-2024 PPR/G: 8.6, 3.6, 1.5; receiving line: 33/444/1, 16/221/0, 4/34/0."
-          }
-        },
-        {
-          "historical_player_id": "wr-rashod-bateman-2021",
-          "player_name": "Rashod Bateman",
-          "draft_year": 2021,
-          "position": "WR",
-          "similarity_score": 65.1449,
-          "distance": 0.348551,
-          "feature_snapshot": {
-            "ras_0_100": 80.4,
-            "production_0_100": 25.43,
-            "draft_capital_proxy_0_100": 80.0,
-            "size_context_0_100": 55.0,
-            "normalization_scope": "class-local",
-            "opt_out_season_flag": false
-          },
-          "effective_features_used": [
-            "ras_0_100",
-            "production_0_100"
-          ],
-          "outcome_snapshot": {
-            "career_outcome_label": "depth_peak",
-            "best_season_fantasy_ppg": 10.3,
-            "top_finish_band": "Depth (<12.0 PPR/G peak)",
-            "years_1_to_3_summary": "2021-2023 PPR/G: 8.6, 8.9, 4.8; receiving line: 46/515/1, 15/285/2, 32/367/1."
-          }
-        },
-        {
-          "historical_player_id": "wr-justin-jefferson-2020",
-          "player_name": "Justin Jefferson",
-          "draft_year": 2020,
-          "position": "WR",
-          "similarity_score": 63.7346,
-          "distance": 0.362654,
-          "feature_snapshot": {
-            "ras_0_100": 96.9,
-            "production_0_100": 100.0,
-            "draft_capital_proxy_0_100": 75.0,
-            "size_context_0_100": 45.0,
-            "normalization_scope": "class-local",
-            "opt_out_season_flag": false
-          },
-          "effective_features_used": [
-            "ras_0_100",
-            "production_0_100"
-          ],
-          "outcome_snapshot": {
-            "career_outcome_label": "wr1_peak",
-            "best_season_fantasy_ppg": 21.7,
-            "top_finish_band": "WR1 (>=20.0 PPR/G peak)",
-            "years_1_to_3_summary": "2020-2022 PPR/G: 17.1, 19.4, 21.7; receiving line: 88/1400/7, 108/1616/10, 128/1809/8."
-          }
-        }
-      ]
-    },
-    {
-      "player_id": "wr-elijah-sarratt",
-      "player_name": "Elijah Sarratt",
-      "position": "WR",
-      "comp_mode": "talent_comp",
-      "comps": [
-        {
-          "historical_player_id": "wr-ceedee-lamb-2020",
-          "player_name": "CeeDee Lamb",
-          "draft_year": 2020,
-          "position": "WR",
-          "similarity_score": 80.2305,
-          "distance": 0.197695,
-          "feature_snapshot": {
-            "ras_0_100": 74.5,
-            "production_0_100": 43.5,
-            "draft_capital_proxy_0_100": 85.0,
-            "size_context_0_100": 75.0,
-            "normalization_scope": "class-local",
-            "opt_out_season_flag": false
-          },
-          "effective_features_used": [
-            "ras_0_100",
-            "production_0_100"
-          ],
-          "outcome_snapshot": {
-            "career_outcome_label": "wr1_peak",
-            "best_season_fantasy_ppg": 23.7,
-            "top_finish_band": "WR1 (>=20.0 PPR/G peak)",
-            "years_1_to_3_summary": "2020-2022 PPR/G: 13.2, 14.6, 17.7; receiving line: 74/935/5, 79/1102/6, 107/1359/9."
-          }
-        },
-        {
-          "historical_player_id": "wr-kadarius-toney-2021",
-          "player_name": "Kadarius Toney",
-          "draft_year": 2021,
-          "position": "WR",
-          "similarity_score": 76.6858,
-          "distance": 0.233142,
-          "feature_snapshot": {
-            "ras_0_100": 89.9,
-            "production_0_100": 53.02,
-            "draft_capital_proxy_0_100": 75.0,
-            "size_context_0_100": 20.0,
-            "normalization_scope": "class-local",
-            "opt_out_season_flag": false
-          },
-          "effective_features_used": [
-            "ras_0_100",
-            "production_0_100"
-          ],
-          "outcome_snapshot": {
-            "career_outcome_label": "depth_peak",
-            "best_season_fantasy_ppg": 8.2,
-            "top_finish_band": "Depth (<12.0 PPR/G peak)",
-            "years_1_to_3_summary": "2021-2023 PPR/G: 8.2, 6.4, 4.1; receiving line: 39/420/0, 16/171/2, 27/169/1."
-          }
-        },
-        {
-          "historical_player_id": "wr-treylon-burks-2022",
-          "player_name": "Treylon Burks",
-          "draft_year": 2022,
-          "position": "WR",
-          "similarity_score": 70.8265,
-          "distance": 0.291735,
-          "feature_snapshot": {
-            "ras_0_100": 57.8,
-            "production_0_100": 26.42,
-            "draft_capital_proxy_0_100": 85.0,
-            "size_context_0_100": 58.89,
-            "normalization_scope": "class-local",
-            "opt_out_season_flag": false
-          },
-          "effective_features_used": [
-            "ras_0_100",
-            "production_0_100"
-          ],
-          "outcome_snapshot": {
-            "career_outcome_label": "depth_peak",
-            "best_season_fantasy_ppg": 8.6,
-            "top_finish_band": "Depth (<12.0 PPR/G peak)",
-            "years_1_to_3_summary": "2022-2024 PPR/G: 8.6, 3.6, 1.5; receiving line: 33/444/1, 16/221/0, 4/34/0."
-          }
-        },
-        {
-          "historical_player_id": "wr-rashod-bateman-2021",
-          "player_name": "Rashod Bateman",
-          "draft_year": 2021,
-          "position": "WR",
-          "similarity_score": 66.9757,
-          "distance": 0.330243,
-          "feature_snapshot": {
-            "ras_0_100": 80.4,
-            "production_0_100": 25.43,
-            "draft_capital_proxy_0_100": 80.0,
-            "size_context_0_100": 55.0,
-            "normalization_scope": "class-local",
-            "opt_out_season_flag": false
-          },
-          "effective_features_used": [
-            "ras_0_100",
-            "production_0_100"
-          ],
-          "outcome_snapshot": {
-            "career_outcome_label": "depth_peak",
-            "best_season_fantasy_ppg": 10.3,
-            "top_finish_band": "Depth (<12.0 PPR/G peak)",
-            "years_1_to_3_summary": "2021-2023 PPR/G: 8.6, 8.9, 4.8; receiving line: 46/515/1, 15/285/2, 32/367/1."
-          }
-        },
-        {
-          "historical_player_id": "wr-justin-jefferson-2020",
-          "player_name": "Justin Jefferson",
-          "draft_year": 2020,
-          "position": "WR",
-          "similarity_score": 65.4508,
-          "distance": 0.345492,
-          "feature_snapshot": {
-            "ras_0_100": 96.9,
-            "production_0_100": 100.0,
-            "draft_capital_proxy_0_100": 75.0,
-            "size_context_0_100": 45.0,
-            "normalization_scope": "class-local",
-            "opt_out_season_flag": false
-          },
-          "effective_features_used": [
-            "ras_0_100",
-            "production_0_100"
-          ],
-          "outcome_snapshot": {
-            "career_outcome_label": "wr1_peak",
-            "best_season_fantasy_ppg": 21.7,
-            "top_finish_band": "WR1 (>=20.0 PPR/G peak)",
-            "years_1_to_3_summary": "2020-2022 PPR/G: 17.1, 19.4, 21.7; receiving line: 88/1400/7, 108/1616/10, 128/1809/8."
-          }
-        }
-      ]
-    },
-    {
-      "player_id": "wr-jordyn-tyson",
-      "player_name": "Jordyn Tyson",
-      "position": "WR",
-      "comp_mode": "talent_comp",
-      "comps": [
-        {
-          "historical_player_id": "wr-ceedee-lamb-2020",
-          "player_name": "CeeDee Lamb",
-          "draft_year": 2020,
-          "position": "WR",
-          "similarity_score": 82.9496,
-          "distance": 0.170504,
-          "feature_snapshot": {
-            "ras_0_100": 74.5,
-            "production_0_100": 43.5,
-            "draft_capital_proxy_0_100": 85.0,
-            "size_context_0_100": 75.0,
-            "normalization_scope": "class-local",
-            "opt_out_season_flag": false
-          },
-          "effective_features_used": [
-            "ras_0_100",
-            "production_0_100"
-          ],
-          "outcome_snapshot": {
-            "career_outcome_label": "wr1_peak",
-            "best_season_fantasy_ppg": 23.7,
-            "top_finish_band": "WR1 (>=20.0 PPR/G peak)",
-            "years_1_to_3_summary": "2020-2022 PPR/G: 13.2, 14.6, 17.7; receiving line: 74/935/5, 79/1102/6, 107/1359/9."
-          }
-        },
-        {
-          "historical_player_id": "wr-treylon-burks-2022",
-          "player_name": "Treylon Burks",
-          "draft_year": 2022,
-          "position": "WR",
-          "similarity_score": 78.1221,
-          "distance": 0.218779,
-          "feature_snapshot": {
-            "ras_0_100": 57.8,
-            "production_0_100": 26.42,
-            "draft_capital_proxy_0_100": 85.0,
-            "size_context_0_100": 58.89,
-            "normalization_scope": "class-local",
-            "opt_out_season_flag": false
-          },
-          "effective_features_used": [
-            "ras_0_100",
-            "production_0_100"
-          ],
-          "outcome_snapshot": {
-            "career_outcome_label": "depth_peak",
-            "best_season_fantasy_ppg": 8.6,
-            "top_finish_band": "Depth (<12.0 PPR/G peak)",
-            "years_1_to_3_summary": "2022-2024 PPR/G: 8.6, 3.6, 1.5; receiving line: 33/444/1, 16/221/0, 4/34/0."
-          }
-        },
-        {
-          "historical_player_id": "wr-kadarius-toney-2021",
-          "player_name": "Kadarius Toney",
-          "draft_year": 2021,
-          "position": "WR",
-          "similarity_score": 74.9048,
-          "distance": 0.250952,
-          "feature_snapshot": {
-            "ras_0_100": 89.9,
-            "production_0_100": 53.02,
-            "draft_capital_proxy_0_100": 75.0,
-            "size_context_0_100": 20.0,
-            "normalization_scope": "class-local",
-            "opt_out_season_flag": false
-          },
-          "effective_features_used": [
-            "ras_0_100",
-            "production_0_100"
-          ],
-          "outcome_snapshot": {
-            "career_outcome_label": "depth_peak",
-            "best_season_fantasy_ppg": 8.2,
-            "top_finish_band": "Depth (<12.0 PPR/G peak)",
-            "years_1_to_3_summary": "2021-2023 PPR/G: 8.2, 6.4, 4.1; receiving line: 39/420/0, 16/171/2, 27/169/1."
-          }
-        },
-        {
-          "historical_player_id": "wr-rashod-bateman-2021",
-          "player_name": "Rashod Bateman",
-          "draft_year": 2021,
-          "position": "WR",
-          "similarity_score": 71.086,
-          "distance": 0.28914,
-          "feature_snapshot": {
-            "ras_0_100": 80.4,
-            "production_0_100": 25.43,
-            "draft_capital_proxy_0_100": 80.0,
-            "size_context_0_100": 55.0,
-            "normalization_scope": "class-local",
-            "opt_out_season_flag": false
-          },
-          "effective_features_used": [
-            "ras_0_100",
-            "production_0_100"
-          ],
-          "outcome_snapshot": {
-            "career_outcome_label": "depth_peak",
-            "best_season_fantasy_ppg": 10.3,
-            "top_finish_band": "Depth (<12.0 PPR/G peak)",
-            "years_1_to_3_summary": "2021-2023 PPR/G: 8.6, 8.9, 4.8; receiving line: 46/515/1, 15/285/2, 32/367/1."
+            "career_outcome_label": "wr2_peak",
+            "best_season_fantasy_ppg": 15.6,
+            "top_finish_band": "WR2 (15.0-19.9 PPR/G peak)",
+            "years_1_to_3_summary": "2020-2022 PPR/G: 15.4, 10.0, 13.4; receiving line: 60/748/5, 56/826/5, 78/1015/8."
           }
         },
         {
@@ -1254,14 +702,14 @@
           "player_name": "Tee Higgins",
           "draft_year": 2020,
           "position": "WR",
-          "similarity_score": 59.2435,
-          "distance": 0.407565,
+          "similarity_score": 83.8105,
+          "distance": 0.161895,
           "feature_snapshot": {
             "ras_0_100": 41.6,
-            "production_0_100": 1.06,
+            "production_0_100": 62.88,
             "draft_capital_proxy_0_100": 65.0,
             "size_context_0_100": 50.0,
-            "normalization_scope": "class-local",
+            "normalization_scope": "cross-class-wr-v0",
             "opt_out_season_flag": false
           },
           "effective_features_used": [
@@ -1278,50 +726,24 @@
       ]
     },
     {
-      "player_id": "wr-kc-concepcion",
-      "player_name": "KC Concepcion",
+      "player_id": "wr-chris-brazzell-ii",
+      "player_name": "Chris Brazzell II",
       "position": "WR",
       "comp_mode": "talent_comp",
       "comps": [
-        {
-          "historical_player_id": "wr-ceedee-lamb-2020",
-          "player_name": "CeeDee Lamb",
-          "draft_year": 2020,
-          "position": "WR",
-          "similarity_score": 71.4802,
-          "distance": 0.285198,
-          "feature_snapshot": {
-            "ras_0_100": 74.5,
-            "production_0_100": 43.5,
-            "draft_capital_proxy_0_100": 85.0,
-            "size_context_0_100": 75.0,
-            "normalization_scope": "class-local",
-            "opt_out_season_flag": false
-          },
-          "effective_features_used": [
-            "ras_0_100",
-            "production_0_100"
-          ],
-          "outcome_snapshot": {
-            "career_outcome_label": "wr1_peak",
-            "best_season_fantasy_ppg": 23.7,
-            "top_finish_band": "WR1 (>=20.0 PPR/G peak)",
-            "years_1_to_3_summary": "2020-2022 PPR/G: 13.2, 14.6, 17.7; receiving line: 74/935/5, 79/1102/6, 107/1359/9."
-          }
-        },
         {
           "historical_player_id": "wr-treylon-burks-2022",
           "player_name": "Treylon Burks",
           "draft_year": 2022,
           "position": "WR",
-          "similarity_score": 68.1823,
-          "distance": 0.318177,
+          "similarity_score": 89.8585,
+          "distance": 0.101415,
           "feature_snapshot": {
             "ras_0_100": 57.8,
-            "production_0_100": 26.42,
+            "production_0_100": 59.48,
             "draft_capital_proxy_0_100": 85.0,
             "size_context_0_100": 58.89,
-            "normalization_scope": "class-local",
+            "normalization_scope": "cross-class-wr-v0",
             "opt_out_season_flag": false
           },
           "effective_features_used": [
@@ -1336,70 +758,70 @@
           }
         },
         {
-          "historical_player_id": "wr-kadarius-toney-2021",
-          "player_name": "Kadarius Toney",
-          "draft_year": 2021,
-          "position": "WR",
-          "similarity_score": 65.1324,
-          "distance": 0.348676,
-          "feature_snapshot": {
-            "ras_0_100": 89.9,
-            "production_0_100": 53.02,
-            "draft_capital_proxy_0_100": 75.0,
-            "size_context_0_100": 20.0,
-            "normalization_scope": "class-local",
-            "opt_out_season_flag": false
-          },
-          "effective_features_used": [
-            "ras_0_100",
-            "production_0_100"
-          ],
-          "outcome_snapshot": {
-            "career_outcome_label": "depth_peak",
-            "best_season_fantasy_ppg": 8.2,
-            "top_finish_band": "Depth (<12.0 PPR/G peak)",
-            "years_1_to_3_summary": "2021-2023 PPR/G: 8.2, 6.4, 4.1; receiving line: 39/420/0, 16/171/2, 27/169/1."
-          }
-        },
-        {
-          "historical_player_id": "wr-rashod-bateman-2021",
-          "player_name": "Rashod Bateman",
-          "draft_year": 2021,
-          "position": "WR",
-          "similarity_score": 59.513,
-          "distance": 0.40487,
-          "feature_snapshot": {
-            "ras_0_100": 80.4,
-            "production_0_100": 25.43,
-            "draft_capital_proxy_0_100": 80.0,
-            "size_context_0_100": 55.0,
-            "normalization_scope": "class-local",
-            "opt_out_season_flag": false
-          },
-          "effective_features_used": [
-            "ras_0_100",
-            "production_0_100"
-          ],
-          "outcome_snapshot": {
-            "career_outcome_label": "depth_peak",
-            "best_season_fantasy_ppg": 10.3,
-            "top_finish_band": "Depth (<12.0 PPR/G peak)",
-            "years_1_to_3_summary": "2021-2023 PPR/G: 8.6, 8.9, 4.8; receiving line: 46/515/1, 15/285/2, 32/367/1."
-          }
-        },
-        {
-          "historical_player_id": "wr-justin-jefferson-2020",
-          "player_name": "Justin Jefferson",
+          "historical_player_id": "wr-tee-higgins-2020",
+          "player_name": "Tee Higgins",
           "draft_year": 2020,
           "position": "WR",
-          "similarity_score": 56.1866,
-          "distance": 0.438134,
+          "similarity_score": 88.3141,
+          "distance": 0.116859,
           "feature_snapshot": {
-            "ras_0_100": 96.9,
-            "production_0_100": 100.0,
-            "draft_capital_proxy_0_100": 75.0,
-            "size_context_0_100": 45.0,
-            "normalization_scope": "class-local",
+            "ras_0_100": 41.6,
+            "production_0_100": 62.88,
+            "draft_capital_proxy_0_100": 65.0,
+            "size_context_0_100": 50.0,
+            "normalization_scope": "cross-class-wr-v0",
+            "opt_out_season_flag": false
+          },
+          "effective_features_used": [
+            "ras_0_100",
+            "production_0_100"
+          ],
+          "outcome_snapshot": {
+            "career_outcome_label": "wr2_peak",
+            "best_season_fantasy_ppg": 18.5,
+            "top_finish_band": "WR2 (15.0-19.9 PPR/G peak)",
+            "years_1_to_3_summary": "2020-2022 PPR/G: 12.2, 15.7, 13.8; receiving line: 67/908/6, 74/1091/6, 74/1029/7."
+          }
+        },
+        {
+          "historical_player_id": "wr-jerry-jeudy-2020",
+          "player_name": "Jerry Jeudy",
+          "draft_year": 2020,
+          "position": "WR",
+          "similarity_score": 87.8269,
+          "distance": 0.121731,
+          "feature_snapshot": {
+            "ras_0_100": 67.8,
+            "production_0_100": 62.66,
+            "draft_capital_proxy_0_100": 85.0,
+            "size_context_0_100": 65.0,
+            "normalization_scope": "cross-class-wr-v0",
+            "opt_out_season_flag": false
+          },
+          "effective_features_used": [
+            "ras_0_100",
+            "production_0_100"
+          ],
+          "outcome_snapshot": {
+            "career_outcome_label": "wr3_peak",
+            "best_season_fantasy_ppg": 14.2,
+            "top_finish_band": "WR3 (12.0-14.9 PPR/G peak)",
+            "years_1_to_3_summary": "2020-2022 PPR/G: 9.8, 8.5, 13.6; receiving line: 52/856/3, 38/467/0, 67/972/6."
+          }
+        },
+        {
+          "historical_player_id": "wr-ceedee-lamb-2020",
+          "player_name": "CeeDee Lamb",
+          "draft_year": 2020,
+          "position": "WR",
+          "similarity_score": 85.6855,
+          "distance": 0.143145,
+          "feature_snapshot": {
+            "ras_0_100": 74.5,
+            "production_0_100": 71.5,
+            "draft_capital_proxy_0_100": 85.0,
+            "size_context_0_100": 75.0,
+            "normalization_scope": "cross-class-wr-v0",
             "opt_out_season_flag": false
           },
           "effective_features_used": [
@@ -1408,9 +830,587 @@
           ],
           "outcome_snapshot": {
             "career_outcome_label": "wr1_peak",
-            "best_season_fantasy_ppg": 21.7,
+            "best_season_fantasy_ppg": 23.7,
             "top_finish_band": "WR1 (>=20.0 PPR/G peak)",
-            "years_1_to_3_summary": "2020-2022 PPR/G: 17.1, 19.4, 21.7; receiving line: 88/1400/7, 108/1616/10, 128/1809/8."
+            "years_1_to_3_summary": "2020-2022 PPR/G: 13.2, 14.6, 17.7; receiving line: 74/935/5, 79/1102/6, 107/1359/9."
+          }
+        },
+        {
+          "historical_player_id": "wr-brandon-aiyuk-2020",
+          "player_name": "Brandon Aiyuk",
+          "draft_year": 2020,
+          "position": "WR",
+          "similarity_score": 77.6438,
+          "distance": 0.223562,
+          "feature_snapshot": {
+            "ras_0_100": 84.6,
+            "production_0_100": 64.22,
+            "draft_capital_proxy_0_100": 75.0,
+            "size_context_0_100": 30.0,
+            "normalization_scope": "cross-class-wr-v0",
+            "opt_out_season_flag": false
+          },
+          "effective_features_used": [
+            "ras_0_100",
+            "production_0_100"
+          ],
+          "outcome_snapshot": {
+            "career_outcome_label": "wr2_peak",
+            "best_season_fantasy_ppg": 15.6,
+            "top_finish_band": "WR2 (15.0-19.9 PPR/G peak)",
+            "years_1_to_3_summary": "2020-2022 PPR/G: 15.4, 10.0, 13.4; receiving line: 60/748/5, 56/826/5, 78/1015/8."
+          }
+        }
+      ]
+    },
+    {
+      "player_id": "wr-denzel-boston",
+      "player_name": "Denzel Boston",
+      "position": "WR",
+      "comp_mode": "talent_comp",
+      "comps": [
+        {
+          "historical_player_id": "wr-treylon-burks-2022",
+          "player_name": "Treylon Burks",
+          "draft_year": 2022,
+          "position": "WR",
+          "similarity_score": 93.5484,
+          "distance": 0.064516,
+          "feature_snapshot": {
+            "ras_0_100": 57.8,
+            "production_0_100": 59.48,
+            "draft_capital_proxy_0_100": 85.0,
+            "size_context_0_100": 58.89,
+            "normalization_scope": "cross-class-wr-v0",
+            "opt_out_season_flag": false
+          },
+          "effective_features_used": [
+            "ras_0_100",
+            "production_0_100"
+          ],
+          "outcome_snapshot": {
+            "career_outcome_label": "depth_peak",
+            "best_season_fantasy_ppg": 8.6,
+            "top_finish_band": "Depth (<12.0 PPR/G peak)",
+            "years_1_to_3_summary": "2022-2024 PPR/G: 8.6, 3.6, 1.5; receiving line: 33/444/1, 16/221/0, 4/34/0."
+          }
+        },
+        {
+          "historical_player_id": "wr-jerry-jeudy-2020",
+          "player_name": "Jerry Jeudy",
+          "draft_year": 2020,
+          "position": "WR",
+          "similarity_score": 90.9594,
+          "distance": 0.090406,
+          "feature_snapshot": {
+            "ras_0_100": 67.8,
+            "production_0_100": 62.66,
+            "draft_capital_proxy_0_100": 85.0,
+            "size_context_0_100": 65.0,
+            "normalization_scope": "cross-class-wr-v0",
+            "opt_out_season_flag": false
+          },
+          "effective_features_used": [
+            "ras_0_100",
+            "production_0_100"
+          ],
+          "outcome_snapshot": {
+            "career_outcome_label": "wr3_peak",
+            "best_season_fantasy_ppg": 14.2,
+            "top_finish_band": "WR3 (12.0-14.9 PPR/G peak)",
+            "years_1_to_3_summary": "2020-2022 PPR/G: 9.8, 8.5, 13.6; receiving line: 52/856/3, 38/467/0, 67/972/6."
+          }
+        },
+        {
+          "historical_player_id": "wr-tee-higgins-2020",
+          "player_name": "Tee Higgins",
+          "draft_year": 2020,
+          "position": "WR",
+          "similarity_score": 88.7883,
+          "distance": 0.112117,
+          "feature_snapshot": {
+            "ras_0_100": 41.6,
+            "production_0_100": 62.88,
+            "draft_capital_proxy_0_100": 65.0,
+            "size_context_0_100": 50.0,
+            "normalization_scope": "cross-class-wr-v0",
+            "opt_out_season_flag": false
+          },
+          "effective_features_used": [
+            "ras_0_100",
+            "production_0_100"
+          ],
+          "outcome_snapshot": {
+            "career_outcome_label": "wr2_peak",
+            "best_season_fantasy_ppg": 18.5,
+            "top_finish_band": "WR2 (15.0-19.9 PPR/G peak)",
+            "years_1_to_3_summary": "2020-2022 PPR/G: 12.2, 15.7, 13.8; receiving line: 67/908/6, 74/1091/6, 74/1029/7."
+          }
+        },
+        {
+          "historical_player_id": "wr-ceedee-lamb-2020",
+          "player_name": "CeeDee Lamb",
+          "draft_year": 2020,
+          "position": "WR",
+          "similarity_score": 87.0452,
+          "distance": 0.129548,
+          "feature_snapshot": {
+            "ras_0_100": 74.5,
+            "production_0_100": 71.5,
+            "draft_capital_proxy_0_100": 85.0,
+            "size_context_0_100": 75.0,
+            "normalization_scope": "cross-class-wr-v0",
+            "opt_out_season_flag": false
+          },
+          "effective_features_used": [
+            "ras_0_100",
+            "production_0_100"
+          ],
+          "outcome_snapshot": {
+            "career_outcome_label": "wr1_peak",
+            "best_season_fantasy_ppg": 23.7,
+            "top_finish_band": "WR1 (>=20.0 PPR/G peak)",
+            "years_1_to_3_summary": "2020-2022 PPR/G: 13.2, 14.6, 17.7; receiving line: 74/935/5, 79/1102/6, 107/1359/9."
+          }
+        },
+        {
+          "historical_player_id": "wr-brandon-aiyuk-2020",
+          "player_name": "Brandon Aiyuk",
+          "draft_year": 2020,
+          "position": "WR",
+          "similarity_score": 79.8497,
+          "distance": 0.201503,
+          "feature_snapshot": {
+            "ras_0_100": 84.6,
+            "production_0_100": 64.22,
+            "draft_capital_proxy_0_100": 75.0,
+            "size_context_0_100": 30.0,
+            "normalization_scope": "cross-class-wr-v0",
+            "opt_out_season_flag": false
+          },
+          "effective_features_used": [
+            "ras_0_100",
+            "production_0_100"
+          ],
+          "outcome_snapshot": {
+            "career_outcome_label": "wr2_peak",
+            "best_season_fantasy_ppg": 15.6,
+            "top_finish_band": "WR2 (15.0-19.9 PPR/G peak)",
+            "years_1_to_3_summary": "2020-2022 PPR/G: 15.4, 10.0, 13.4; receiving line: 60/748/5, 56/826/5, 78/1015/8."
+          }
+        }
+      ]
+    },
+    {
+      "player_id": "wr-elijah-sarratt",
+      "player_name": "Elijah Sarratt",
+      "position": "WR",
+      "comp_mode": "talent_comp",
+      "comps": [
+        {
+          "historical_player_id": "wr-treylon-burks-2022",
+          "player_name": "Treylon Burks",
+          "draft_year": 2022,
+          "position": "WR",
+          "similarity_score": 93.9866,
+          "distance": 0.060134,
+          "feature_snapshot": {
+            "ras_0_100": 57.8,
+            "production_0_100": 59.48,
+            "draft_capital_proxy_0_100": 85.0,
+            "size_context_0_100": 58.89,
+            "normalization_scope": "cross-class-wr-v0",
+            "opt_out_season_flag": false
+          },
+          "effective_features_used": [
+            "ras_0_100",
+            "production_0_100"
+          ],
+          "outcome_snapshot": {
+            "career_outcome_label": "depth_peak",
+            "best_season_fantasy_ppg": 8.6,
+            "top_finish_band": "Depth (<12.0 PPR/G peak)",
+            "years_1_to_3_summary": "2022-2024 PPR/G: 8.6, 3.6, 1.5; receiving line: 33/444/1, 16/221/0, 4/34/0."
+          }
+        },
+        {
+          "historical_player_id": "wr-jerry-jeudy-2020",
+          "player_name": "Jerry Jeudy",
+          "draft_year": 2020,
+          "position": "WR",
+          "similarity_score": 93.666,
+          "distance": 0.06334,
+          "feature_snapshot": {
+            "ras_0_100": 67.8,
+            "production_0_100": 62.66,
+            "draft_capital_proxy_0_100": 85.0,
+            "size_context_0_100": 65.0,
+            "normalization_scope": "cross-class-wr-v0",
+            "opt_out_season_flag": false
+          },
+          "effective_features_used": [
+            "ras_0_100",
+            "production_0_100"
+          ],
+          "outcome_snapshot": {
+            "career_outcome_label": "wr3_peak",
+            "best_season_fantasy_ppg": 14.2,
+            "top_finish_band": "WR3 (12.0-14.9 PPR/G peak)",
+            "years_1_to_3_summary": "2020-2022 PPR/G: 9.8, 8.5, 13.6; receiving line: 52/856/3, 38/467/0, 67/972/6."
+          }
+        },
+        {
+          "historical_player_id": "wr-ceedee-lamb-2020",
+          "player_name": "CeeDee Lamb",
+          "draft_year": 2020,
+          "position": "WR",
+          "similarity_score": 89.6061,
+          "distance": 0.103939,
+          "feature_snapshot": {
+            "ras_0_100": 74.5,
+            "production_0_100": 71.5,
+            "draft_capital_proxy_0_100": 85.0,
+            "size_context_0_100": 75.0,
+            "normalization_scope": "cross-class-wr-v0",
+            "opt_out_season_flag": false
+          },
+          "effective_features_used": [
+            "ras_0_100",
+            "production_0_100"
+          ],
+          "outcome_snapshot": {
+            "career_outcome_label": "wr1_peak",
+            "best_season_fantasy_ppg": 23.7,
+            "top_finish_band": "WR1 (>=20.0 PPR/G peak)",
+            "years_1_to_3_summary": "2020-2022 PPR/G: 13.2, 14.6, 17.7; receiving line: 74/935/5, 79/1102/6, 107/1359/9."
+          }
+        },
+        {
+          "historical_player_id": "wr-tee-higgins-2020",
+          "player_name": "Tee Higgins",
+          "draft_year": 2020,
+          "position": "WR",
+          "similarity_score": 86.3435,
+          "distance": 0.136565,
+          "feature_snapshot": {
+            "ras_0_100": 41.6,
+            "production_0_100": 62.88,
+            "draft_capital_proxy_0_100": 65.0,
+            "size_context_0_100": 50.0,
+            "normalization_scope": "cross-class-wr-v0",
+            "opt_out_season_flag": false
+          },
+          "effective_features_used": [
+            "ras_0_100",
+            "production_0_100"
+          ],
+          "outcome_snapshot": {
+            "career_outcome_label": "wr2_peak",
+            "best_season_fantasy_ppg": 18.5,
+            "top_finish_band": "WR2 (15.0-19.9 PPR/G peak)",
+            "years_1_to_3_summary": "2020-2022 PPR/G: 12.2, 15.7, 13.8; receiving line: 67/908/6, 74/1091/6, 74/1029/7."
+          }
+        },
+        {
+          "historical_player_id": "wr-brandon-aiyuk-2020",
+          "player_name": "Brandon Aiyuk",
+          "draft_year": 2020,
+          "position": "WR",
+          "similarity_score": 82.6712,
+          "distance": 0.173288,
+          "feature_snapshot": {
+            "ras_0_100": 84.6,
+            "production_0_100": 64.22,
+            "draft_capital_proxy_0_100": 75.0,
+            "size_context_0_100": 30.0,
+            "normalization_scope": "cross-class-wr-v0",
+            "opt_out_season_flag": false
+          },
+          "effective_features_used": [
+            "ras_0_100",
+            "production_0_100"
+          ],
+          "outcome_snapshot": {
+            "career_outcome_label": "wr2_peak",
+            "best_season_fantasy_ppg": 15.6,
+            "top_finish_band": "WR2 (15.0-19.9 PPR/G peak)",
+            "years_1_to_3_summary": "2020-2022 PPR/G: 15.4, 10.0, 13.4; receiving line: 60/748/5, 56/826/5, 78/1015/8."
+          }
+        }
+      ]
+    },
+    {
+      "player_id": "wr-jordyn-tyson",
+      "player_name": "Jordyn Tyson",
+      "position": "WR",
+      "comp_mode": "talent_comp",
+      "comps": [
+        {
+          "historical_player_id": "wr-treylon-burks-2022",
+          "player_name": "Treylon Burks",
+          "draft_year": 2022,
+          "position": "WR",
+          "similarity_score": 97.2544,
+          "distance": 0.027456,
+          "feature_snapshot": {
+            "ras_0_100": 57.8,
+            "production_0_100": 59.48,
+            "draft_capital_proxy_0_100": 85.0,
+            "size_context_0_100": 58.89,
+            "normalization_scope": "cross-class-wr-v0",
+            "opt_out_season_flag": false
+          },
+          "effective_features_used": [
+            "ras_0_100",
+            "production_0_100"
+          ],
+          "outcome_snapshot": {
+            "career_outcome_label": "depth_peak",
+            "best_season_fantasy_ppg": 8.6,
+            "top_finish_band": "Depth (<12.0 PPR/G peak)",
+            "years_1_to_3_summary": "2022-2024 PPR/G: 8.6, 3.6, 1.5; receiving line: 33/444/1, 16/221/0, 4/34/0."
+          }
+        },
+        {
+          "historical_player_id": "wr-jerry-jeudy-2020",
+          "player_name": "Jerry Jeudy",
+          "draft_year": 2020,
+          "position": "WR",
+          "similarity_score": 89.9365,
+          "distance": 0.100635,
+          "feature_snapshot": {
+            "ras_0_100": 67.8,
+            "production_0_100": 62.66,
+            "draft_capital_proxy_0_100": 85.0,
+            "size_context_0_100": 65.0,
+            "normalization_scope": "cross-class-wr-v0",
+            "opt_out_season_flag": false
+          },
+          "effective_features_used": [
+            "ras_0_100",
+            "production_0_100"
+          ],
+          "outcome_snapshot": {
+            "career_outcome_label": "wr3_peak",
+            "best_season_fantasy_ppg": 14.2,
+            "top_finish_band": "WR3 (12.0-14.9 PPR/G peak)",
+            "years_1_to_3_summary": "2020-2022 PPR/G: 9.8, 8.5, 13.6; receiving line: 52/856/3, 38/467/0, 67/972/6."
+          }
+        },
+        {
+          "historical_player_id": "wr-tee-higgins-2020",
+          "player_name": "Tee Higgins",
+          "draft_year": 2020,
+          "position": "WR",
+          "similarity_score": 89.9315,
+          "distance": 0.100685,
+          "feature_snapshot": {
+            "ras_0_100": 41.6,
+            "production_0_100": 62.88,
+            "draft_capital_proxy_0_100": 65.0,
+            "size_context_0_100": 50.0,
+            "normalization_scope": "cross-class-wr-v0",
+            "opt_out_season_flag": false
+          },
+          "effective_features_used": [
+            "ras_0_100",
+            "production_0_100"
+          ],
+          "outcome_snapshot": {
+            "career_outcome_label": "wr2_peak",
+            "best_season_fantasy_ppg": 18.5,
+            "top_finish_band": "WR2 (15.0-19.9 PPR/G peak)",
+            "years_1_to_3_summary": "2020-2022 PPR/G: 12.2, 15.7, 13.8; receiving line: 67/908/6, 74/1091/6, 74/1029/7."
+          }
+        },
+        {
+          "historical_player_id": "wr-ceedee-lamb-2020",
+          "player_name": "CeeDee Lamb",
+          "draft_year": 2020,
+          "position": "WR",
+          "similarity_score": 82.705,
+          "distance": 0.17295,
+          "feature_snapshot": {
+            "ras_0_100": 74.5,
+            "production_0_100": 71.5,
+            "draft_capital_proxy_0_100": 85.0,
+            "size_context_0_100": 75.0,
+            "normalization_scope": "cross-class-wr-v0",
+            "opt_out_season_flag": false
+          },
+          "effective_features_used": [
+            "ras_0_100",
+            "production_0_100"
+          ],
+          "outcome_snapshot": {
+            "career_outcome_label": "wr1_peak",
+            "best_season_fantasy_ppg": 23.7,
+            "top_finish_band": "WR1 (>=20.0 PPR/G peak)",
+            "years_1_to_3_summary": "2020-2022 PPR/G: 13.2, 14.6, 17.7; receiving line: 74/935/5, 79/1102/6, 107/1359/9."
+          }
+        },
+        {
+          "historical_player_id": "wr-brandon-aiyuk-2020",
+          "player_name": "Brandon Aiyuk",
+          "draft_year": 2020,
+          "position": "WR",
+          "similarity_score": 78.253,
+          "distance": 0.21747,
+          "feature_snapshot": {
+            "ras_0_100": 84.6,
+            "production_0_100": 64.22,
+            "draft_capital_proxy_0_100": 75.0,
+            "size_context_0_100": 30.0,
+            "normalization_scope": "cross-class-wr-v0",
+            "opt_out_season_flag": false
+          },
+          "effective_features_used": [
+            "ras_0_100",
+            "production_0_100"
+          ],
+          "outcome_snapshot": {
+            "career_outcome_label": "wr2_peak",
+            "best_season_fantasy_ppg": 15.6,
+            "top_finish_band": "WR2 (15.0-19.9 PPR/G peak)",
+            "years_1_to_3_summary": "2020-2022 PPR/G: 15.4, 10.0, 13.4; receiving line: 60/748/5, 56/826/5, 78/1015/8."
+          }
+        }
+      ]
+    },
+    {
+      "player_id": "wr-kc-concepcion",
+      "player_name": "KC Concepcion",
+      "position": "WR",
+      "comp_mode": "talent_comp",
+      "comps": [
+        {
+          "historical_player_id": "wr-tee-higgins-2020",
+          "player_name": "Tee Higgins",
+          "draft_year": 2020,
+          "position": "WR",
+          "similarity_score": 95.5178,
+          "distance": 0.044822,
+          "feature_snapshot": {
+            "ras_0_100": 41.6,
+            "production_0_100": 62.88,
+            "draft_capital_proxy_0_100": 65.0,
+            "size_context_0_100": 50.0,
+            "normalization_scope": "cross-class-wr-v0",
+            "opt_out_season_flag": false
+          },
+          "effective_features_used": [
+            "ras_0_100",
+            "production_0_100"
+          ],
+          "outcome_snapshot": {
+            "career_outcome_label": "wr2_peak",
+            "best_season_fantasy_ppg": 18.5,
+            "top_finish_band": "WR2 (15.0-19.9 PPR/G peak)",
+            "years_1_to_3_summary": "2020-2022 PPR/G: 12.2, 15.7, 13.8; receiving line: 67/908/6, 74/1091/6, 74/1029/7."
+          }
+        },
+        {
+          "historical_player_id": "wr-treylon-burks-2022",
+          "player_name": "Treylon Burks",
+          "draft_year": 2022,
+          "position": "WR",
+          "similarity_score": 87.7056,
+          "distance": 0.122944,
+          "feature_snapshot": {
+            "ras_0_100": 57.8,
+            "production_0_100": 59.48,
+            "draft_capital_proxy_0_100": 85.0,
+            "size_context_0_100": 58.89,
+            "normalization_scope": "cross-class-wr-v0",
+            "opt_out_season_flag": false
+          },
+          "effective_features_used": [
+            "ras_0_100",
+            "production_0_100"
+          ],
+          "outcome_snapshot": {
+            "career_outcome_label": "depth_peak",
+            "best_season_fantasy_ppg": 8.6,
+            "top_finish_band": "Depth (<12.0 PPR/G peak)",
+            "years_1_to_3_summary": "2022-2024 PPR/G: 8.6, 3.6, 1.5; receiving line: 33/444/1, 16/221/0, 4/34/0."
+          }
+        },
+        {
+          "historical_player_id": "wr-jerry-jeudy-2020",
+          "player_name": "Jerry Jeudy",
+          "draft_year": 2020,
+          "position": "WR",
+          "similarity_score": 82.0716,
+          "distance": 0.179284,
+          "feature_snapshot": {
+            "ras_0_100": 67.8,
+            "production_0_100": 62.66,
+            "draft_capital_proxy_0_100": 85.0,
+            "size_context_0_100": 65.0,
+            "normalization_scope": "cross-class-wr-v0",
+            "opt_out_season_flag": false
+          },
+          "effective_features_used": [
+            "ras_0_100",
+            "production_0_100"
+          ],
+          "outcome_snapshot": {
+            "career_outcome_label": "wr3_peak",
+            "best_season_fantasy_ppg": 14.2,
+            "top_finish_band": "WR3 (12.0-14.9 PPR/G peak)",
+            "years_1_to_3_summary": "2020-2022 PPR/G: 9.8, 8.5, 13.6; receiving line: 52/856/3, 38/467/0, 67/972/6."
+          }
+        },
+        {
+          "historical_player_id": "wr-ceedee-lamb-2020",
+          "player_name": "CeeDee Lamb",
+          "draft_year": 2020,
+          "position": "WR",
+          "similarity_score": 77.8329,
+          "distance": 0.221671,
+          "feature_snapshot": {
+            "ras_0_100": 74.5,
+            "production_0_100": 71.5,
+            "draft_capital_proxy_0_100": 85.0,
+            "size_context_0_100": 75.0,
+            "normalization_scope": "cross-class-wr-v0",
+            "opt_out_season_flag": false
+          },
+          "effective_features_used": [
+            "ras_0_100",
+            "production_0_100"
+          ],
+          "outcome_snapshot": {
+            "career_outcome_label": "wr1_peak",
+            "best_season_fantasy_ppg": 23.7,
+            "top_finish_band": "WR1 (>=20.0 PPR/G peak)",
+            "years_1_to_3_summary": "2020-2022 PPR/G: 13.2, 14.6, 17.7; receiving line: 74/935/5, 79/1102/6, 107/1359/9."
+          }
+        },
+        {
+          "historical_player_id": "wr-brandon-aiyuk-2020",
+          "player_name": "Brandon Aiyuk",
+          "draft_year": 2020,
+          "position": "WR",
+          "similarity_score": 70.5671,
+          "distance": 0.294329,
+          "feature_snapshot": {
+            "ras_0_100": 84.6,
+            "production_0_100": 64.22,
+            "draft_capital_proxy_0_100": 75.0,
+            "size_context_0_100": 30.0,
+            "normalization_scope": "cross-class-wr-v0",
+            "opt_out_season_flag": false
+          },
+          "effective_features_used": [
+            "ras_0_100",
+            "production_0_100"
+          ],
+          "outcome_snapshot": {
+            "career_outcome_label": "wr2_peak",
+            "best_season_fantasy_ppg": 15.6,
+            "top_finish_band": "WR2 (15.0-19.9 PPR/G peak)",
+            "years_1_to_3_summary": "2020-2022 PPR/G: 15.4, 10.0, 13.4; receiving line: 60/748/5, 56/826/5, 78/1015/8."
           }
         }
       ]
@@ -1422,18 +1422,18 @@
       "comp_mode": "talent_comp",
       "comps": [
         {
-          "historical_player_id": "wr-ceedee-lamb-2020",
-          "player_name": "CeeDee Lamb",
+          "historical_player_id": "wr-tee-higgins-2020",
+          "player_name": "Tee Higgins",
           "draft_year": 2020,
           "position": "WR",
-          "similarity_score": 66.4171,
-          "distance": 0.335829,
+          "similarity_score": 92.2192,
+          "distance": 0.077808,
           "feature_snapshot": {
-            "ras_0_100": 74.5,
-            "production_0_100": 43.5,
-            "draft_capital_proxy_0_100": 85.0,
-            "size_context_0_100": 75.0,
-            "normalization_scope": "class-local",
+            "ras_0_100": 41.6,
+            "production_0_100": 62.88,
+            "draft_capital_proxy_0_100": 65.0,
+            "size_context_0_100": 50.0,
+            "normalization_scope": "cross-class-wr-v0",
             "opt_out_season_flag": false
           },
           "effective_features_used": [
@@ -1441,10 +1441,10 @@
             "production_0_100"
           ],
           "outcome_snapshot": {
-            "career_outcome_label": "wr1_peak",
-            "best_season_fantasy_ppg": 23.7,
-            "top_finish_band": "WR1 (>=20.0 PPR/G peak)",
-            "years_1_to_3_summary": "2020-2022 PPR/G: 13.2, 14.6, 17.7; receiving line: 74/935/5, 79/1102/6, 107/1359/9."
+            "career_outcome_label": "wr2_peak",
+            "best_season_fantasy_ppg": 18.5,
+            "top_finish_band": "WR2 (15.0-19.9 PPR/G peak)",
+            "years_1_to_3_summary": "2020-2022 PPR/G: 12.2, 15.7, 13.8; receiving line: 67/908/6, 74/1091/6, 74/1029/7."
           }
         },
         {
@@ -1452,14 +1452,14 @@
           "player_name": "Treylon Burks",
           "draft_year": 2022,
           "position": "WR",
-          "similarity_score": 64.0084,
-          "distance": 0.359916,
+          "similarity_score": 82.6235,
+          "distance": 0.173765,
           "feature_snapshot": {
             "ras_0_100": 57.8,
-            "production_0_100": 26.42,
+            "production_0_100": 59.48,
             "draft_capital_proxy_0_100": 85.0,
             "size_context_0_100": 58.89,
-            "normalization_scope": "class-local",
+            "normalization_scope": "cross-class-wr-v0",
             "opt_out_season_flag": false
           },
           "effective_features_used": [
@@ -1474,70 +1474,44 @@
           }
         },
         {
-          "historical_player_id": "wr-kadarius-toney-2021",
-          "player_name": "Kadarius Toney",
-          "draft_year": 2021,
-          "position": "WR",
-          "similarity_score": 60.1997,
-          "distance": 0.398003,
-          "feature_snapshot": {
-            "ras_0_100": 89.9,
-            "production_0_100": 53.02,
-            "draft_capital_proxy_0_100": 75.0,
-            "size_context_0_100": 20.0,
-            "normalization_scope": "class-local",
-            "opt_out_season_flag": false
-          },
-          "effective_features_used": [
-            "ras_0_100",
-            "production_0_100"
-          ],
-          "outcome_snapshot": {
-            "career_outcome_label": "depth_peak",
-            "best_season_fantasy_ppg": 8.2,
-            "top_finish_band": "Depth (<12.0 PPR/G peak)",
-            "years_1_to_3_summary": "2021-2023 PPR/G: 8.2, 6.4, 4.1; receiving line: 39/420/0, 16/171/2, 27/169/1."
-          }
-        },
-        {
-          "historical_player_id": "wr-rashod-bateman-2021",
-          "player_name": "Rashod Bateman",
-          "draft_year": 2021,
-          "position": "WR",
-          "similarity_score": 54.6002,
-          "distance": 0.453998,
-          "feature_snapshot": {
-            "ras_0_100": 80.4,
-            "production_0_100": 25.43,
-            "draft_capital_proxy_0_100": 80.0,
-            "size_context_0_100": 55.0,
-            "normalization_scope": "class-local",
-            "opt_out_season_flag": false
-          },
-          "effective_features_used": [
-            "ras_0_100",
-            "production_0_100"
-          ],
-          "outcome_snapshot": {
-            "career_outcome_label": "depth_peak",
-            "best_season_fantasy_ppg": 10.3,
-            "top_finish_band": "Depth (<12.0 PPR/G peak)",
-            "years_1_to_3_summary": "2021-2023 PPR/G: 8.6, 8.9, 4.8; receiving line: 46/515/1, 15/285/2, 32/367/1."
-          }
-        },
-        {
-          "historical_player_id": "wr-justin-jefferson-2020",
-          "player_name": "Justin Jefferson",
+          "historical_player_id": "wr-jerry-jeudy-2020",
+          "player_name": "Jerry Jeudy",
           "draft_year": 2020,
           "position": "WR",
-          "similarity_score": 53.7203,
-          "distance": 0.462797,
+          "similarity_score": 77.2138,
+          "distance": 0.227862,
           "feature_snapshot": {
-            "ras_0_100": 96.9,
-            "production_0_100": 100.0,
-            "draft_capital_proxy_0_100": 75.0,
-            "size_context_0_100": 45.0,
-            "normalization_scope": "class-local",
+            "ras_0_100": 67.8,
+            "production_0_100": 62.66,
+            "draft_capital_proxy_0_100": 85.0,
+            "size_context_0_100": 65.0,
+            "normalization_scope": "cross-class-wr-v0",
+            "opt_out_season_flag": false
+          },
+          "effective_features_used": [
+            "ras_0_100",
+            "production_0_100"
+          ],
+          "outcome_snapshot": {
+            "career_outcome_label": "wr3_peak",
+            "best_season_fantasy_ppg": 14.2,
+            "top_finish_band": "WR3 (12.0-14.9 PPR/G peak)",
+            "years_1_to_3_summary": "2020-2022 PPR/G: 9.8, 8.5, 13.6; receiving line: 52/856/3, 38/467/0, 67/972/6."
+          }
+        },
+        {
+          "historical_player_id": "wr-ceedee-lamb-2020",
+          "player_name": "CeeDee Lamb",
+          "draft_year": 2020,
+          "position": "WR",
+          "similarity_score": 73.6597,
+          "distance": 0.263403,
+          "feature_snapshot": {
+            "ras_0_100": 74.5,
+            "production_0_100": 71.5,
+            "draft_capital_proxy_0_100": 85.0,
+            "size_context_0_100": 75.0,
+            "normalization_scope": "cross-class-wr-v0",
             "opt_out_season_flag": false
           },
           "effective_features_used": [
@@ -1546,9 +1520,35 @@
           ],
           "outcome_snapshot": {
             "career_outcome_label": "wr1_peak",
-            "best_season_fantasy_ppg": 21.7,
+            "best_season_fantasy_ppg": 23.7,
             "top_finish_band": "WR1 (>=20.0 PPR/G peak)",
-            "years_1_to_3_summary": "2020-2022 PPR/G: 17.1, 19.4, 21.7; receiving line: 88/1400/7, 108/1616/10, 128/1809/8."
+            "years_1_to_3_summary": "2020-2022 PPR/G: 13.2, 14.6, 17.7; receiving line: 74/935/5, 79/1102/6, 107/1359/9."
+          }
+        },
+        {
+          "historical_player_id": "wr-brandon-aiyuk-2020",
+          "player_name": "Brandon Aiyuk",
+          "draft_year": 2020,
+          "position": "WR",
+          "similarity_score": 65.9682,
+          "distance": 0.340318,
+          "feature_snapshot": {
+            "ras_0_100": 84.6,
+            "production_0_100": 64.22,
+            "draft_capital_proxy_0_100": 75.0,
+            "size_context_0_100": 30.0,
+            "normalization_scope": "cross-class-wr-v0",
+            "opt_out_season_flag": false
+          },
+          "effective_features_used": [
+            "ras_0_100",
+            "production_0_100"
+          ],
+          "outcome_snapshot": {
+            "career_outcome_label": "wr2_peak",
+            "best_season_fantasy_ppg": 15.6,
+            "top_finish_band": "WR2 (15.0-19.9 PPR/G peak)",
+            "years_1_to_3_summary": "2020-2022 PPR/G: 15.4, 10.0, 13.4; receiving line: 60/748/5, 56/826/5, 78/1015/8."
           }
         }
       ]


### PR DESCRIPTION
### Motivation
- Make WR `production_0_100` comparable across draft vintages by pooling raw pre-draft receiving yards for all 15 WR historical rows and removing per-class min-max compression. 
- Preserve existing provenance and other signals while including Ja'Marr Chase's opt-out-year `0` yards in the normalization pool so anchors reflect real sourced values. 

### Description
- Extracted raw pre-draft receiving yards from each WR row's `notes` and computed a single pooled min-max anchor of `min = 0` (Ja'Marr Chase `wr-jamarr-chase-2021`) and `max = 1856` (DeVonta Smith `wr-devonta-smith-2021`) using `production_0_100 = ((raw_yards - min) / (max - min)) * 100` and rounding to 2 decimals. 
- Updated all 15 WR rows in `data/historical/historical_prospect_features.sample.json` to set `normalization_scope` to `cross-class-wr-v0`, replace `production_0_100` with the computed pooled values, add identical `normalization_anchor` objects, and revise `notes` to explicitly state the raw yards and cross-class min/max method; no other fields were changed. 
- Added `normalization_anchor` to the Optional fields in `data/historical/historical_prospect_features.schema.md` and updated `data/historical/README.md` to document `cross-class-wr-v0` and note calibration caveats. 
- Arithmetic by player (formula used for each row: `production_0_100 = ((raw_yards - 0) / (1856 - 0)) * 100`, rounded to 2 decimals):
- CeeDee Lamb (`wr-ceedee-lamb-2020`): raw 1327 -> `((1327-0)/1856)*100 = 71.50`.
- Jerry Jeudy (`wr-jerry-jeudy-2020`): raw 1163 -> `62.66`.
- Justin Jefferson (`wr-justin-jefferson-2020`): raw 1540 -> `82.97`.
- Brandon Aiyuk (`wr-brandon-aiyuk-2020`): raw 1192 -> `64.22`.
- Tee Higgins (`wr-tee-higgins-2020`): raw 1167 -> `62.88`.
- Ja'Marr Chase (`wr-jamarr-chase-2021`): raw 0 -> `0.00`.
- Jaylen Waddle (`wr-jaylen-waddle-2021`): raw 557 -> `30.01`.
- DeVonta Smith (`wr-devonta-smith-2021`): raw 1856 -> `100.00`.
- Kadarius Toney (`wr-kadarius-toney-2021`): raw 984 -> `53.02`.
- Rashod Bateman (`wr-rashod-bateman-2021`): raw 472 -> `25.43`.
- Garrett Wilson (`wr-garrett-wilson-2022`): raw 1058 -> `57.00`.
- Drake London (`wr-drake-london-2022`): raw 1084 -> `58.41`.
- Chris Olave (`wr-chris-olave-2022`): raw 936 -> `50.43`.
- Jameson Williams (`wr-jameson-williams-2022`): raw 1572 -> `84.70`.
- Treylon Burks (`wr-treylon-burks-2022`): raw 1104 -> `59.48`.

### Testing
- Ran the promoted comps regeneration with `python scripts/compute_historical_comps.py --rookie-export exports/promoted/rookie-alpha/2026_rookie_alpha_predraft_v0.json --historical-features data/historical/historical_prospect_features.sample.json --historical-outcomes data/historical/historical_player_outcomes.sample.json --output-json exports/promoted/historical-comps/2026_historical_comps_v0.json` and the script completed successfully and wrote `exports/promoted/historical-comps/2026_historical_comps_v0.json`.
- Validated raw-yard extraction and computed `production_0_100` values via an ad-hoc Python check that printed each WR's raw yards and the rounded cross-class `production_0_100`, and the values in the committed JSON match the printed results. 
- Checked `comp_data_warnings` in the regenerated artifact and confirmed the WR concentration warning still fires as: `WR lane remains insufficiently differentiated for UI use: at least one historical WR is the #1 comp for 4 prospects (>3 threshold). Similarities remain directional only.`
- Cross-class anchors documented in rows and schema are: `min` = Ja'Marr Chase (`wr-jamarr-chase-2021`) = `0` yards, and `max` = DeVonta Smith (`wr-devonta-smith-2021`) = `1856` yards.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c966f843208332bf0ebbc8763603ab)