### PR TITLE
data: add Laviska Shenault Jr. (2020) to WR historical pool

### DIFF
--- a/data/historical/historical_player_outcomes.sample.json
+++ b/data/historical/historical_player_outcomes.sample.json
@@ -139,6 +139,19 @@
     "notes": "best_season_fantasy_ppg uses max season FPTS/G from cited table; top_finish_band derived deterministically from that max using fixed bands: >=18 WR1, 15-17.9 WR2, 12-14.9 WR3, 8-11.9 flex, <8 depth_bust."
   },
   {
+    "player_id": "wr-laviska-shenault-2020",
+    "player_name": "Laviska Shenault Jr.",
+    "position": "WR",
+    "draft_year": 2020,
+    "career_outcome_label": "flex_peak",
+    "best_season_fantasy_ppg": 11.2,
+    "top_finish_band": "Flex/Depth (8.0-11.9 PPR/G peak)",
+    "years_1_to_3_summary": "2020-2022 PPR/G: 11.2, 7.3, 4.6; stat lines: 58/600/5 + 18/91/0 rush, 63/619/0 + 18/41/0 rush, 27/272/1 + 7/42/0 rush.",
+    "source_name": "Pro-Football-Reference player receiving/rushing tables (PPR/G computed manually)",
+    "source_url": "https://www.pro-football-reference.com/players/S/ShenLa00.htm",
+    "notes": "Best-season PPR/G computed as max of first three seasons (2020-2022) using full-PPR formula: receptions + receiving yards/10 + receiving TD*6 + rushing yards/10 + rushing TD*6, divided by games played."
+  },
+  {
     "player_id": "sample-te-2021-a",
     "player_name": "Sample TE Profile A",
     "position": "TE",

--- a/data/historical/historical_prospect_features.sample.json
+++ b/data/historical/historical_prospect_features.sample.json
@@ -220,6 +220,26 @@
     "production_0_100_legacy": 62.88
   },
   {
+    "player_id": "wr-laviska-shenault-2020",
+    "player_name": "Laviska Shenault Jr.",
+    "position": "WR",
+    "school": "Colorado",
+    "draft_year": 2020,
+    "source_season": 2019,
+    "ras_0_100": 63.2,
+    "production_0_100": null,
+    "draft_capital_proxy_0_100": 80.0,
+    "size_context_0_100": 63.3,
+    "normalization_scope": "historical-wr-cfbd-method-v1",
+    "source_name": "CFB Stats (2019 Colorado receiving), RAS.football player card, Pro-Football-Reference draft record",
+    "source_url": "https://www.sports-reference.com/cfb/players/laviska-shenault-jr-1.html",
+    "notes": "Added for WR lane coverage; 2019 Colorado receiving line used for source_season alignment (56/764/4). RAS from ras.football (6.32 -> 63.2). Draft capital proxy set to 80.0 for No. 42 overall (round 2). size_context computed from schema formula using 73 in / 227 lb. production_0_100 intentionally null for runtime recompute.",
+    "receptions": 56,
+    "receiving_yards": 764,
+    "receiving_tds": 4,
+    "production_0_100_legacy": null
+  },
+  {
     "player_id": "wr-jamarr-chase-2021",
     "player_name": "Ja'Marr Chase",
     "position": "WR",

--- a/exports/promoted/historical-comps/2026_historical_comps_v0.json
+++ b/exports/promoted/historical-comps/2026_historical_comps_v0.json
@@ -11,7 +11,7 @@
     },
     "notes": "v0 emits talent_comp by default; market_comp support is scaffolded and optional."
   },
