### PR TITLE
Harden historical comps artifact with similarity-quality signaling and stricter UI gating

### DIFF
--- a/data/historical/README.md
+++ b/data/historical/README.md
@@ -20,6 +20,9 @@ WR now includes multiple real draft vintages (2020 + 2021) while QB/TE remain sa
 - WR outcome rows for the seeded real cohort now include sourced PPR/G-based snapshots (`best_season_fantasy_ppg`, `years_1_to_3_summary`) plus deterministic label/band derivations.
 - WR `production_0_100` is currently `normalization_scope = "cross-class-wr-v0"` min-max over raw pre-draft receiving-yards values pooled across all current WR historical rows in this artifact.
 - `cross-class-wr-v0` uses raw pre-draft receiving yards pooled across all current WR historical rows; it is not yet calibrated against the 2026 prospect `production_0_100` methodology, which is a multi-signal score.
+- `scripts/compute_historical_comps.py` defines `PRODUCTION_SCOPE_COMPATIBLE` as an empty frozenset in v0, so `methodology_compatible` currently resolves to `false` for every position.
+- `cross-class-wr-v0` is explicitly out-of-scope for production compatibility today because it is raw receiving-yards based rather than aligned to the 2026 multi-signal production composite.
+- WR `methodology_compatible` is expected to remain false until historical normalization and 2026 prospect production normalization are validated as aligned.
 - WR `career_outcome_label` and `top_finish_band` are currently deterministic derivations from each player's sourced peak `FPTS/G` (not yet a fully league-ranked finish model).
 - The promoted comp artifact now exposes `effective_features_used` per comp row plus `comp_data_warnings` so partial feature overlap is visible in-artifact.
 - As a result, current WR similarity behavior is improved versus one-vintage/one-proxy, but remains partial and not UI-ready.

--- a/docs/historical-comps-contract.md
+++ b/docs/historical-comps-contract.md
@@ -41,6 +41,22 @@ Example:
   "comp_data_warnings": {
     "WR": "artifact-visible caveat string for partial lane quality (and explicit non-differentiation warning when #1 comp concentration exceeds threshold)"
   },
+  "similarity_quality_by_position": {
+    "WR": {
+      "status": "directional_only",
+      "reason": "no_lane_warning: false; methodology_compatible: false",
+      "requirements_checked": {
+        "no_lane_warning": false,
+        "min_effective_feature_count_met": true,
+        "outcomes_present": true,
+        "non_market_dimension_present": true,
+        "methodology_compatible": false
+      }
+    }
+  },
+  "methodology_compatibility_by_position": {
+    "WR": false
+  },
   "players": [
     {
       "player_id": "...",
@@ -95,12 +111,68 @@ Shape and semantics:
 - `true` is allowed **only** when all conditions below hold for that position:
   1. `comp_data_warnings` has no entry for the position (or warnings object is empty),
   2. every emitted comp has `effective_features_used` length `>= 2`,
-  3. every emitted comp has non-null `outcome_snapshot.career_outcome_label`.
+  3. every emitted comp has non-null `outcome_snapshot.career_outcome_label`,
+  4. every emitted comp includes at least one non-market dimension in `effective_features_used` (`ras_0_100` or `size_context_0_100`),
+  5. the position is methodology-compatible with current production normalization.
 - Any uncertainty or failed condition must resolve to `false`.
 
 Consumer requirement:
 
 - Downstream/UI consumers must check `ui_display_allowed[position]` before surfacing comps in any UI flow.
+- Binary gating alone is insufficient. Consumers should also read `similarity_quality_by_position[position]` to understand *why* a lane is blocked or partial.
+
+## Similarity quality signaling (`similarity_quality_by_position`)
+
+Producer emits an additive top-level field:
+
+```json
+"similarity_quality_by_position": {
+  "WR": {
+    "status": "directional_only",
+    "reason": "no_lane_warning: false; methodology_compatible: false",
+    "requirements_checked": {
+      "no_lane_warning": false,
+      "min_effective_feature_count_met": true,
+      "outcomes_present": true,
+      "non_market_dimension_present": true,
+      "methodology_compatible": false
+    }
+  }
+}
+```
+
+Status derivation rules:
+
+- `ui_safe`: all five booleans in `requirements_checked` are true.
+- `directional_only`: `no_lane_warning` is false **or** `methodology_compatible` is false.
+- `partial`: both hard blockers above pass, but at least one remaining check fails.
+
+Field definitions in `requirements_checked`:
+
+1. `no_lane_warning`: no entry for that position in `comp_data_warnings`.
+2. `min_effective_feature_count_met`: every emitted comp for the position has at least two features in `effective_features_used`.
+3. `outcomes_present`: every emitted comp has non-null `outcome_snapshot.career_outcome_label`.
+4. `non_market_dimension_present`: every emitted comp includes at least one of `ras_0_100` or `size_context_0_100` in `effective_features_used`.
+5. `methodology_compatible`: all historical feature rows for the position have `normalization_scope` values in `PRODUCTION_SCOPE_COMPATIBLE`.
+
+`reason` is always a non-empty string that enumerates failed checks (`<check>: false; ...`) or `all_checks_passed`.
+
+## Methodology compatibility projection (`methodology_compatibility_by_position`)
+
+Producer emits:
+
+```json
+"methodology_compatibility_by_position": {
+  "WR": false,
+  "QB": false
+}
+```
+
+This field is a convenience projection from:
+
+- `similarity_quality_by_position[position].requirements_checked.methodology_compatible`
+
+It must not be independently computed from different logic.
 
 ## Comp modes
 

--- a/exports/promoted/historical-comps/2026_historical_comps_v0.json
+++ b/exports/promoted/historical-comps/2026_historical_comps_v0.json
@@ -11,7 +11,7 @@
     },
     "notes": "v0 emits talent_comp by default; market_comp support is scaffolded and optional."
   },
