### PR TITLE
Deterministic WR lane coverage checks and diagnostics for historical comps

### DIFF
--- a/data/historical/README.md
+++ b/data/historical/README.md
@@ -39,6 +39,7 @@ WR now includes multiple real draft vintages (2018 + 2020 + 2021) while QB/TE re
 
 
 - Current 2026 repro still emits a WR comp-data warning: one historical WR can remain the #1 comp for all eight 2026 WR prospects. This is currently driven by sparse WR RAS coverage and remaining feature-shape compression across partial vintages; do not fabricate rows or synthetic deltas to suppress this warning.
+- Producer warning behavior is now deterministic via `lane_coverage_by_position.WR`: warning clears only when all WR lane coverage thresholds pass (`rookie_wr_with_comps`, `max_top1_count`, `unique_top1_count`, `unique_comp_pool_count`, `% all comps with 3+ features`, `% top-1 comps with 3+ features`).
 
 
 - 2018 WR cohort was added with source season 2017 (D.J. Moore, Calvin Ridley, Courtland Sutton, Christian Kirk).

--- a/docs/historical-comps-contract.md
+++ b/docs/historical-comps-contract.md
@@ -39,7 +39,28 @@ Example:
     "data/historical/historical_player_outcomes.sample.json"
   ],
   "comp_data_warnings": {
-    "WR": "artifact-visible caveat string for partial lane quality (and explicit non-differentiation warning when #1 comp concentration exceeds threshold)"
+    "WR": "artifact-visible caveat string that appears only when WR lane coverage thresholds fail"
+  },
+  "lane_coverage_by_position": {
+    "WR": {
+      "total_promoted_wrs": 8,
+      "rookie_wr_with_comps": 8,
+      "max_top1_count": 3,
+      "unique_top1_count": 4,
+      "unique_comp_pool_count": 9,
+      "all_comps_count": 40,
+      "all_comps_with_3plus_features_count": 23,
+      "top1_comps_count": 8,
+      "top1_comps_with_3plus_features_count": 3,
+      "pct_all_comps_with_3plus_features": 0.575,
+      "pct_top1_comps_with_3plus_features": 0.375,
+      "coverage_sufficient": false,
+      "failed_checks": [
+        "unique_top1_count",
+        "pct_all_comps_with_3plus_features",
+        "pct_top1_comps_with_3plus_features"
+      ]
+    }
   },
   "similarity_quality_by_position": {
     "WR": {
@@ -119,6 +140,26 @@ Shape and semantics:
   4. every emitted comp includes at least one non-market dimension in `effective_features_used` (`ras_0_100` or `size_context_0_100`),
   5. the position is methodology-compatible with current production normalization.
 - Any uncertainty or failed condition must resolve to `false`.
+- Clearing WR lane warning **alone** does not imply `ui_display_allowed["WR"] == true`; methodology compatibility and every other gating check still apply.
+
+## WR lane coverage diagnostics (`lane_coverage_by_position.WR`)
+
+Producer now emits deterministic WR lane diagnostics used for warning gating:
+
+- `coverage_sufficient` is true only if all six checks pass:
+  1. `rookie_wr_with_comps == total_promoted_wrs`
+  2. `max_top1_count <= 3`
+  3. `unique_top1_count >= 5`
+  4. `unique_comp_pool_count >= 8`
+  5. `pct_all_comps_with_3plus_features >= 0.75`
+  6. `pct_top1_comps_with_3plus_features >= 0.50`
+- If any check fails:
+  - `comp_data_warnings["WR"]` is present and includes `failed_checks`,
+  - `lane_coverage_by_position.WR.failed_checks` enumerates the failing threshold names.
+- If all checks pass:
+  - `comp_data_warnings["WR"]` is omitted from the artifact.
+
+This warning answers lane breadth/differentiation only; it must not be conflated with methodology compatibility checks.
 
 Consumer requirement:
 

--- a/exports/promoted/historical-comps/2026_historical_comps_v0.json
+++ b/exports/promoted/historical-comps/2026_historical_comps_v0.json
@@ -11,7 +11,7 @@
     },
     "notes": "v0 emits talent_comp by default; market_comp support is scaffolded and optional."
   },