-  "generated_at": "2026-03-31T22:26:23+00:00",
+  "generated_at": "2026-03-31T23:20:15+00:00",
   "season": 2026,
   "source_files_used": [
     "exports/promoted/rookie-alpha/2026_rookie_alpha_predraft_v0.json",
@@ -27,7 +27,7 @@
       "rookie_wr_with_comps": 8,
       "max_top1_count": 3,
       "unique_top1_count": 4,
-      "unique_comp_pool_count": 9,
+      "unique_comp_pool_count": 10,
       "all_comps_count": 40,
       "all_comps_with_3plus_features_count": 33,
       "top1_comps_count": 8,
@@ -725,6 +725,37 @@
           }
         },
         {
+          "historical_player_id": "wr-laviska-shenault-2020",
+          "player_name": "Laviska Shenault Jr.",
+          "draft_year": 2020,
+          "position": "WR",
+          "similarity_score": 96.0582,
+          "distance": 0.039418,
+          "feature_snapshot": {
+            "ras_0_100": 63.2,
+            "production_0_100": 54.9,
+            "draft_capital_proxy_0_100": 80.0,
+            "size_context_0_100": 63.3,
+            "normalization_scope": "historical-wr-cfbd-season-pop-v1",
+            "opt_out_season_flag": false,
+            "production_0_100_legacy": null,
+            "receptions": 56,
+            "receiving_yards": 764,
+            "receiving_tds": 4
+          },
+          "effective_features_used": [
+            "ras_0_100",
+            "production_0_100",
+            "size_context_0_100"
+          ],
+          "outcome_snapshot": {
+            "career_outcome_label": "flex_peak",
+            "best_season_fantasy_ppg": 11.2,
+            "top_finish_band": "Flex/Depth (8.0-11.9 PPR/G peak)",
+            "years_1_to_3_summary": "2020-2022 PPR/G: 11.2, 7.3, 4.6; stat lines: 58/600/5 + 18/91/0 rush, 63/619/0 + 18/41/0 rush, 27/272/1 + 7/42/0 rush."
+          }
+        },
+        {
           "historical_player_id": "wr-deebo-samuel-2019",
           "player_name": "Deebo Samuel",
           "draft_year": 2019,
@@ -815,37 +846,6 @@
             "best_season_fantasy_ppg": 14.2,
             "top_finish_band": "WR3 (12.0-14.9 PPR/G peak)",
             "years_1_to_3_summary": "2018-2020 PPR/G: 9.6, 10.5, 12.1; receiving line: 43/590/3, 68/709/3, 48/621/6."
-          }
-        },
-        {
-          "historical_player_id": "wr-treylon-burks-2022",
-          "player_name": "Treylon Burks",
-          "draft_year": 2022,
-          "position": "WR",
-          "similarity_score": 90.2119,
-          "distance": 0.097881,
-          "feature_snapshot": {
-            "ras_0_100": 57.8,
-            "production_0_100": 73.3,
-            "draft_capital_proxy_0_100": 85.0,
-            "size_context_0_100": 58.89,
-            "normalization_scope": "historical-wr-cfbd-season-pop-v1",
-            "opt_out_season_flag": false,
-            "production_0_100_legacy": 59.48,
-            "receptions": 66,
-            "receiving_yards": 1104,
-            "receiving_tds": 11
-          },
-          "effective_features_used": [
-            "ras_0_100",
-            "production_0_100",
-            "size_context_0_100"
-          ],
-          "outcome_snapshot": {
-            "career_outcome_label": "flex_peak",
-            "best_season_fantasy_ppg": 8.6,
-            "top_finish_band": "Flex/Depth (8.0-11.9 PPR/G peak)",
-            "years_1_to_3_summary": "2022-2024 PPR/G: 8.6, 3.6, 1.5; receiving line: 33/444/1, 16/221/0, 4/34/0."
           }
         }
       ]
