### PR TITLE
feat(board): surface consensus delta as first-class signal

### DIFF
--- a/cards/rookies/board/index.html
+++ b/cards/rookies/board/index.html
@@ -36,7 +36,7 @@
       const boardRoot = document.getElementById('board-root');
       const queueRoot = document.getElementById('queue-root');
       const queueJumpLink = document.getElementById('queue-jump-link');
-      const SORT_OPTIONS = new Set(['grade', 'rank', 'position']);
+      const SORT_OPTIONS = new Set(['grade', 'rank', 'position', 'edge']);
       const VIEW_OPTIONS = new Set(['tiered', 'flat']);
       const DRAFT_CLASS_OPTIONS = new Set(['ALL', '2026', '2025', '2024', '2023', '2022']);
       const state = { sort: 'grade', position: 'ALL', draftClass: 'ALL', view: 'tiered' };

--- a/components/rookies/RookieBoardControls.js
+++ b/components/rookies/RookieBoardControls.js
@@ -22,6 +22,7 @@ export function renderRookieBoardControls({ positions, state }) {
           ${option('grade', 'Rookie Grade (desc)', state.sort)}
           ${option('rank', 'Class Rank (asc)', state.sort)}
           ${option('position', 'Position → Grade', state.sort)}
+          ${option('edge', 'Model Edge ↑', state.sort)}
         </select>
       </label>
 

--- a/components/rookies/RookieBoardRow.js
+++ b/components/rookies/RookieBoardRow.js
@@ -51,8 +51,10 @@ function renderPprCell(row) {
 function deltaSpan(delta, label) {
   if (delta == null) return `<span class="delta-row"><span class="delta-label">${label}</span><span class="delta-na">—</span></span>`;
   const abs = Math.abs(delta).toFixed(1);
-  if (delta >= 3)  return `<span class="delta-row"><span class="delta-label">${label}</span><span class="delta-bull">+${abs} ↑</span></span>`;
-  if (delta <= -3) return `<span class="delta-row"><span class="delta-label">${label}</span><span class="delta-bear">−${abs} ↓</span></span>`;
+  if (delta >= 10)  return `<span class="delta-row"><span class="delta-label">${label}</span><span class="delta-extreme-bull">+${abs} ↑↑</span></span>`;
+  if (delta <= -10) return `<span class="delta-row"><span class="delta-label">${label}</span><span class="delta-extreme-bear">−${abs} ↓↓</span></span>`;
+  if (delta >= 3)   return `<span class="delta-row"><span class="delta-label">${label}</span><span class="delta-bull">+${abs} ↑</span></span>`;
+  if (delta <= -3)  return `<span class="delta-row"><span class="delta-label">${label}</span><span class="delta-bear">−${abs} ↓</span></span>`;
   return `<span class="delta-row"><span class="delta-label">${label}</span><span class="delta-neutral">${delta >= 0 ? '+' : ''}${delta.toFixed(1)}</span></span>`;
 }
 
@@ -78,6 +80,20 @@ function renderBreakoutBadge(row) {
     return `<span class="breakout-badge breakout-young">⚡ Age ${esc(row.breakoutAge)}</span>`;
   }
   return `<span class="breakout-badge breakout-late">Age ${esc(row.breakoutAge)}</span>`;
+}
+
+function renderEdgeOutlierBadge(row) {
+  const d = row.consensusDelta;
+  if (d == null) return '';
+  if (d >= 10) {
+    const abs = Math.abs(d).toFixed(1);
+    return `<span class="edge-outlier-badge edge-outlier-badge-bull" title="Model edge: +${abs} above NFL consensus">▲ EDGE +${abs}</span>`;
+  }
+  if (d <= -10) {
+    const abs = Math.abs(d).toFixed(1);
+    return `<span class="edge-outlier-badge edge-outlier-badge-bear" title="Model edge: −${abs} below NFL consensus">▽ −${abs}</span>`;
+  }
+  return '';
 }
 
 const TIER_CSS = {
@@ -109,6 +125,7 @@ export function renderRookieBoardRow(row, { isQueued = false, queueAnnotation = 
         <div class="board-player-top">
           <span class="board-player-name">${esc(row.name)}</span>
           ${renderBreakoutBadge(row)}
+          ${renderEdgeOutlierBadge(row)}
           ${renderMiniScoreChart(row)}
         </div>
         <div class="meta board-summary-line">${esc(row.profileSummary)}</div>

--- a/components/rookies/rookieCardStyles.css
+++ b/components/rookies/rookieCardStyles.css
@@ -116,6 +116,27 @@ body {
   color: var(--muted);
 }
 
+/* ─── Model edge outlier badge ────────────────────────────────────────────── */
+.edge-outlier-badge {
+  display: inline-block;
+  border-radius: 999px;
+  padding: 2px 7px;
+  font-size: 11px;
+  font-weight: 700;
+  vertical-align: middle;
+  white-space: nowrap;
+}
+.edge-outlier-badge-bull {
+  background: var(--accent-glow);
+  border: 1px solid var(--border-accent);
+  color: var(--accent-soft);
+}
+.edge-outlier-badge-bear {
+  background: rgba(158, 139, 122, 0.1);
+  border: 1px solid rgba(158, 139, 122, 0.3);
+  color: var(--muted);
+}
+
 /* ─── PPR projection (card) ───────────────────────────────────────────────── */
 .ppr-card-section {
   margin-top: 16px;
@@ -159,6 +180,8 @@ body {
 .board-delta { font-size: 12px; display: flex; flex-direction: column; gap: 3px; }
 .delta-row   { display: flex; align-items: baseline; gap: 4px; }
 .delta-label { font-size: 10px; color: var(--muted); letter-spacing: .06em; text-transform: uppercase; min-width: 22px; }
+.delta-extreme-bull { font-weight: 800; color: var(--accent-soft); letter-spacing: 0.03em; }
+.delta-extreme-bear { font-weight: 800; color: var(--muted); font-style: italic; }
 .delta-bull    { font-weight: 700; color: var(--accent); }
 .delta-bear    { font-weight: 700; color: var(--muted); }
 .delta-neutral { font-weight: 600; color: #8a9ab0; }

--- a/lib/rookies/buildRookieBoardRows.js
+++ b/lib/rookies/buildRookieBoardRows.js
@@ -57,6 +57,17 @@ export function sortRookieBoard(rows, sort = 'grade') {
     });
   }
 
+  if (sort === 'edge') {
+    return copy.sort((a, b) => {
+      const av = a.consensusDelta ?? Number.NEGATIVE_INFINITY;
+      const bv = b.consensusDelta ?? Number.NEGATIVE_INFINITY;
+      if (bv !== av) return bv - av;
+      const ag = a.rookieGrade ?? Number.NEGATIVE_INFINITY;
+      const bg = b.rookieGrade ?? Number.NEGATIVE_INFINITY;
+      return bg - ag;
+    });
+  }
+
   return copy.sort((a, b) => {
     const bv = b.rookieGrade ?? Number.NEGATIVE_INFINITY;
     const av = a.rookieGrade ?? Number.NEGATIVE_INFINITY;


### PR DESCRIPTION
- Add extreme-tier delta rendering (>= 10 / <= -10): double arrows and distinct CSS (.delta-extreme-bull / .delta-extreme-bear) so a +19.4 outlier looks dramatically different from a +4 moderate signal
- Add outlier badge (.edge-outlier-badge) in the player name cell: fires at the same >=10 threshold so the signal is unmissable without opening the detail view (▲ EDGE +19.4 / ▽ −13.5)
- Add 'Model Edge ↑' sort option — sortRookieBoard('edge') orders by consensusDelta descending, tie-broken by rookieGrade; null-safe
- Wire 'edge' into SORT_OPTIONS whitelist so ?sort=edge URLs persist

https://claude.ai/code/session_01BFKHiAMPXTrWhNuub1FSGs