### PR TITLE
feat(ui): add multi-class board with draft class filter

### DIFF
--- a/cards/rookies/board/index.html
+++ b/cards/rookies/board/index.html
@@ -3,13 +3,13 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>TIBER Rookie Board | 2026</title>
+    <title>TIBER Rookie Board | Multi-Class</title>
     <link rel="stylesheet" href="/components/rookies/rookieCardStyles.css" />
   </head>
   <body>
     <main class="page">
       <a class="nav-link" href="/cards/rookies/index.html">← Back to rookie gallery</a>
-      <div class="section-title" style="margin-top: 12px">TIBER 2026 Rookie Board</div>
+      <div class="section-title" style="margin-top: 12px">TIBER Rookie Board</div>
       <h1>Draft board surface</h1>
       <p class="meta">Ranking-first board powered by promoted Rookie Grade artifacts. Use tiers to spot cliffs, then jump to detail/compare.</p>
       <p style="margin-top: 10px"><a class="nav-link" href="/cards/rookies/compare/index.html">Open compare tool →</a></p>
@@ -38,7 +38,8 @@
       const queueJumpLink = document.getElementById('queue-jump-link');
       const SORT_OPTIONS = new Set(['grade', 'rank', 'position']);
       const VIEW_OPTIONS = new Set(['tiered', 'flat']);
-      const state = { sort: 'grade', position: 'ALL', view: 'tiered' };
+      const DRAFT_CLASS_OPTIONS = new Set(['ALL', '2026', '2025', '2024', '2023', '2022']);
+      const state = { sort: 'grade', position: 'ALL', draftClass: 'ALL', view: 'tiered' };
       const compareState = { left: null, right: null };
       const portabilityState = { mode: 'replace', tone: 'info', message: '' };
 
@@ -49,17 +50,20 @@
         const params = new URLSearchParams(window.location.search);
         const sort = params.get('sort');
         const position = params.get('position');
+        const draftClass = params.get('draftClass');
         const view = params.get('view');
 
         if (SORT_OPTIONS.has(sort)) state.sort = sort;
         if (VIEW_OPTIONS.has(view)) state.view = view;
         if (position && position.trim()) state.position = position.toUpperCase();
+        if (DRAFT_CLASS_OPTIONS.has(draftClass)) state.draftClass = draftClass;
       }
 
       function syncUrlState() {
         const next = new URL(window.location.href);
         next.searchParams.set('sort', state.sort);
         next.searchParams.set('position', state.position);
+        next.searchParams.set('draftClass', state.draftClass);
         next.searchParams.set('view', state.view);
         window.history.replaceState({}, '', next.toString());
       }