@@ -1405,6 +1405,37 @@
           }
         },
         {
+          "historical_player_id": "wr-laviska-shenault-2020",
+          "player_name": "Laviska Shenault Jr.",
+          "draft_year": 2020,
+          "position": "WR",
+          "similarity_score": 93.8662,
+          "distance": 0.061338,
+          "feature_snapshot": {
+            "ras_0_100": 63.2,
+            "production_0_100": 54.9,
+            "draft_capital_proxy_0_100": 80.0,
+            "size_context_0_100": 63.3,
+            "normalization_scope": "historical-wr-cfbd-season-pop-v1",
+            "opt_out_season_flag": false,
+            "production_0_100_legacy": null,
+            "receptions": 56,
+            "receiving_yards": 764,
+            "receiving_tds": 4
+          },
+          "effective_features_used": [
+            "ras_0_100",
+            "production_0_100",
+            "size_context_0_100"
+          ],
+          "outcome_snapshot": {
+            "career_outcome_label": "flex_peak",
+            "best_season_fantasy_ppg": 11.2,
+            "top_finish_band": "Flex/Depth (8.0-11.9 PPR/G peak)",
+            "years_1_to_3_summary": "2020-2022 PPR/G: 11.2, 7.3, 4.6; stat lines: 58/600/5 + 18/91/0 rush, 63/619/0 + 18/41/0 rush, 27/272/1 + 7/42/0 rush."
+          }
+        },
+        {
           "historical_player_id": "wr-christian-kirk-2018",
           "player_name": "Christian Kirk",
           "draft_year": 2018,
@@ -1464,37 +1495,6 @@
             "best_season_fantasy_ppg": 15.8,
             "top_finish_band": "WR2 (15.0-17.9 PPR/G peak)",
             "years_1_to_3_summary": "2019-2021 PPR/G: 10.3, 11.2, 15.8; receiving line: 57/802/3, 33/391/1, 77/1405/6."
-          }
-        },
-        {
-          "historical_player_id": "wr-treylon-burks-2022",
-          "player_name": "Treylon Burks",
-          "draft_year": 2022,
-          "position": "WR",
-          "similarity_score": 88.9948,
-          "distance": 0.110052,
-          "feature_snapshot": {
-            "ras_0_100": 57.8,
-            "production_0_100": 73.3,
-            "draft_capital_proxy_0_100": 85.0,
-            "size_context_0_100": 58.89,
-            "normalization_scope": "historical-wr-cfbd-season-pop-v1",
-            "opt_out_season_flag": false,
-            "production_0_100_legacy": 59.48,
-            "receptions": 66,
-            "receiving_yards": 1104,
-            "receiving_tds": 11
-          },
-          "effective_features_used": [
-            "ras_0_100",
-            "production_0_100",
-            "size_context_0_100"
-          ],
-          "outcome_snapshot": {
-            "career_outcome_label": "flex_peak",
-            "best_season_fantasy_ppg": 8.6,
-            "top_finish_band": "Flex/Depth (8.0-11.9 PPR/G peak)",
-            "years_1_to_3_summary": "2022-2024 PPR/G: 8.6, 3.6, 1.5; receiving line: 33/444/1, 16/221/0, 4/34/0."
           }
         }
       ]


### PR DESCRIPTION
### Motivation
- Improve WR lane historical coverage used by the historical comps generator so rookie WRs have closer historical analogs and better top-comp diversity.
- Address the data gap that caused missing/insufficient WR coverage in generated comps and related tests referenced in issue #67.

### Description
- Added a new historical feature row `wr-laviska-shenault-2020` to `data/historical/historical_prospect_features.sample.json` with 2019 receiving inputs (`56/764/4`), `ras_0_100` of `63.2`, `draft_capital_proxy_0_100` of `80.0`, computed `size_context_0_100` of `63.3`, `production_0_100: null` for runtime recompute, and `production_0_100_legacy: null` for test compatibility.
- Added a matching outcome row for `wr-laviska-shenault-2020` to `data/historical/historical_player_outcomes.sample.json` with `career_outcome_label: flex_peak`, `best_season_fantasy_ppg: 11.2`, and a 2020–2022 summary plus provenance.
- Regenerated the promoted comps artifact `exports/promoted/historical-comps/2026_historical_comps_v0.json` so Shenault appears in WR top comp pools for affected rookies.

### Testing
- Ran the comps generator with `python scripts/compute_historical_comps.py` and it completed and wrote `exports/promoted/historical-comps/2026_historical_comps_v0.json` successfully.
- Ran the automated test suite with `python -m pytest tests/ -q` and all tests passed (`53 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc50ddbb148332a1a84d873713b7a1)