-  "generated_at": "2026-03-29T18:23:34+00:00",
+  "generated_at": "2026-03-29T21:38:40+00:00",
   "season": 2026,
   "source_files_used": [
     "exports/promoted/rookie-alpha/2026_rookie_alpha_predraft_v0.json",
@@ -20,6 +20,58 @@
   ],
   "comp_data_warnings": {
     "WR": "WR lane remains insufficiently differentiated for UI use: at least one historical WR is the #1 comp for 4 prospects (>3 threshold). Similarities remain directional only."
+  },
+  "similarity_quality_by_position": {
+    "QB": {
+      "status": "directional_only",
+      "reason": "outcomes_present: false; methodology_compatible: false",
+      "requirements_checked": {
+        "no_lane_warning": true,
+        "min_effective_feature_count_met": true,
+        "outcomes_present": false,
+        "non_market_dimension_present": true,
+        "methodology_compatible": false
+      }
+    },
+    "RB": {
+      "status": "directional_only",
+      "reason": "min_effective_feature_count_met: false; outcomes_present: false; non_market_dimension_present: false; methodology_compatible: false",
+      "requirements_checked": {
+        "no_lane_warning": true,
+        "min_effective_feature_count_met": false,
+        "outcomes_present": false,
+        "non_market_dimension_present": false,
+        "methodology_compatible": false
+      }
+    },
+    "TE": {
+      "status": "directional_only",
+      "reason": "min_effective_feature_count_met: false; outcomes_present: false; non_market_dimension_present: false; methodology_compatible: false",
+      "requirements_checked": {
+        "no_lane_warning": true,
+        "min_effective_feature_count_met": false,
+        "outcomes_present": false,
+        "non_market_dimension_present": false,
+        "methodology_compatible": false
+      }
+    },
+    "WR": {
+      "status": "directional_only",
+      "reason": "no_lane_warning: false; methodology_compatible: false",
+      "requirements_checked": {
+        "no_lane_warning": false,
+        "min_effective_feature_count_met": true,
+        "outcomes_present": true,
+        "non_market_dimension_present": true,
+        "methodology_compatible": false
+      }
+    }
+  },
+  "methodology_compatibility_by_position": {
+    "QB": false,
+    "RB": false,
+    "TE": false,
+    "WR": false
   },
   "ui_display_allowed": {
     "QB": false,

--- a/scripts/compute_historical_comps.py
+++ b/scripts/compute_historical_comps.py
@@ -45,6 +45,7 @@ MARKET_WEIGHTS = {
     "size_context_0_100": 0.10,
     "draft_capital_proxy_0_100": 0.20,
 }
+PRODUCTION_SCOPE_COMPATIBLE: frozenset[str] = frozenset()
 
 
 def load_json(path: Path) -> Any:
@@ -245,7 +246,9 @@ def build_comp_candidates(
 
 
 def build_ui_display_allowed(
-    players: list[dict[str, Any]], comp_data_warnings: dict[str, Any]
+    players: list[dict[str, Any]],
+    comp_data_warnings: dict[str, Any],
+    methodology_compatible_by_position: dict[str, bool],
 ) -> dict[str, bool]:
     """Emit conservative per-position UI gating for downstream consumers."""
     ui_display_allowed: dict[str, bool] = {}
@@ -267,10 +270,74 @@ def build_ui_display_allowed(
             (comp.get("outcome_snapshot") or {}).get("career_outcome_label") is not None
             for comp in position_comps
         )
+        has_non_market_dimension = bool(position_comps) and all(
+            bool({"ras_0_100", "size_context_0_100"}.intersection(comp.get("effective_features_used", [])))
+            for comp in position_comps
+        )
+        is_methodology_compatible = bool(methodology_compatible_by_position.get(position))
 
-        ui_display_allowed[position] = (not has_warning) and has_min_features and has_outcome_labels
+        ui_display_allowed[position] = (
+            (not has_warning)
+            and has_min_features
+            and has_outcome_labels
+            and has_non_market_dimension
+            and is_methodology_compatible
+        )
 
     return ui_display_allowed
+
+
+def build_methodology_compatible_by_position(
+    positions: set[str], historical_features: list[dict[str, Any]]
+) -> dict[str, bool]:
+    output: dict[str, bool] = {}
+    for position in sorted(positions):
+        position_rows = [row for row in historical_features if row.get("position") == position]
+        output[position] = bool(position_rows) and all(
+            row.get("normalization_scope") in PRODUCTION_SCOPE_COMPATIBLE for row in position_rows
+        )
+    return output
+
+
+def build_similarity_quality_by_position(
+    players: list[dict[str, Any]],
+    comp_data_warnings: dict[str, Any],
+    methodology_compatible_by_position: dict[str, bool],
+) -> dict[str, Any]:
+    output: dict[str, Any] = {}
+    positions = sorted({str(player.get("position")) for player in players if player.get("position") is not None})
+    for position in positions:
+        position_players = [player for player in players if player.get("position") == position]
+        position_comps = [comp for player in position_players for comp in player.get("comps", [])]
+        requirements_checked = {
+            "no_lane_warning": not (isinstance(comp_data_warnings, dict) and bool(comp_data_warnings.get(position))),
+            "min_effective_feature_count_met": bool(position_comps)
+            and all(len(comp.get("effective_features_used", [])) >= 2 for comp in position_comps),
+            "outcomes_present": bool(position_comps)
+            and all((comp.get("outcome_snapshot") or {}).get("career_outcome_label") is not None for comp in position_comps),
+            "non_market_dimension_present": bool(position_comps)
+            and all(
+                bool({"ras_0_100", "size_context_0_100"}.intersection(comp.get("effective_features_used", [])))
+                for comp in position_comps
+            ),
+            "methodology_compatible": bool(methodology_compatible_by_position.get(position)),
+        }
+
+        if all(requirements_checked.values()):
+            status = "ui_safe"
+        elif (not requirements_checked["no_lane_warning"]) or (not requirements_checked["methodology_compatible"]):
+            status = "directional_only"
+        else:
+            status = "partial"
+
+        failed = [f"{name}: false" for name, is_true in requirements_checked.items() if not is_true]
+        reason = "; ".join(failed) if failed else "all_checks_passed"
+        output[position] = {
+            "status": status,
+            "reason": reason,
+            "requirements_checked": requirements_checked,
+        }
+    return output
 def compute_historical_comps(
     season: int,
     rookies: list[dict[str, Any]],
@@ -326,7 +393,18 @@ def compute_historical_comps(
             "coverage is added."
         )
 
-    ui_display_allowed = build_ui_display_allowed(players, warnings)
+    positions = {str(player.get("position")) for player in players if player.get("position") is not None}
+    methodology_compatible_by_position = build_methodology_compatible_by_position(positions, historical_features)
+    similarity_quality_by_position = build_similarity_quality_by_position(
+        players,
+        warnings,
+        methodology_compatible_by_position,
+    )
+    methodology_compatibility_by_position = {
+        position: bool(quality.get("requirements_checked", {}).get("methodology_compatible"))
+        for position, quality in similarity_quality_by_position.items()
+    }
+    ui_display_allowed = build_ui_display_allowed(players, warnings, methodology_compatible_by_position)
 
     return {
         "model": {
@@ -341,6 +419,8 @@ def compute_historical_comps(
         "season": season,
         "source_files_used": source_files_used,
         "comp_data_warnings": warnings,
+        "similarity_quality_by_position": similarity_quality_by_position,
+        "methodology_compatibility_by_position": methodology_compatibility_by_position,
         "ui_display_allowed": ui_display_allowed,
         "players": players,
     }

--- a/tests/test_compute_historical_comps.py
+++ b/tests/test_compute_historical_comps.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from scripts.compute_historical_comps import (
     MARKET_WEIGHTS,
+    build_ui_display_allowed,
     REQUIRED_HISTORICAL_FEATURE_FIELDS,
     REQUIRED_HISTORICAL_OUTCOME_FIELDS,
     build_comp_candidates,
@@ -296,61 +297,37 @@ class ComputeHistoricalCompsTests(unittest.TestCase):
         self.assertIn("QB", artifact["ui_display_allowed"])
 
     def test_ui_display_allowed_false_when_warning_present(self) -> None:
-        rookies = [
+        players = [
             {
-                "player_id": "wr-r",
-                "player_name": "Rookie WR",
-                "position": "WR",
-                "ras_0_100": 90.0,
-                "production_0_100": 90.0,
-                "draft_capital_proxy_0_100": 80.0,
-                "size_context_0_100": 70.0,
-            }
+                "player_id": "qb-r",
+                "player_name": "Rookie QB",
+                "position": "QB",
+                "comps": [
+                    {
+                        "effective_features_used": ["ras_0_100", "production_0_100", "size_context_0_100"],
+                        "outcome_snapshot": {"career_outcome_label": "Starter"},
+                    }
+                ],
+            },
+            {
+                "player_id": "rb-r",
+                "player_name": "Rookie RB",
+                "position": "RB",
+                "comps": [
+                    {
+                        "effective_features_used": ["ras_0_100", "production_0_100", "size_context_0_100"],
+                        "outcome_snapshot": {"career_outcome_label": "Starter"},
+                    }
+                ],
+            },
         ]
-        historical_features = normalize_historical_feature_rows(
-            [
-                {
-                    "player_id": "wr-h",
-                    "player_name": "Historical WR",
-                    "position": "WR",
-                    "school": "Sample",
-                    "draft_year": 2018,
-                    "source_season": 2017,
-                    "ras_0_100": 90.0,
-                    "production_0_100": 90.0,
-                    "draft_capital_proxy_0_100": 80.0,
-                    "size_context_0_100": 70.0,
-                    "normalization_scope": "class-local",
-                }
-            ]
+        ui_display_allowed = build_ui_display_allowed(
+            players,
+            {"QB": "explicit warning"},
+            {"QB": True, "RB": True},
         )
-        outcomes = normalize_outcome_rows(
-            [
-                {
-                    "player_id": "wr-h",
-                    "player_name": "Historical WR",
-                    "position": "WR",
-                    "draft_year": 2018,
-                    "career_outcome_label": "Starter",
-                    "best_season_fantasy_ppg": 14.0,
-                    "top_finish_band": "WR2",
-                    "years_1_to_3_summary": "sample",
-                }
-            ]
-        )
-
-        artifact = compute_historical_comps(
-            season=2026,
-            rookies=rookies,
-            historical_features=historical_features,
-            outcomes_by_player_id=outcomes,
-            comp_mode="talent_comp",
-            top_n=3,
-            source_files_used=["a", "b"],
-            generated_at="2026-03-28T00:00:00+00:00",
-        )
-
-        self.assertFalse(artifact["ui_display_allowed"]["WR"])
+        self.assertFalse(ui_display_allowed["QB"])
+        self.assertTrue(ui_display_allowed["RB"])
 
     def test_ui_display_allowed_false_when_any_comp_has_too_few_effective_features(self) -> None:
         rookies = [
@@ -409,6 +386,44 @@ class ComputeHistoricalCompsTests(unittest.TestCase):
 
         self.assertEqual(artifact["players"][0]["comps"][0]["effective_features_used"], ["ras_0_100"])
         self.assertFalse(artifact["ui_display_allowed"]["QB"])
+
+    def test_similarity_quality_by_position_shape_and_keys(self) -> None:
+        artifact = json.loads(
+            Path("exports/promoted/historical-comps/2026_historical_comps_v0.json").read_text(encoding="utf-8")
+        )
+        self.assertIn("similarity_quality_by_position", artifact)
+        self.assertIsInstance(artifact["similarity_quality_by_position"], dict)
+        required_keys = {
+            "no_lane_warning",
+            "min_effective_feature_count_met",
+            "outcomes_present",
+            "non_market_dimension_present",
+            "methodology_compatible",
+        }
+        for position, quality in artifact["similarity_quality_by_position"].items():
+            self.assertIn("status", quality, msg=position)
+            self.assertIn("reason", quality, msg=position)
+            self.assertTrue(bool(quality["reason"]), msg=position)
+            self.assertIn("requirements_checked", quality, msg=position)
+            self.assertEqual(set(quality["requirements_checked"].keys()), required_keys, msg=position)
+
+    def test_similarity_quality_wr_directional_only_when_warning_present(self) -> None:
+        artifact = json.loads(
+            Path("exports/promoted/historical-comps/2026_historical_comps_v0.json").read_text(encoding="utf-8")
+        )
+        self.assertIn("WR", artifact["comp_data_warnings"])
+        self.assertEqual(artifact["similarity_quality_by_position"]["WR"]["status"], "directional_only")
+
+    def test_methodology_compatibility_projection_matches_similarity_quality(self) -> None:
+        artifact = json.loads(
+            Path("exports/promoted/historical-comps/2026_historical_comps_v0.json").read_text(encoding="utf-8")
+        )
+        self.assertIn("methodology_compatibility_by_position", artifact)
+        for position, compatible in artifact["methodology_compatibility_by_position"].items():
+            self.assertEqual(
+                compatible,
+                artifact["similarity_quality_by_position"][position]["requirements_checked"]["methodology_compatible"],
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation

- Ensure the promoted historical comps artifact is explicit about lane quality and safe for downstream UI use by surfacing why a position is blocked or partial. 
- Prevent accidental UI surfacing when historical normalization or outcome coverage is incompatible with production methodology.

### Description

- Added module-level `PRODUCTION_SCOPE_COMPATIBLE` (empty `frozenset`) and new helpers `build_methodology_compatible_by_position` and `build_similarity_quality_by_position` to project per-position compatibility and signal quality.
- Extended `build_ui_display_allowed(...)` signature and logic to require two additional checks: `non_market_dimension_present` (presence of `ras_0_100` or `size_context_0_100` in comps) and `methodology_compatible` (historical `normalization_scope` compatibility).
- Emit two new top-level artifact fields: `similarity_quality_by_position` (status, reason, requirements) and `methodology_compatibility_by_position` (boolean projection), and include them in the produced JSON artifact.`
- Updated contract docs (`docs/historical-comps-contract.md`) and historical lane README (`data/historical/README.md`) to document the five-condition gate, similarity-quality semantics, and current compatibility posture; regenerated `exports/promoted/historical-comps/2026_historical_comps_v0.json` to include new metadata.
- Adjusted unit tests in `tests/test_compute_historical_comps.py` to validate the new shapes, gating rules, and projection parity.

### Testing

- Ran the producer script with `python3 scripts/compute_historical_comps.py` which wrote the updated artifact `exports/promoted/historical-comps/2026_historical_comps_v0.json` successfully.
- Ran the test suite with `python3 -m unittest tests/test_compute_historical_comps.py` and all tests passed (`Ran 14 tests`, `OK`).
- Verified artifact gating and signals with `jq` by checking `.ui_display_allowed.WR`, `.similarity_quality_by_position.WR.status`, and `.methodology_compatibility_by_position.WR`, which returned `false`, `"directional_only"`, and `false` respectively.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c99b4aa18483328736b74148a6a7a0)