### PR TITLE
chore: regenerate comps artifact post-PR75 (TE lane)

### DIFF
--- a/exports/promoted/historical-comps/2026_historical_comps_v0.json
+++ b/exports/promoted/historical-comps/2026_historical_comps_v0.json
@@ -11,7 +11,7 @@
     },
     "notes": "v0 emits talent_comp by default; market_comp support is scaffolded and optional."
   },
-  "generated_at": "2026-03-31T23:59:24+00:00",
+  "generated_at": "2026-04-01T00:08:28+00:00",
   "season": 2026,
   "source_files_used": [
     "exports/promoted/rookie-alpha/2026_rookie_alpha_predraft_v0.json",


### PR DESCRIPTION
Regenerates the comps artifact to reflect the TE lane added in PR #75. WR and TE both show `coverage_sufficient: true` and `ui_display_allowed: true`.