-  "generated_at": "2026-03-30T21:01:24+00:00",
+  "generated_at": "2026-03-30T00:00:00+00:00",
   "season": 2026,
   "source_files_used": [
     "exports/promoted/rookie-alpha/2026_rookie_alpha_predraft_v0.json",
@@ -19,7 +19,28 @@
     "data/historical/historical_player_outcomes.sample.json"
   ],
   "comp_data_warnings": {
-    "WR": "WR lane is still partial and directional; do not surface in UI until broader cross-class and outcomes coverage is added."
+    "WR": "WR lane coverage is insufficient for differentiation breadth/feature depth checks; failed_checks=unique_top1_count, pct_all_comps_with_3plus_features, pct_top1_comps_with_3plus_features. Similarities remain directional only."
+  },
+  "lane_coverage_by_position": {
+    "WR": {
+      "total_promoted_wrs": 8,
+      "rookie_wr_with_comps": 8,
+      "max_top1_count": 3,
+      "unique_top1_count": 4,
+      "unique_comp_pool_count": 9,
+      "all_comps_count": 40,
+      "all_comps_with_3plus_features_count": 23,
+      "top1_comps_count": 8,
+      "top1_comps_with_3plus_features_count": 3,
+      "pct_all_comps_with_3plus_features": 0.575,
+      "pct_top1_comps_with_3plus_features": 0.375,
+      "coverage_sufficient": false,
+      "failed_checks": [
+        "unique_top1_count",
+        "pct_all_comps_with_3plus_features",
+        "pct_top1_comps_with_3plus_features"
+      ]
+    }
   },
   "similarity_quality_by_position": {
     "QB": {

--- a/scripts/compute_historical_comps.py
+++ b/scripts/compute_historical_comps.py
@@ -531,6 +531,78 @@ def build_similarity_quality_by_position(
             "requirements_checked": requirements_checked,
         }
     return output
+
+
+def build_wr_lane_coverage_summary(players: list[dict[str, Any]]) -> dict[str, Any]:
+    wr_players = [player for player in players if player.get("position") == "WR"]
+    total_promoted_wrs = len(wr_players)
+    wr_players_with_comps = [player for player in wr_players if isinstance(player.get("comps"), list) and player["comps"]]
+    rookie_wr_with_comps = len(wr_players_with_comps)
+
+    top1_counter: Counter[str] = Counter()
+    unique_comp_pool_ids: set[str] = set()
+    all_comps_count = 0
+    all_comps_with_3plus_features_count = 0
+    top1_comps_count = 0
+    top1_comps_with_3plus_features_count = 0
+
+    for player in wr_players_with_comps:
+        comps = player["comps"]
+        for index, comp in enumerate(comps):
+            effective_features = comp.get("effective_features_used", [])
+            feature_count = len(effective_features) if isinstance(effective_features, list) else 0
+            historical_player_id = comp.get("historical_player_id")
+            if historical_player_id is not None:
+                unique_comp_pool_ids.add(str(historical_player_id))
+
+            all_comps_count += 1
+            if feature_count >= 3:
+                all_comps_with_3plus_features_count += 1
+
+            if index == 0:
+                top1_comps_count += 1
+                if historical_player_id is not None:
+                    top1_counter[str(historical_player_id)] += 1
+                if feature_count >= 3:
+                    top1_comps_with_3plus_features_count += 1
+
+    max_top1_count = max(top1_counter.values(), default=0)
+    unique_top1_count = len(top1_counter)
+    unique_comp_pool_count = len(unique_comp_pool_ids)
+    pct_all_comps_with_3plus_features = (
+        all_comps_with_3plus_features_count / all_comps_count if all_comps_count else 0.0
+    )
+    pct_top1_comps_with_3plus_features = (
+        top1_comps_with_3plus_features_count / top1_comps_count if top1_comps_count else 0.0
+    )
+
+    checks = {
+        "rookie_wr_with_comps": rookie_wr_with_comps == total_promoted_wrs,
+        "max_top1_count": max_top1_count <= 3,
+        "unique_top1_count": unique_top1_count >= 5,
+        "unique_comp_pool_count": unique_comp_pool_count >= 8,
+        "pct_all_comps_with_3plus_features": pct_all_comps_with_3plus_features >= 0.75,
+        "pct_top1_comps_with_3plus_features": pct_top1_comps_with_3plus_features >= 0.50,
+    }
+    failed_checks = [name for name, passed in checks.items() if not passed]
+
+    return {
+        "total_promoted_wrs": total_promoted_wrs,
+        "rookie_wr_with_comps": rookie_wr_with_comps,
+        "max_top1_count": max_top1_count,
+        "unique_top1_count": unique_top1_count,
+        "unique_comp_pool_count": unique_comp_pool_count,
+        "all_comps_count": all_comps_count,
+        "all_comps_with_3plus_features_count": all_comps_with_3plus_features_count,
+        "top1_comps_count": top1_comps_count,
+        "top1_comps_with_3plus_features_count": top1_comps_with_3plus_features_count,
+        "pct_all_comps_with_3plus_features": pct_all_comps_with_3plus_features,
+        "pct_top1_comps_with_3plus_features": pct_top1_comps_with_3plus_features,
+        "coverage_sufficient": not failed_checks,
+        "failed_checks": failed_checks,
+    }
+
+
 def compute_historical_comps(
     season: int,
     rookies: list[dict[str, Any]],
@@ -564,27 +636,13 @@ def compute_historical_comps(
             }
         )
 
-    wr_top_1_counter: Counter[str] = Counter()
-    for player in players:
-        if player["position"] != "WR" or not player["comps"]:
-            continue
-        wr_top_1_counter[player["comps"][0]["player_name"]] += 1
-    wr_max_top_1 = max(wr_top_1_counter.values(), default=0)
-
+    wr_lane_coverage_summary = build_wr_lane_coverage_summary(players)
     warnings = {}
-    if wr_max_top_1 > 3:
-        # Known v0 behavior: even with added 2021/2022 WR rows, the promoted 2026 rookie WR
-        # feature cluster can still collapse to one nearest neighbor when RAS/size coverage is
-        # sparse or class-local normalization compresses variance across cohorts. Keep warning
-        # explicit rather than forcing synthetic differentiation in historical rows.
+    if not wr_lane_coverage_summary["coverage_sufficient"]:
+        failed_checks = ", ".join(wr_lane_coverage_summary["failed_checks"])
         warnings["WR"] = (
-            "WR lane remains insufficiently differentiated for UI use: at least one historical WR is the #1 comp for "
-            f"{wr_max_top_1} prospects (>3 threshold). Similarities remain directional only."
-        )
-    else:
-        warnings["WR"] = (
-            "WR lane is still partial and directional; do not surface in UI until broader cross-class and outcomes "
-            "coverage is added."
+            "WR lane coverage is insufficient for differentiation breadth/feature depth checks; "
+            f"failed_checks={failed_checks}. Similarities remain directional only."
         )
 
     positions = {str(player.get("position")) for player in players if player.get("position") is not None}
@@ -617,6 +675,7 @@ def compute_historical_comps(
         "season": season,
         "source_files_used": source_files_used,
         "comp_data_warnings": warnings,
+        "lane_coverage_by_position": {"WR": wr_lane_coverage_summary},
         "similarity_quality_by_position": similarity_quality_by_position,
         "methodology_compatibility_by_position": methodology_compatibility_by_position,
         "ui_display_allowed": ui_display_allowed,

--- a/tests/test_compute_historical_comps.py
+++ b/tests/test_compute_historical_comps.py
@@ -7,6 +7,7 @@ from scripts.compute_historical_comps import (
     WR_POPULATION_SCOPE,
     _load_wr_reference_populations,
     apply_wr_historical_production_methodology,
+    build_wr_lane_coverage_summary,
     build_methodology_compatible_by_position,
     build_ui_display_allowed,
     REQUIRED_HISTORICAL_FEATURE_FIELDS,
@@ -418,6 +419,233 @@ class ComputeHistoricalCompsTests(unittest.TestCase):
         self.assertIn("WR", artifact["comp_data_warnings"])
         self.assertEqual(artifact["similarity_quality_by_position"]["WR"]["status"], "directional_only")
 
+    def test_wr_lane_coverage_summary_fields_present(self) -> None:
+        artifact = json.loads(
+            Path("exports/promoted/historical-comps/2026_historical_comps_v0.json").read_text(encoding="utf-8")
+        )
+        summary = artifact["lane_coverage_by_position"]["WR"]
+        expected_fields = {
+            "total_promoted_wrs",
+            "rookie_wr_with_comps",
+            "max_top1_count",
+            "unique_top1_count",
+            "unique_comp_pool_count",
+            "all_comps_count",
+            "all_comps_with_3plus_features_count",
+            "top1_comps_count",
+            "top1_comps_with_3plus_features_count",
+            "pct_all_comps_with_3plus_features",
+            "pct_top1_comps_with_3plus_features",
+            "coverage_sufficient",
+            "failed_checks",
+        }
+        self.assertEqual(set(summary.keys()), expected_fields)
+
+    def test_wr_coverage_insufficient_emits_warning(self) -> None:
+        players = [
+            {
+                "player_id": "wr-r1",
+                "player_name": "Rookie WR1",
+                "position": "WR",
+                "comps": [
+                    {"historical_player_id": "h1", "effective_features_used": ["a", "b"]},
+                    {"historical_player_id": "h2", "effective_features_used": ["a", "b"]},
+                ],
+            },
+            {
+                "player_id": "wr-r2",
+                "player_name": "Rookie WR2",
+                "position": "WR",
+                "comps": [
+                    {"historical_player_id": "h1", "effective_features_used": ["a", "b"]},
+                    {"historical_player_id": "h3", "effective_features_used": ["a", "b"]},
+                ],
+            },
+        ]
+        summary = build_wr_lane_coverage_summary(players)
+        self.assertFalse(summary["coverage_sufficient"])
+        self.assertTrue(summary["failed_checks"])
+
+    def test_wr_coverage_sufficient_clears_warning(self) -> None:
+        players = []
+        for i in range(8):
+            comps = []
+            for j in range(5):
+                feature_keys = ["ras_0_100", "production_0_100", "size_context_0_100"]
+                comps.append(
+                    {
+                        "historical_player_id": f"h{j + i}",
+                        "effective_features_used": feature_keys,
+                        "outcome_snapshot": {"career_outcome_label": "Starter"},
+                    }
+                )
+            comps[0]["historical_player_id"] = f"top{i}"
+            players.append(
+                {
+                    "player_id": f"wr-r{i}",
+                    "player_name": f"Rookie WR{i}",
+                    "position": "WR",
+                    "comps": comps,
+                }
+            )
+
+        summary = build_wr_lane_coverage_summary(players)
+        self.assertTrue(summary["coverage_sufficient"])
+        self.assertEqual(summary["failed_checks"], [])
+
+    def test_wr_coverage_sufficient_false_when_single_threshold_fails(self) -> None:
+        base_players = []
+        for i in range(8):
+            base_players.append(
+                {
+                    "player_id": f"wr-r{i}",
+                    "player_name": f"Rookie WR{i}",
+                    "position": "WR",
+                    "comps": [
+                        {
+                            "historical_player_id": f"top{i}",
+                            "effective_features_used": ["ras_0_100", "production_0_100", "size_context_0_100"],
+                        },
+                        {
+                            "historical_player_id": f"pool{i}",
+                            "effective_features_used": ["ras_0_100", "production_0_100", "size_context_0_100"],
+                        },
+                    ],
+                }
+            )
+        scenarios = {
+            "rookie_wr_with_comps": [dict(player, comps=[] if idx == 0 else player["comps"]) for idx, player in enumerate(base_players)],
+            "max_top1_count": [
+                dict(player, comps=[dict(player["comps"][0], historical_player_id="same"), player["comps"][1]])
+                for player in base_players
+            ],
+            "unique_top1_count": [
+                dict(player, comps=[dict(player["comps"][0], historical_player_id=f"top{idx % 4}"), player["comps"][1]])
+                for idx, player in enumerate(base_players)
+            ],
+            "unique_comp_pool_count": [
+                dict(player, comps=[dict(player["comps"][0], historical_player_id=f"top{idx % 5}"), dict(player["comps"][1], historical_player_id=f"top{idx % 5}")])
+                for idx, player in enumerate(base_players)
+            ],
+            "pct_all_comps_with_3plus_features": [
+                dict(player, comps=[dict(player["comps"][0], effective_features_used=["ras_0_100", "production_0_100"]), player["comps"][1]])
+                for player in base_players
+            ],
+            "pct_top1_comps_with_3plus_features": [
+                dict(player, comps=[dict(player["comps"][0], effective_features_used=["ras_0_100", "production_0_100"]), player["comps"][1]])
+                for player in base_players
+            ],
+        }
+        for failed_check, players in scenarios.items():
+            summary = build_wr_lane_coverage_summary(players)
+            self.assertFalse(summary["coverage_sufficient"])
+            self.assertIn(failed_check, summary["failed_checks"])
+
+    def test_compute_historical_comps_wr_warning_present_when_coverage_insufficient(self) -> None:
+        rookies = [
+            {
+                "player_id": f"wr-r{i}",
+                "player_name": f"Rookie WR{i}",
+                "position": "WR",
+                "ras_0_100": 80.0,
+                "production_0_100": 70.0,
+                "draft_capital_proxy_0_100": 80.0,
+                "size_context_0_100": 60.0,
+            }
+            for i in range(4)
+        ]
+        historical_features = normalize_historical_feature_rows(
+            [
+                {
+                    "player_id": "wr-h1",
+                    "player_name": "Hist WR1",
+                    "position": "WR",
+                    "school": "A",
+                    "draft_year": 2019,
+                    "source_season": 2018,
+                    "ras_0_100": 80.0,
+                    "production_0_100": 70.0,
+                    "draft_capital_proxy_0_100": 80.0,
+                    "size_context_0_100": 60.0,
+                    "normalization_scope": "class-local",
+                }
+            ]
+        )
+        artifact = compute_historical_comps(
+            season=2026,
+            rookies=rookies,
+            historical_features=historical_features,
+            outcomes_by_player_id={},
+            comp_mode="talent_comp",
+            top_n=1,
+            source_files_used=["a"],
+            generated_at="2026-03-30T00:00:00+00:00",
+        )
+        self.assertIn("WR", artifact["comp_data_warnings"])
+        self.assertFalse(artifact["lane_coverage_by_position"]["WR"]["coverage_sufficient"])
+
+    def test_compute_historical_comps_wr_warning_absent_when_coverage_sufficient(self) -> None:
+        rookies = [
+            {
+                "player_id": f"wr-r{i}",
+                "player_name": f"Rookie WR{i}",
+                "position": "WR",
+                "ras_0_100": 50.0 + (i * 5.0),
+                "production_0_100": 45.0 + (i * 5.0),
+                "draft_capital_proxy_0_100": 40.0 + (i * 5.0),
+                "size_context_0_100": 35.0 + (i * 5.0),
+            }
+            for i in range(8)
+        ]
+        historical_rows = []
+        for i in range(8):
+            historical_rows.append(
+                {
+                    "player_id": f"wr-h{i}",
+                    "player_name": f"Hist WR{i}",
+                    "position": "WR",
+                    "school": "A",
+                    "draft_year": 2010 + i,
+                    "source_season": 2009 + i,
+                    "ras_0_100": 50.0 + (i * 5.0),
+                    "production_0_100": 45.0 + (i * 5.0),
+                    "draft_capital_proxy_0_100": 40.0 + (i * 5.0),
+                    "size_context_0_100": 35.0 + (i * 5.0),
+                    "normalization_scope": "class-local",
+                }
+            )
+        historical_features = normalize_historical_feature_rows(historical_rows)
+        outcomes = normalize_outcome_rows(
+            [
+                {
+                    "player_id": row["player_id"],
+                    "player_name": row["player_name"],
+                    "position": "WR",
+                    "draft_year": row["draft_year"],
+                    "career_outcome_label": "Starter",
+                    "best_season_fantasy_ppg": 12.0,
+                    "top_finish_band": "WR2",
+                    "years_1_to_3_summary": "ok",
+                }
+                for row in historical_rows
+            ]
+        )
+        artifact = compute_historical_comps(
+            season=2026,
+            rookies=rookies,
+            historical_features=historical_features,
+            outcomes_by_player_id=outcomes,
+            comp_mode="talent_comp",
+            top_n=1,
+            source_files_used=["a"],
+            generated_at="2026-03-30T00:00:00+00:00",
+            production_scope_compatible=frozenset({"class-local"}),
+        )
+        self.assertNotIn("WR", artifact["comp_data_warnings"])
+        self.assertTrue(artifact["lane_coverage_by_position"]["WR"]["coverage_sufficient"])
+        self.assertTrue(artifact["methodology_compatibility_by_position"]["WR"])
+        self.assertTrue(artifact["ui_display_allowed"]["WR"])
+
     def test_methodology_compatibility_projection_matches_similarity_quality(self) -> None:
         artifact = json.loads(
             Path("exports/promoted/historical-comps/2026_historical_comps_v0.json").read_text(encoding="utf-8")
@@ -566,7 +794,10 @@ class ComputeHistoricalCompsTests(unittest.TestCase):
         artifact = json.loads(
             Path("exports/promoted/historical-comps/2026_historical_comps_v0.json").read_text(encoding="utf-8")
         )
-        self.assertFalse(artifact["methodology_compatibility_by_position"]["WR"])
+        self.assertEqual(
+            artifact["methodology_compatibility_by_position"]["WR"],
+            artifact["similarity_quality_by_position"]["WR"]["requirements_checked"]["methodology_compatible"],
+        )
         self.assertEqual(artifact["similarity_quality_by_position"]["WR"]["status"], "directional_only")
         self.assertFalse(artifact["ui_display_allowed"]["WR"])
 


### PR DESCRIPTION
### Motivation
- Make WR warning behavior deterministic and inspectable by replacing the previous scaffold string with explicit lane-coverage diagnostics and thresholds. 
- Provide downstream consumers a machine-readable signal that explains why WR comps remain directional and to avoid inferring status from opaque text. 
- Preserve existing safety gates for UI eligibility while giving a clear path to clear the WR warning when coverage meets objective thresholds.

### Description
- Added `build_wr_lane_coverage_summary(players)` which computes six coverage checks and returns detailed diagnostics including `coverage_sufficient` and `failed_checks`. 
- Emit a new top-level artifact field `lane_coverage_by_position` (currently populated for `"WR"`) and make `comp_data_warnings["WR"]` conditional on `coverage_sufficient`. 
- Kept existing downstream gating intact by preserving `similarity_quality_by_position`, `methodology_compatibility_by_position`, and `ui_display_allowed` logic and ensured no warning clearance automatically implies UI eligibility. 
- Updated tests, docs, README, and regenerated the promoted artifact; changed files include `scripts/compute_historical_comps.py`, `tests/test_compute_historical_comps.py`, `docs/historical-comps-contract.md`, `data/historical/README.md`, and the committed artifact `exports/promoted/historical-comps/2026_historical_comps_v0.json`.

### Testing
- Ran the unit test suite with `python -m unittest tests.test_compute_historical_comps` and all tests passed (`31 tests, OK`).
- Executed the producer script with `python scripts/compute_historical_comps.py --generated-at 2026-03-30T00:00:00+00:00` and it successfully wrote the regenerated artifact; the artifact reflects `lane_coverage_by_position.WR` diagnostics and conditional `comp_data_warnings["WR"]` as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69caf411f7ac8332be84e23d1fcfdb23)