### PR TITLE
feat(board): mobile card layout redesign

### DIFF
--- a/components/rookies/RookieBoardRow.js
+++ b/components/rookies/RookieBoardRow.js
@@ -58,6 +58,16 @@ function deltaSpan(delta, label) {
   return `<span class="delta-row"><span class="delta-label">${label}</span><span class="delta-neutral">${delta >= 0 ? '+' : ''}${delta.toFixed(1)}</span></span>`;
 }
 
+function deltaSpanInline(delta) {
+  if (delta == null) return `<span class="delta-na">—</span>`;
+  const abs = Math.abs(delta).toFixed(1);
+  if (delta >= 10)  return `<span class="delta-extreme-bull">+${abs} ↑↑</span>`;
+  if (delta <= -10) return `<span class="delta-extreme-bear">−${abs} ↓↓</span>`;
+  if (delta >= 3)   return `<span class="delta-bull">+${abs} ↑</span>`;
+  if (delta <= -3)  return `<span class="delta-bear">−${abs} ↓</span>`;
+  return `<span class="delta-neutral">${delta >= 0 ? '+' : ''}${delta.toFixed(1)}</span>`;
+}
+
 function renderConsensusDeltaCell(row) {
   return `
     <div class="board-cell board-delta" data-label="Model Edge">
@@ -109,6 +119,64 @@ function renderPosBadge(position) {
   return `<span class="pos-badge ${cls}">${esc(pos)}</span>`;
 }
 
+function renderMobileCard(row, { isQueued = false, queueAnnotation = null } = {}) {
+  const rank = row.classRank == null ? 'N/A' : `#${row.classRank}`;
+  const grade = row.rookieGrade == null ? 'N/A' : row.rookieGrade.toFixed(1);
+  const slug = encodeURIComponent(String(row.slug ?? ''));
+  const compareLeftHref = `/cards/rookies/compare/index.html?left=${slug}`;
+  const compareRightHref = `/cards/rookies/compare/index.html?right=${slug}`;
+  const queueTag = queueAnnotation?.queueTag ?? '';
+
+  const identityParts = [
+    row.position,
+    row.school,
+    row.draftClass ? String(row.draftClass) : null,
+  ].filter(Boolean);
+
+  const pprBand = row.pprProjection?.band ?? null;
+  const pprRange = row.pprProjection
+    ? `${esc(row.pprProjection.floor)}–${esc(row.pprProjection.ceiling)}`
+    : null;
+
+  return `
+    <div class="board-mobile-card">
+      <div class="bmc-header">
+        <span class="bmc-rank board-num">${esc(rank)}</span>
+        <span class="bmc-grade">Grade <strong class="bmc-grade-value">${esc(grade)}</strong></span>
+      </div>
+      <div class="bmc-name">
+        <span class="board-player-name">${esc(row.name)}</span>
+        ${renderBreakoutBadge(row)}
+        ${renderEdgeOutlierBadge(row)}
+      </div>
+      <div class="bmc-meta">${esc(identityParts.join(' • '))}</div>
+      <div class="bmc-thesis">${esc(row.profileSummary)}</div>
+      <div class="bmc-pills">
+        <span class="board-tier-pill">${esc(row.tier?.label ?? '')}</span>
+        ${pprBand ? `<span class="ppr-band ${PPR_BAND_CLASS[pprBand] ?? 'ppr-band-lottery'}">${esc(pprBand)}</span>` : ''}
+      </div>
+      <div class="bmc-stats">
+        <div class="bmc-stat-row">
+          <span class="bmc-stat-label">NFL Edge</span>
+          <span>${deltaSpanInline(row.consensusDelta)}</span>
+        </div>
+        <div class="bmc-stat-row">
+          <span class="bmc-stat-label">Dyn Edge</span>
+          <span>${deltaSpanInline(row.dynastyDelta)}</span>
+        </div>
+        ${pprRange ? `<div class="bmc-stat-row"><span class="bmc-stat-label">Range</span><span class="bmc-ppr-range">${pprRange} PPR</span></div>` : ''}
+      </div>
+      ${isQueued && queueTag ? `<div class="meta queue-inline-indicator" style="margin-bottom:6px">Queue tag: <span class="queue-tag-pill">${esc(queueTag)}</span></div>` : ''}
+      <div class="bmc-actions-utility">
+        <a class="nav-link" href="/cards/rookies/player.html?slug=${slug}">Detail</a>
+        <a class="nav-link" href="${compareLeftHref}">Compare L</a>
+        <a class="nav-link" href="${compareRightHref}">Compare R</a>
+      </div>
+      <button type="button" class="queue-toggle bmc-queue-btn ${isQueued ? 'is-queued' : ''}" data-queue-toggle="${esc(row.slug)}">${isQueued ? 'Queued ✓' : 'Add to queue'}</button>
+    </div>
+  `;
+}
+
 export function renderRookieBoardRow(row, { isQueued = false, queueAnnotation = null } = {}) {
   const rank = row.classRank == null ? 'N/A' : `#${row.classRank}`;
   const grade = row.rookieGrade == null ? 'N/A' : row.rookieGrade.toFixed(1);
@@ -120,6 +188,7 @@ export function renderRookieBoardRow(row, { isQueued = false, queueAnnotation = 
 
   return `
     <article class="board-row ${tierCss} ${isQueued ? 'board-row-queued' : ''}">
+      ${renderMobileCard(row, { isQueued, queueAnnotation })}
       <div class="board-cell board-rank board-num" data-label="Rank">${esc(rank)}</div>
       <div class="board-cell board-player" data-label="Player">
         <div class="board-player-top">
@@ -139,8 +208,8 @@ export function renderRookieBoardRow(row, { isQueued = false, queueAnnotation = 
       ${renderConsensusDeltaCell(row)}
       <div class="board-cell board-actions" data-label="Actions">
         <a class="nav-link" href="/cards/rookies/player.html?slug=${slug}">Detail</a>
-        <a class="nav-link" href="${compareLeftHref}">Set Left</a>
-        <a class="nav-link" href="${compareRightHref}">Set Right</a>
+        <a class="nav-link" href="${compareLeftHref}">Compare L</a>
+        <a class="nav-link" href="${compareRightHref}">Compare R</a>
         <button type="button" class="queue-toggle ${isQueued ? 'is-queued' : ''}" data-queue-toggle="${esc(row.slug)}">${isQueued ? 'Queued ✓' : 'Add to queue'}</button>
       </div>
     </article>

--- a/components/rookies/rookieCardStyles.css
+++ b/components/rookies/rookieCardStyles.css
@@ -562,6 +562,9 @@ body {
 .queue-note-counter { text-align: right; }
 .queue-note-counter-limit { color: #ffb4b4; }
 
+/* ─── Mobile board card (hidden on desktop, shown via media query) ────────── */
+.board-mobile-card { display: none; }
+
 /* ─── Tier groups ─────────────────────────────────────────────────────────── */
 .tier-group { border-top: 1px solid var(--border); }
 .tier-group:first-child { border-top: none; }
@@ -584,22 +587,111 @@ body {
 }
 
 @media (max-width: 760px) {
+  /* ── Full-detail card (player.html) ──────────────────────────────────────── */
   .player-name { font-size: 26px; }
-  .board-row { grid-template-columns: 1fr; gap: 4px; }
+
+  /* ── Board rows: switch to block, surface mobile card ───────────────────── */
+  .board-row { grid-template-columns: 1fr; gap: 0; padding: 12px; }
   .board-header { display: none; }
-  .board-actions { flex-direction: row; gap: 10px; }
-  .board-cell { display: flex; justify-content: space-between; }
-  .board-cell::before {
-    content: attr(data-label);
+  .board-cell { display: none; }
+  .board-mobile-card { display: block; }
+
+  /* ── Mobile card sections ────────────────────────────────────────────────── */
+  .bmc-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    padding-bottom: 8px;
+    border-bottom: 1px solid var(--border);
+    margin-bottom: 10px;
+  }
+  .bmc-rank {
+    font-size: 13px;
+    color: #C8B9A8;
+    font-weight: 700;
+  }
+  .bmc-grade {
+    font-size: 11px;
     color: var(--muted);
     text-transform: uppercase;
-    font-size: 11px;
-    letter-spacing: .08em;
-    margin-right: 10px;
+    letter-spacing: .07em;
   }
-  .board-player { display: block; }
-  .board-player::before,
-  .board-actions::before { display: none; }
+  .bmc-grade-value {
+    color: var(--accent);
+    font-size: 15px;
+    font-family: 'JetBrains Mono', 'Fira Mono', ui-monospace, monospace;
+    font-variant-numeric: tabular-nums;
+    font-weight: 800;
+  }
+  .bmc-name {
+    font-size: 18px;
+    font-weight: 700;
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-bottom: 3px;
+  }
+  .bmc-meta {
+    font-size: 12px;
+    color: var(--muted);
+    margin-bottom: 10px;
+  }
+  .bmc-thesis {
+    font-size: 13px;
+    line-height: 1.5;
+    margin-bottom: 10px;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+  .bmc-pills {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-bottom: 12px;
+  }
+  .bmc-stats {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+    margin-bottom: 12px;
+  }
+  .bmc-stat-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    font-size: 13px;
+  }
+  .bmc-stat-label {
+    font-size: 11px;
+    color: var(--muted);
+    text-transform: uppercase;
+    letter-spacing: .07em;
+    min-width: 76px;
+  }
+  .bmc-ppr-range {
+    font-weight: 700;
+    font-size: 13px;
+  }
+  .bmc-actions-utility {
+    display: flex;
+    flex-direction: row;
+    gap: 14px;
+    flex-wrap: wrap;
+    margin-bottom: 8px;
+  }
+  .bmc-queue-btn {
+    display: block;
+    width: 100%;
+    box-sizing: border-box;
+    padding: 10px;
+    text-align: center;
+    font-size: 13px;
+  }
+
+  /* ── Non-board mobile adjustments ────────────────────────────────────────── */
   .compact-actions-row,
   .queue-toolbar,
   .queue-item { flex-direction: column; align-items: flex-start; }


### PR DESCRIPTION
Replace the flat labeled-list mobile board row with a structured card layout.

On ≤760px, all board-cell elements are hidden and a new board-mobile-card div is rendered (dual-render / CSS toggle approach). Desktop layout is unchanged.

Mobile card structure:
- Header row: rank (left) | Grade N.N (right), separated by border
- Name row: player name + breakout badge + edge outlier badge
- Identity line: POS • School • ClassYear (muted, compact)
- Thesis: profile summary, 2-line clamp with natural wrap
- Pills: tier label + PPR band outcome (2 max)
- Stats stack: NFL Edge / Dyn Edge / Range — label-left, value-right
- Actions: utility row (Detail, Compare L, Compare R) + full-width queue button

Also renames "Set Left"/"Set Right" to "Compare L"/"Compare R" globally (desktop actions cell + mobile card links).

https://claude.ai/code/session_01BFKHiAMPXTrWhNuub1FSGs