@@ -300,7 +304,7 @@
       function render(allRows) {
         const positions = collectPositions(allRows);
         if (state.position !== 'ALL' && !positions.includes(state.position)) state.position = 'ALL';
-        const filtered = filterRookieBoard(allRows, { position: state.position });
+        const filtered = filterRookieBoard(allRows, { position: state.position, draftClass: state.draftClass });
         const sorted = sortRookieBoard(filtered, state.sort);
         const queue = loadRookieQueue();
 

--- a/components/rookies/RookieBoardControls.js
+++ b/components/rookies/RookieBoardControls.js
@@ -11,6 +11,8 @@ function option(value, label, selectedValue) {
   return `<option value="${esc(value)}"${selected}>${esc(label)}</option>`;
 }
 
+const DRAFT_CLASS_OPTIONS = [2026, 2025, 2024, 2023, 2022];
+
 export function renderRookieBoardControls({ positions, state }) {
   return `
     <form class="gallery-controls board-controls" id="rookie-board-controls">
@@ -20,6 +22,14 @@ export function renderRookieBoardControls({ positions, state }) {
           ${option('grade', 'Rookie Grade (desc)', state.sort)}
           ${option('rank', 'Class Rank (asc)', state.sort)}
           ${option('position', 'Position → Grade', state.sort)}
+        </select>
+      </label>
+
+      <label class="control-field">
+        <span class="control-label">Draft class</span>
+        <select data-board-control="draftClass">
+          ${option('ALL', 'All classes', state.draftClass)}
+          ${DRAFT_CLASS_OPTIONS.map((yr) => option(String(yr), String(yr), state.draftClass)).join('')}
         </select>
       </label>
 

--- a/lib/rookies/buildRookieBoardRows.js
+++ b/lib/rookies/buildRookieBoardRows.js
@@ -19,6 +19,7 @@ export function buildRookieBoardRows(cards) {
       name: card.identity.name,
       position: card.identity.position ?? 'N/A',
       school: card.identity.schoolDisplay ?? card.identity.school ?? 'School unavailable in current artifacts',
+      draftClass: card.identity.classYear ?? null,
       rookieGrade,
       classRank: card.summary.classRank,
       tier,
@@ -64,6 +65,10 @@ export function sortRookieBoard(rows, sort = 'grade') {
   });
 }
 
-export function filterRookieBoard(rows, { position = 'ALL' } = {}) {
-  return rows.filter((row) => position === 'ALL' || row.position === position);
+export function filterRookieBoard(rows, { position = 'ALL', draftClass = 'ALL' } = {}) {
+  return rows.filter(
+    (row) =>
+      (position === 'ALL' || row.position === position) &&
+      (draftClass === 'ALL' || String(row.draftClass) === String(draftClass)),
+  );
 }

--- a/lib/rookies/getRookieCardData.js
+++ b/lib/rookies/getRookieCardData.js
@@ -2,6 +2,8 @@ import { mapRookieToCard } from './mapRookieToCard.js';
 
 let rookieCardsPromise = null;
 
+const SEASONS = [2026, 2025, 2024, 2023, 2022];
+
 async function loadJson(path) {
   const response = await fetch(path);
   if (!response.ok) {
@@ -14,17 +16,23 @@ function keyByPlayerId(rows) {
   return new Map(rows.map((row) => [String(row.player_id ?? '').toLowerCase(), row]));
 }
 
-async function loadAllRookieCards() {
-  const [alphaExport, combineRows, productionRows, draftRows, statsRows, pprRows, dynastyRows, trendRows] = await Promise.all([
-    loadJson('/exports/promoted/rookie-alpha/2026_rookie_alpha_predraft_v0.json'),
-    loadJson('/data/raw/2026_combine_results.json'),
-    loadJson('/data/processed/2026_college_production.json'),
-    loadJson('/data/processed/2026_draft_capital_proxy.json'),
-    loadJson('/data/processed/2026_player_stats.json'),
-    loadJson('/data/processed/2026_ppr_projections.json').catch(() => []),
-    loadJson('/data/processed/2026_dynasty_adp.json').catch(() => []),
-    loadJson('/data/processed/2026_yoy_trends.json').catch(() => []),
-  ]);
+async function loadSeasonCards(season) {
+  const alphaExport = await loadJson(
+    `/exports/promoted/rookie-alpha/${season}_rookie_alpha_predraft_v0.json`,
+  ).catch(() => null);
+
+  if (!alphaExport) return [];
+
+  const [combineRows, productionRows, draftRows, statsRows, pprRows, dynastyRows, trendRows] =
+    await Promise.all([
+      loadJson(`/data/raw/${season}_combine_results.json`).catch(() => []),
+      loadJson(`/data/processed/${season}_college_production.json`).catch(() => []),
+      loadJson(`/data/processed/${season}_draft_capital_proxy.json`).catch(() => []),
+      loadJson(`/data/processed/${season}_player_stats.json`).catch(() => []),
+      loadJson(`/data/processed/${season}_ppr_projections.json`).catch(() => []),
+      loadJson(`/data/processed/${season}_dynasty_adp.json`).catch(() => []),
+      loadJson(`/data/processed/${season}_yoy_trends.json`).catch(() => []),
+    ]);
 
   const combineById = keyByPlayerId(combineRows);
   const productionById = keyByPlayerId(productionRows);
@@ -36,8 +44,12 @@ async function loadAllRookieCards() {
 
   return alphaExport.players.map((alphaPlayer, idx) => {
     const playerId = String(alphaPlayer.player_id ?? '').toLowerCase();
+    // Inject class_year so identity.classYear reflects the correct draft class
+    const playerWithClass = alphaPlayer.class_year != null
+      ? alphaPlayer
+      : { ...alphaPlayer, class_year: season };
     return mapRookieToCard({
-      alphaPlayer,
+      alphaPlayer: playerWithClass,
       combineRow: combineById.get(playerId),
       productionRow: productionById.get(playerId),
       draftRow: draftById.get(playerId),
@@ -48,6 +60,11 @@ async function loadAllRookieCards() {
       rank: alphaPlayer.rookie_alpha_rank ?? idx + 1,
     });
   });
+}
+
+async function loadAllRookieCards() {
+  const perSeasonArrays = await Promise.all(SEASONS.map(loadSeasonCards));
+  return perSeasonArrays.flat();
 }
 
 export async function getAllRookieCards() {

--- a/lib/rookies/normalizeRookieIdentity.js
+++ b/lib/rookies/normalizeRookieIdentity.js
@@ -54,6 +54,6 @@ export function normalizeRookieIdentity({ alphaPlayer, combineRow, productionRow
     roleLabel: position ? ROLE_BY_POSITION[position] ?? 'Role still forming' : 'Role still forming',
     school,
     schoolDisplay: school ?? 'School unavailable in current artifacts',
-    classYear: Number.isFinite(alphaPlayer?.class_year) ? alphaPlayer.class_year : 2026,
+    classYear: Number.isFinite(alphaPlayer?.class_year) ? alphaPlayer.class_year : null,
   };
 }


### PR DESCRIPTION
Load all 5 seasons (2022-2026) in getRookieCardData via per-season loadSeasonCards(); inject class_year so identity.classYear is correct for historical classes. Drop the hardcoded 2026 fallback in normalizeRookieIdentity (now null when unknown).

Add draftClass field to board rows and extend filterRookieBoard to filter by it. Add a Draft class dropdown to RookieBoardControls and wire it into state, URL sync, and render in board/index.html.

Puka Nacua (2023) and all 2022/2023 calibration class players are now browsable from the same board with a single dropdown.

https://claude.ai/code/session_01BFKHiAMPXTrWhNuub1FSGs