### PR TITLE
feat: add BOAR (breakout age rating) with position-aware detection

### DIFF
--- a/components/rookies/RookieBoardRow.js
+++ b/components/rookies/RookieBoardRow.js
@@ -106,6 +106,20 @@ function renderBreakoutBadge(row) {
   return `<span class="breakout-badge breakout-late">Age ${esc(row.breakoutAge)}</span>`;
 }
 
+function boarChipClass(boar) {
+  if (boar >= 75) return 'bmc-signal-boar-elite';
+  if (boar >= 60) return 'bmc-signal-boar-early';
+  if (boar >= 45) return 'bmc-signal-boar-avg';
+  return 'bmc-signal-boar-late';
+}
+
+function renderBoarChip(row) {
+  const boar = row.breakoutAgeRating;
+  if (boar == null) return '';
+  const tip = row.breakoutAge != null ? `Age ${row.breakoutAge} breakout` : 'Breakout Age Rating';
+  return `<span class="bmc-signal-chip ${boarChipClass(boar)}" title="${esc(tip)}">BOAR ${Math.round(boar)}</span>`;
+}
+
 function renderEdgeOutlierBadge(row) {
   const d = row.consensusDelta;
   if (d == null) return '';
@@ -174,6 +188,7 @@ function renderMobileCard(row, { isQueued = false, queueAnnotation = null } = {}
         ${row.draftCapitalScore != null ? `<span class="bmc-signal-chip bmc-signal-capital" title="Draft Capital">CAP ${Math.round(row.draftCapitalScore)}</span>` : ''}
         ${row.rasScore         != null ? `<span class="bmc-signal-chip bmc-signal-ras"     title="Relative Athletic Score">RAS ${Math.round(row.rasScore)}</span>` : ''}
         ${row.productionScore  != null ? `<span class="bmc-signal-chip bmc-signal-prod"    title="Production Score">PRD ${Math.round(row.productionScore)}</span>` : ''}
+        ${renderBoarChip(row)}
       </div>
       <div class="bmc-stats">
         <div class="bmc-stat-row">
@@ -215,6 +230,7 @@ export function renderRookieBoardRow(row, { isQueued = false, queueAnnotation = 
           ${renderTeamLogos(row.school, row.nflTeam)}
           <span class="board-player-name">${esc(row.name)}</span>
           ${renderBreakoutBadge(row)}
+          ${renderBoarChip(row)}
           ${renderEdgeOutlierBadge(row)}
           ${renderMiniScoreChart(row)}
         </div>

--- a/components/rookies/RookieCard.js
+++ b/components/rookies/RookieCard.js
@@ -101,6 +101,36 @@ function renderBreakoutAgeBadge(card) {
   return `<span class="breakout-badge breakout-late">Age ${esc(card.breakoutAge)} breakout</span>`;
 }
 
+function boarTierClass(boar) {
+  if (boar >= 75) return 'boar-elite';
+  if (boar >= 60) return 'boar-early';
+  if (boar >= 45) return 'boar-avg';
+  return 'boar-late';
+}
+
+function renderBoarSection(card) {
+  const boar = card.breakoutAgeRating;
+  const boa = card.breakoutAge;
+  if (boar == null && boa == null) return '';
+
+  const boarChip = boar != null
+    ? `<span class="boar-chip ${boarTierClass(boar)}"><span class="boar-label">BOAR</span> <span class="boar-value">${Math.round(boar)}</span></span>`
+    : '';
+  const boaChip = boa != null
+    ? `<span class="boa-chip"><span class="boa-label">BOA</span> <span class="boa-value">${esc(boa)}</span></span>`
+    : '';
+  const labelText = card.breakoutLabel ?? null;
+  const labelSpan = labelText
+    ? `<span class="boar-signal-label">${esc(labelText)}</span>`
+    : '';
+
+  return `
+    <div class="boar-section">
+      <div class="boar-chips">${boaChip}${boarChip}</div>
+      ${labelSpan}
+    </div>`;
+}
+
 function renderPprProjection(ppr) {
   if (!ppr) return '';
   const bandClass = { Elite: 'ppr-band-elite', Starter: 'ppr-band-starter', Contributor: 'ppr-band-contributor', Lottery: 'ppr-band-lottery' }[ppr.band] ?? 'ppr-band-lottery';
@@ -191,7 +221,7 @@ export function renderRookieCard(container, card) {
           </h1>
           <div class="meta">${esc(identityBits || 'Profile context not available')}</div>
           <div class="meta">${esc(card.summary.profileSummary ?? card.summary.identityNote ?? 'Identity summary unavailable')}</div>
-          ${renderBreakoutAgeBadge(card)}
+          ${renderBoarSection(card)}
         </div>
         <div class="hero-score">
           <div class="section-title">Rookie Grade</div>

--- a/components/rookies/rookieCardStyles.css
+++ b/components/rookies/rookieCardStyles.css
@@ -116,6 +116,65 @@ body {
   color: var(--muted);
 }
 
+/* BOAR section (full player card) */
+.boar-section {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 6px;
+  flex-wrap: wrap;
+}
+.boar-chips {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+.boa-chip, .boar-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  border-radius: 6px;
+  padding: 2px 7px;
+  font-size: 12px;
+  font-weight: 700;
+  font-family: 'JetBrains Mono', 'Fira Mono', ui-monospace, monospace;
+  letter-spacing: .04em;
+  white-space: nowrap;
+}
+.boa-chip {
+  background: rgba(158, 139, 122, 0.12);
+  border: 1px solid rgba(158, 139, 122, 0.3);
+  color: var(--muted);
+}
+.boa-label, .boar-label { font-size: 10px; opacity: 0.7; }
+.boar-elite {
+  background: rgba(232, 133, 61, 0.18);
+  border: 1px solid rgba(232, 133, 61, 0.4);
+  color: #E8853D;
+}
+.boar-early {
+  background: rgba(78, 205, 196, 0.18);
+  border: 1px solid rgba(78, 205, 196, 0.35);
+  color: #4ECDC4;
+}
+.boar-avg {
+  background: rgba(158, 139, 122, 0.12);
+  border: 1px solid rgba(158, 139, 122, 0.3);
+  color: var(--muted);
+}
+.boar-late {
+  background: rgba(120, 113, 108, 0.12);
+  border: 1px solid rgba(120, 113, 108, 0.25);
+  color: #78716C;
+}
+.boar-signal-label {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--muted);
+  font-style: italic;
+}
+
+
 /* ─── Model edge outlier badge ────────────────────────────────────────────── */
 .edge-outlier-badge {
   display: inline-block;
@@ -707,6 +766,10 @@ body {
   .bmc-signal-capital { background: rgba(232, 133, 61, .18); color: #E8853D; border: 1px solid rgba(232, 133, 61, .35); }
   .bmc-signal-ras     { background: rgba(107, 159, 212, .18); color: #6B9FD4; border: 1px solid rgba(107, 159, 212, .35); }
   .bmc-signal-prod    { background: rgba(78, 205, 196, .18); color: #4ECDC4; border: 1px solid rgba(78, 205, 196, .35); }
+  .bmc-signal-boar-elite { background: rgba(232, 133, 61, .18); color: #E8853D; border: 1px solid rgba(232, 133, 61, .35); }
+  .bmc-signal-boar-early { background: rgba(78, 205, 196, .14); color: #4ECDC4; border: 1px solid rgba(78, 205, 196, .30); }
+  .bmc-signal-boar-avg   { background: rgba(158, 139, 122, .12); color: #9E8B7A; border: 1px solid rgba(158, 139, 122, .25); }
+  .bmc-signal-boar-late  { background: rgba(120, 113, 108, .10); color: #78716C; border: 1px solid rgba(120, 113, 108, .20); }
   .bmc-stats {
     display: flex;
     flex-direction: column;

--- a/lib/rookies/buildRookieBoardRows.js
+++ b/lib/rookies/buildRookieBoardRows.js
@@ -34,6 +34,8 @@ export function buildRookieBoardRows(cards) {
       efficiencyTrend: card.efficiencyTrend ?? null,
       breakoutAge: card.breakoutAge ?? null,
       youngBreakoutFlag: card.youngBreakoutFlag ?? false,
+      breakoutAgeRating: card.breakoutAgeRating ?? null,
+      breakoutLabel: card.breakoutLabel ?? null,
       rasScore: card.scores[1]?.value ?? null,
       productionScore: card.scores[2]?.value ?? null,
       draftCapitalScore: card.scores[3]?.value ?? null,

--- a/lib/rookies/mapRookieToCard.js
+++ b/lib/rookies/mapRookieToCard.js
@@ -69,6 +69,10 @@ export function mapRookieToCard({ alphaPlayer, combineRow, productionRow, draftR
   const consensusDelta = alphaPlayer?.scores?.consensus_delta ?? null;
   const breakoutAge = alphaPlayer?.context?.breakout_age ?? null;
   const youngBreakoutFlag = alphaPlayer?.context?.young_breakout_flag ?? false;
+  const breakoutAgeRating = alphaPlayer?.context?.breakout_age_rating_0_100 ?? null;
+  const breakoutStrength = alphaPlayer?.context?.breakout_strength ?? null;
+  const breakoutConfidence = alphaPlayer?.context?.breakout_confidence ?? null;
+  const breakoutLabel = alphaPlayer?.context?.breakout_label ?? null;
   const missingModelInputs = Array.isArray(alphaPlayer?.model_inputs_missing) ? alphaPlayer.model_inputs_missing : [];
   const evidenceTags = Array.isArray(alphaPlayer?.evidence?.evidence_tags) ? alphaPlayer.evidence.evidence_tags : [];
   const contextFlags = Array.isArray(alphaPlayer?.evidence?.context_flags) ? alphaPlayer.evidence.context_flags : [];
@@ -157,6 +161,10 @@ export function mapRookieToCard({ alphaPlayer, combineRow, productionRow, draftR
     translationFlags,
     breakoutAge,
     youngBreakoutFlag,
+    breakoutAgeRating,
+    breakoutStrength,
+    breakoutConfidence,
+    breakoutLabel,
     ageAdjustedProduction,
     consensusDelta,
     dynastyDelta,

--- a/scripts/compute_age_adjusted_production.py
+++ b/scripts/compute_age_adjusted_production.py
@@ -3,7 +3,9 @@
 compute_age_adjusted_production.py
 
 Computes an age-adjusted production score for each 2026 draft prospect by
-combining weighted season volume with a non-linear age multiplier.
+combining weighted season volume with a non-linear age multiplier.  Also
+computes breakout_age_rating_0_100 (BOAR), a derived display metric that
+surfaces hidden profile quality from early breakouts.
 
 Volume metric per position
   WR / TE  — targets
@@ -22,6 +24,12 @@ Age multiplier (non-linear)
   Breakout age 20 → 1.5×
   Breakout age 21 → 1.0×  (baseline)
   Breakout age 22 → 0.85×
+
+BOAR (breakout_age_rating_0_100)
+  Position-aware composite of breakout age, breakout strength, and data
+  confidence.  Intended for UI display and explainability — NOT as a duplicate
+  heavy weight in scoring.  WR carries the highest age-sensitivity; QB the
+  lightest.
 
 Final score
   raw_score = weighted_volume × age_multiplier
@@ -150,6 +158,80 @@ def age_multiplier(breakout_age: int | None) -> float:
 
 
 # ---------------------------------------------------------------------------
+# BOAR — Breakout Age Rating (0–100 display metric)
+# ---------------------------------------------------------------------------
+# Position-aware age sensitivity: points per year younger than baseline.
+# WR gets the most credit for youth; QB the least.
+BOAR_AGE_BASELINE: dict[str, float] = {
+    "WR": 21.0,
+    "TE": 21.5,
+    "RB": 21.0,
+    "QB": 21.5,
+}
+BOAR_AGE_SCALE: dict[str, float] = {
+    "WR": 20.0,   # WR: BOAR matters a lot
+    "TE": 18.0,   # TE: moderate, softer expectations
+    "RB": 16.0,   # RB: matters some, less than WR
+    "QB": 12.0,   # QB: light treatment, avoid fake precision
+}
+BOAR_STRENGTH_BONUS = 15.0  # max bonus points for dominant breakout strength
+
+
+def compute_boar(
+    breakout_age: int | None,
+    position: str,
+    breakout_strength: float | None,
+    breakout_confidence: float | None,
+) -> float | None:
+    """Compute breakout_age_rating_0_100 (BOAR).
+
+    Returns None when breakout_age is unknown (no signal to display).
+    Otherwise returns a 0–100 rating where:
+      - 75+ = elite/early breakout signal
+      - 60–74 = early breakout
+      - 45–59 = average breakout timing
+      - 30–44 = late breakout
+      - <30 = very late breakout
+    """
+    if breakout_age is None:
+        return None
+
+    baseline = BOAR_AGE_BASELINE.get(position, 21.0)
+    scale = BOAR_AGE_SCALE.get(position, 16.0)
+
+    # Age component: 50 at baseline age, higher for younger, lower for older
+    age_component = 50.0 + scale * (baseline - breakout_age)
+    age_component = max(0.0, min(100.0, age_component))
+
+    # Strength bonus: up to BOAR_STRENGTH_BONUS points for dominant breakout
+    strength = breakout_strength if breakout_strength is not None else 0.0
+    strength_bonus = strength * BOAR_STRENGTH_BONUS
+
+    raw_boar = age_component + strength_bonus
+
+    # Confidence regresses toward 50 (uncertain → neutral, not toward 0)
+    confidence = breakout_confidence if breakout_confidence is not None else 0.7
+    boar = 50.0 + (raw_boar - 50.0) * confidence
+
+    return round(max(0.0, min(100.0, boar)), 1)
+
+
+def boar_label(boar_value: float | None) -> str | None:
+    """Human-readable breakout label for UI display."""
+    if boar_value is None:
+        return None
+    if boar_value >= 75:
+        return "Elite breakout"
+    if boar_value >= 60:
+        return "Early breakout"
+    if boar_value >= 45:
+        return "Average breakout"
+    if boar_value >= 30:
+        return "Late breakout"
+    return "Very late breakout"
+
+
+# ---------------------------------------------------------------------------
 # Profile loading
 # ---------------------------------------------------------------------------
 def profile_dir(position: str, args: argparse.Namespace) -> Path:
@@ -254,6 +336,8 @@ def compute(args: argparse.Namespace) -> list[dict[str, Any]]:
             pid = player["player_id"]
             class_year = int(player.get("class_year") or 0)
             breakout_age_val = player.get("breakout_age")
+            breakout_strength_val = player.get("breakout_strength")
+            breakout_confidence_val = player.get("breakout_confidence")
 
             # --- BOA context adjustment ---
             school_adj, school_class = school_boa_adjustment(player.get("school", ""))
@@ -288,6 +372,12 @@ def compute(args: argparse.Namespace) -> list[dict[str, Any]]:
             multiplier = age_multiplier(effective_boa)
             raw = wvol * multiplier
 
+            # --- BOAR computation ---
+            boar_val = compute_boar(
+                breakout_age_val, pos, breakout_strength_val, breakout_confidence_val,
+            )
+            boar_label_val = boar_label(boar_val)
+
             records.append(
                 {
                     "player_id": pid,
@@ -297,6 +387,10 @@ def compute(args: argparse.Namespace) -> list[dict[str, Any]]:
                     "effective_breakout_age": effective_boa,
                     "boa_adjustment": round(total_boa_adj, 2) if total_boa_adj != 0.0 else None,
                     "young_breakout_flag": player.get("young_breakout_flag", False),
+                    "breakout_strength": breakout_strength_val,
+                    "breakout_confidence": breakout_confidence_val,
+                    "breakout_age_rating_0_100": boar_val,
+                    "breakout_label": boar_label_val,
                     "best_season_volume": best_vol,
                     "recent_season_volume": recent_vol,
                     "weighted_volume": round(wvol, 2),
@@ -318,14 +412,16 @@ def compute(args: argparse.Namespace) -> list[dict[str, Any]]:
         logging.info("Position %s (%d players):", pos, len(records))
         for r in records:
             flag = " (young ✓)" if r["young_breakout_flag"] else ""
+            boar_str = f"  BOAR={r['breakout_age_rating_0_100']:.0f}" if r["breakout_age_rating_0_100"] is not None else ""
             logging.info(
-                "  %-28s age=%s  mult=%.2f  wvol=%5.1f  score=%5.1f%s",
+                "  %-28s age=%s  mult=%.2f  wvol=%5.1f  score=%5.1f%s%s",
                 r["player_name"],
                 r["breakout_age"] if r["breakout_age"] is not None else "null",
                 r["age_multiplier"],
                 r["weighted_volume"],
                 r["age_adjusted_production_score"],
                 flag,
+                boar_str,
             )
 
     return results

--- a/scripts/compute_breakout_age.py
+++ b/scripts/compute_breakout_age.py
@@ -1,21 +1,33 @@
 #!/usr/bin/env python3
-"""Compute breakout_age and young_breakout_flag for 2026 prospects.
+"""Compute breakout_age, breakout_strength, breakout_confidence for 2026 prospects.
 
 For each player, finds the earliest season in their play profile data where
-they met the position-specific breakout threshold. Uses CFBD roster data to
-get academic year (1=FR, 2=SO, 3=JR, 4=SR, 5=5th year), then estimates age
-as 17 + academic_year. This is a ±1 year approximation; exact DOBs are not
+they met position-specific breakout criteria. Uses CFBD roster data to get
+academic year (1=FR, 2=SO, 3=JR, 4=SR, 5=5th year), then estimates age as
+17 + academic_year. This is a ±1 year approximation; exact DOBs are not
 available from CFBD.
+
+Breakout detection is position-aware with tiered criteria:
+
+  WR  — preferred: target_share >= 0.20 OR receiving_yard_share >= 0.25
+        fallback:  targets >= 50
+  TE  — preferred: target_share >= 0.15 OR receiving_yard_share >= 0.20
+        fallback:  targets >= 35  (lower bar; college TEs rarely exceed 50)
+  RB  — preferred: rush_share >= 0.30 OR rush_yard_share >= 0.30
+        fallback:  rush_attempts >= 80
+  QB  — pass_attempts >= 150  (lighter treatment, no share criteria)
+
+When a breakout is detected the script also computes:
+  breakout_strength  (0.0–1.0) — how convincingly the player exceeded the
+                                  threshold relative to the position bar.
+  breakout_confidence (0.0–1.0) — how complete the data picture is; lower
+                                  when fewer seasons are available or when
+                                  only raw volume (no share) data was used.
 
 Limitation: only looks at seasons present in play profile files (2024, 2025 by
 default). Players whose breakout predates those seasons (e.g. Nick Singleton
-2022) will show breakout_age=null. This is a known data gap, not a bug.
-
-Breakout thresholds (inclusive):
-  WR  — targets  >= 50
-  TE  — targets  >= 35  (lower bar; college TEs rarely exceed 50)
-  QB  — pass_attempts >= 150
-  RB  — rush_attempts >= 80
+2022) will show breakout_age=null. Missing earlier breakouts lower confidence
+rather than falsely implying no breakout.
 
 young_breakout_flag: True if breakout_age <= 20
 """
@@ -43,12 +55,21 @@ DEFAULT_WR_DIR = Path("data/processed/wr_route_profiles")
 DEFAULT_QB_DIR = Path("data/processed/qb_play_profiles")
 DEFAULT_RB_DIR = Path("data/processed/rb_play_profiles")
 
-# Breakout thresholds by position
+# Breakout thresholds by position — raw volume fallback
 BREAKOUT_THRESHOLDS: dict[str, tuple[str, int]] = {
     "WR": ("targets", 50),
     "TE": ("targets", 35),
     "QB": ("pass_attempts", 150),
     "RB": ("rush_attempts", 80),
+}
+
+# Position-aware share-based breakout criteria (preferred over raw volume).
+# Each entry is a list of (field, threshold) pairs — meeting ANY one qualifies.
+SHARE_BREAKOUT_CRITERIA: dict[str, list[tuple[str, float]]] = {
+    "WR": [("target_share", 0.20), ("receiving_yard_share", 0.25)],
+    "TE": [("target_share", 0.15), ("receiving_yard_share", 0.20)],
+    "RB": [("rush_share", 0.30), ("rush_yard_share", 0.30)],
+    "QB": [],  # QB uses raw volume only — lighter treatment
 }
 
 YOUNG_BREAKOUT_MAX_AGE = 20  # breakout_age <= this → young_breakout_flag = True
@@ -129,6 +150,79 @@ def load_profile_seasons(
     return results
 
 
+def _check_share_breakout(profile: dict[str, Any], position: str) -> tuple[bool, bool]:
+    """Check if a profile meets share-based breakout criteria for the position.
+
+    Returns (met_share_criteria, had_share_data).
+    """
+    criteria = SHARE_BREAKOUT_CRITERIA.get(position, [])
+    if not criteria:
+        return False, False
+    had_share_data = False
+    for field, threshold in criteria:
+        value = profile.get(field)
+        if value is not None:
+            had_share_data = True
+            try:
+                if float(value) >= threshold:
+                    return True, True
+            except (TypeError, ValueError):
+                pass
+    return False, had_share_data
+
+
+def _compute_breakout_strength(
+    stat_value: float,
+    threshold_value: int,
+    profile: dict[str, Any],
+    position: str,
+) -> float:
+    """How convincingly the player exceeded the breakout threshold (0.0–1.0).
+
+    Blends raw volume overshoot with share overshoot when share data is
+    available, giving a richer picture of breakout dominance.
+    """
+    # Volume overshoot: 0 at threshold, 1.0 at 2× threshold
+    if threshold_value > 0 and stat_value > 0:
+        ratio = min(2.0, stat_value / threshold_value)
+        volume_strength = max(0.0, ratio - 1.0)
+    else:
+        volume_strength = 0.0
+
+    # Share overshoot (if available)
+    share_criteria = SHARE_BREAKOUT_CRITERIA.get(position, [])
+    best_share_strength = 0.0
+    has_share = False
+    for field, threshold in share_criteria:
+        value = profile.get(field)
+        if value is not None:
+            has_share = True
+            try:
+                ratio = min(2.0, float(value) / threshold) if threshold > 0 else 0.0
+                best_share_strength = max(best_share_strength, max(0.0, ratio - 1.0))
+            except (TypeError, ValueError):
+                pass
+
+    if has_share:
+        return round(0.5 * volume_strength + 0.5 * best_share_strength, 3)
+    return round(volume_strength, 3)
+
+
+def _compute_breakout_confidence(
+    seasons_with_data: int,
+    used_share_data: bool,
+) -> float:
+    """How complete the data picture is (0.0–1.0).
+
+    Higher when more seasons are observed and richer share metrics are
+    available. A detected breakout starts at 0.70 base confidence.
+    """
+    base = 0.70
+    season_bonus = min(2, seasons_with_data) * 0.10   # up to +0.20
+    share_bonus = 0.10 if used_share_data else 0.0
+    return round(min(1.0, base + season_bonus + share_bonus), 2)
+
+
 def compute_breakout_for_player(
     player: dict[str, Any],
     args: argparse.Namespace,
@@ -145,19 +239,38 @@ def compute_breakout_for_player(
     seasons_to_check = [class_year - 2, class_year - 1]
     season_profiles = load_profile_seasons(player_id, profile_dir, seasons_to_check)
 
+    null_result = {
+        "breakout_age": None,
+        "age_at_first_impact_season": None,
+        "young_breakout_flag": None,
+        "breakout_strength": None,
+        "breakout_confidence": None,
+        "seasons_available": len(season_profiles),
+    }
+
     if position not in BREAKOUT_THRESHOLDS:
-        return {"breakout_age": None, "age_at_first_impact_season": None, "young_breakout_flag": None}
+        return null_result
 
     threshold_field, threshold_value = BREAKOUT_THRESHOLDS[position]
 
     breakout_age: int | None = None
     age_at_first_impact: int | None = None
+    breakout_strength: float | None = None
+    used_share_data = False
 
     for season, profile in season_profiles:
-        # Check if this season meets the breakout threshold
+        # --- Position-aware breakout detection ---
+        # 1. Preferred: share-based criteria (dominator-style)
+        met_share, had_share = _check_share_breakout(profile, position)
+        if had_share:
+            used_share_data = True
+
+        # 2. Fallback: raw volume threshold (current behaviour)
         stat_value = profile.get(threshold_field) or 0
-        if stat_value < threshold_value:
-            continue  # below threshold — not a breakout season
+        met_volume = stat_value >= threshold_value
+
+        if not met_share and not met_volume:
+            continue  # below all thresholds — not a breakout season
 
         # Fetch roster for academic year (cached)
         cache_key = (school, season)
@@ -182,16 +295,26 @@ def compute_breakout_for_player(
         # Breakout is the first qualifying season
         if breakout_age is None:
             breakout_age = age
+            breakout_strength = _compute_breakout_strength(
+                stat_value, threshold_value, profile, position,
+            )
             break  # earliest qualifying season found
 
     young_breakout_flag: bool | None = None
+    breakout_confidence: float | None = None
     if breakout_age is not None:
         young_breakout_flag = breakout_age <= YOUNG_BREAKOUT_MAX_AGE
+        breakout_confidence = _compute_breakout_confidence(
+            len(season_profiles), used_share_data,
+        )
 
     return {
         "breakout_age": breakout_age,
         "age_at_first_impact_season": age_at_first_impact,
         "young_breakout_flag": young_breakout_flag,
+        "breakout_strength": breakout_strength,
+        "breakout_confidence": breakout_confidence,
+        "seasons_available": len(season_profiles),
     }
 
 
@@ -205,6 +328,9 @@ def update_context_entry(
     updated["breakout_age"] = breakout_data["breakout_age"]
     updated["age_at_first_impact_season"] = breakout_data["age_at_first_impact_season"]
     updated["young_breakout_flag"] = breakout_data["young_breakout_flag"]
+    updated["breakout_strength"] = breakout_data["breakout_strength"]
+    updated["breakout_confidence"] = breakout_data["breakout_confidence"]
+    updated["seasons_available"] = breakout_data["seasons_available"]
 
     # Add/remove young_breakout evidence tag
     tags = list(updated.get("evidence_tags") or [])
@@ -238,6 +364,9 @@ def make_minimal_context_entry(
         "breakout_age": breakout_data["breakout_age"],
         "age_at_first_impact_season": breakout_data["age_at_first_impact_season"],
         "young_breakout_flag": breakout_data["young_breakout_flag"],
+        "breakout_strength": breakout_data["breakout_strength"],
+        "breakout_confidence": breakout_data["breakout_confidence"],
+        "seasons_available": breakout_data["seasons_available"],
         "evidence_tags": tags,
         "context_flags": [],
         "evidence_summary": None,
@@ -286,7 +415,9 @@ def main() -> None:
         flag_str = "young ✓" if breakout_data["young_breakout_flag"] else (
             "late" if breakout_data["young_breakout_flag"] is False else "unknown"
         )
-        print(f"{player_name:30} {position} breakout_age={age_str:4} ({flag_str})")
+        str_val = f" str={breakout_data['breakout_strength']:.2f}" if breakout_data["breakout_strength"] is not None else ""
+        conf_val = f" conf={breakout_data['breakout_confidence']:.2f}" if breakout_data["breakout_confidence"] is not None else ""
+        print(f"{player_name:30} {position} breakout_age={age_str:4} ({flag_str}){str_val}{conf_val}")
 
     write_json(args.context_path, updated_entries)
     logging.info("Updated %s with %d entries", args.context_path, len(updated_entries))

--- a/scripts/compute_rookie_alpha.py
+++ b/scripts/compute_rookie_alpha.py
@@ -870,6 +870,10 @@ def normalize_context_entry(context_row: dict[str, Any]) -> dict[str, Any]:
         "sophomore_total_yards": context_row.get("sophomore_total_yards"),
         "freshman_impact_flag": context_row.get("freshman_impact_flag"),
         "young_breakout_flag": context_row.get("young_breakout_flag"),
+        "breakout_strength": context_row.get("breakout_strength"),
+        "breakout_confidence": context_row.get("breakout_confidence"),
+        "breakout_age_rating_0_100": context_row.get("breakout_age_rating_0_100"),
+        "breakout_label": context_row.get("breakout_label"),
         "career_yards_per_route_run": context_row.get("career_yards_per_route_run"),
         "best_season_yprr": context_row.get("best_season_yprr"),
         "worst_season_yprr": context_row.get("worst_season_yprr"),
@@ -1379,6 +1383,16 @@ def main() -> None:
                 AGE_ADJUSTED_BLEND_WEIGHT * 100,
                 EXISTING_PRODUCTION_BLEND_WEIGHT * 100,
             )
+            # Merge BOAR fields from age-adjusted output into context entries
+            # so they flow through normalize_context_entry into the export.
+            boar_fields = ("breakout_strength", "breakout_confidence",
+                           "breakout_age_rating_0_100", "breakout_label")
+            for row in age_adjusted_rows:
+                pid = row.get("player_id", "")
+                if pid and pid in context_by_id:
+                    for field in boar_fields:
+                        if row.get(field) is not None:
+                            context_by_id[pid][field] = row[field]
         else:
             logging.warning("Age-adjusted input %s is not a list — skipping blend", age_adjusted_input)
     else:

--- a/tests/test_compute_age_adjusted_production.py
+++ b/tests/test_compute_age_adjusted_production.py
@@ -11,6 +11,8 @@ from scripts.compute_age_adjusted_production import (
     age_multiplier,
     normalize_scores,
     weighted_volume,
+    compute_boar,
+    boar_label,
 )
 
 
@@ -104,3 +106,76 @@ class WeightedVolumeTests(unittest.TestCase):
         young_raw = volume * age_multiplier(19)
         late_raw = volume * age_multiplier(21)
         self.assertGreater(young_raw, late_raw)
+
+
+class BoarComputationTests(unittest.TestCase):
+    def test_null_breakout_age_returns_none(self) -> None:
+        self.assertIsNone(compute_boar(None, "WR", 0.5, 0.9))
+
+    def test_young_wr_breakout_scores_high(self) -> None:
+        boar = compute_boar(19, "WR", 0.5, 1.0)
+        self.assertIsNotNone(boar)
+        self.assertGreater(boar, 80)
+
+    def test_late_wr_breakout_scores_low(self) -> None:
+        boar = compute_boar(22, "WR", 0.0, 1.0)
+        self.assertIsNotNone(boar)
+        self.assertLess(boar, 35)
+
+    def test_baseline_wr_breakout_near_50(self) -> None:
+        boar = compute_boar(21, "WR", 0.0, 1.0)
+        self.assertIsNotNone(boar)
+        self.assertAlmostEqual(boar, 50.0, delta=5.0)
+
+    def test_wr_higher_sensitivity_than_qb(self) -> None:
+        """WR should get more BOAR credit than QB for same breakout age."""
+        wr_boar = compute_boar(19, "WR", 0.5, 1.0)
+        qb_boar = compute_boar(19, "QB", 0.5, 1.0)
+        self.assertGreater(wr_boar, qb_boar)
+
+    def test_te_softer_than_wr(self) -> None:
+        """TE has slightly later baseline, so same age gives slightly higher BOAR."""
+        wr_boar = compute_boar(20, "WR", 0.5, 1.0)
+        te_boar = compute_boar(20, "TE", 0.5, 1.0)
+        self.assertGreater(te_boar, wr_boar)
+
+    def test_strength_bonus_raises_boar(self) -> None:
+        low = compute_boar(20, "WR", 0.0, 1.0)
+        high = compute_boar(20, "WR", 1.0, 1.0)
+        self.assertGreater(high, low)
+
+    def test_confidence_regresses_toward_50(self) -> None:
+        full = compute_boar(19, "WR", 0.5, 1.0)
+        partial = compute_boar(19, "WR", 0.5, 0.5)
+        # With low confidence, result moves toward 50
+        self.assertGreater(full, partial)
+        self.assertGreater(partial, 50.0)  # still above 50 for young breakout
+
+    def test_boar_clamped_0_100(self) -> None:
+        boar = compute_boar(17, "WR", 1.0, 1.0)  # extreme young
+        self.assertLessEqual(boar, 100.0)
+        self.assertGreaterEqual(boar, 0.0)
+
+    def test_boar_returns_float(self) -> None:
+        boar = compute_boar(20, "WR", 0.5, 0.9)
+        self.assertIsInstance(boar, float)
+
+
+class BoarLabelTests(unittest.TestCase):
+    def test_none_returns_none(self) -> None:
+        self.assertIsNone(boar_label(None))
+
+    def test_elite(self) -> None:
+        self.assertEqual(boar_label(85), "Elite breakout")
+
+    def test_early(self) -> None:
+        self.assertEqual(boar_label(65), "Early breakout")
+
+    def test_average(self) -> None:
+        self.assertEqual(boar_label(50), "Average breakout")
+
+    def test_late(self) -> None:
+        self.assertEqual(boar_label(35), "Late breakout")
+
+    def test_very_late(self) -> None:
+        self.assertEqual(boar_label(20), "Very late breakout")

--- a/tests/test_compute_breakout_age.py
+++ b/tests/test_compute_breakout_age.py
@@ -12,7 +12,11 @@ from scripts.compute_breakout_age import (
     update_context_entry,
     make_minimal_context_entry,
     BREAKOUT_THRESHOLDS,
+    SHARE_BREAKOUT_CRITERIA,
     YOUNG_BREAKOUT_MAX_AGE,
+    _check_share_breakout,
+    _compute_breakout_strength,
+    _compute_breakout_confidence,
 )
 
 
@@ -101,6 +105,13 @@ class ComputeBreakoutTests(unittest.TestCase):
             result = compute_breakout_for_player(player, args, roster_cache)
             self.assertEqual(result["breakout_age"], 19)  # sophomore = 17+2
             self.assertTrue(result["young_breakout_flag"])
+            # New fields
+            self.assertIsNotNone(result["breakout_strength"])
+            self.assertIsNotNone(result["breakout_confidence"])
+            self.assertGreaterEqual(result["breakout_strength"], 0.0)
+            self.assertLessEqual(result["breakout_strength"], 1.0)
+            self.assertGreaterEqual(result["breakout_confidence"], 0.7)
+            self.assertEqual(result["seasons_available"], 2)
 
     def test_wr_late_breakout_senior(self) -> None:
         with tempfile.TemporaryDirectory() as td:
@@ -128,6 +139,9 @@ class ComputeBreakoutTests(unittest.TestCase):
             result = compute_breakout_for_player(player, args, roster_cache)
             self.assertIsNone(result["breakout_age"])
             self.assertIsNone(result["young_breakout_flag"])
+            self.assertIsNone(result["breakout_strength"])
+            self.assertIsNone(result["breakout_confidence"])
+            self.assertEqual(result["seasons_available"], 2)
 
     def test_qb_breakout_threshold(self) -> None:
         with tempfile.TemporaryDirectory() as td:
@@ -162,21 +176,120 @@ class ComputeBreakoutTests(unittest.TestCase):
             self.assertIsNone(result["breakout_age"])
 
 
+class ShareBreakoutTests(unittest.TestCase):
+    def test_wr_target_share_triggers_breakout(self) -> None:
+        profile = {"targets": 30, "target_share": 0.25}
+        met, had = _check_share_breakout(profile, "WR")
+        self.assertTrue(met)
+        self.assertTrue(had)
+
+    def test_wr_below_share_does_not_trigger(self) -> None:
+        profile = {"targets": 30, "target_share": 0.10}
+        met, had = _check_share_breakout(profile, "WR")
+        self.assertFalse(met)
+        self.assertTrue(had)
+
+    def test_qb_has_no_share_criteria(self) -> None:
+        profile = {"pass_attempts": 200}
+        met, had = _check_share_breakout(profile, "QB")
+        self.assertFalse(met)
+        self.assertFalse(had)
+
+    def test_no_share_data_returns_false_false(self) -> None:
+        profile = {"targets": 60}
+        met, had = _check_share_breakout(profile, "WR")
+        self.assertFalse(met)
+        self.assertFalse(had)
+
+    def test_wr_share_breakout_with_low_volume(self) -> None:
+        """A WR with high target share but below raw volume threshold should
+        still qualify via share-based criteria."""
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            args = MagicMock()
+            args.wr_dir = tmp
+            args.qb_dir = tmp
+            args.rb_dir = tmp
+            # 40 targets below raw threshold (50), but high target share
+            path = tmp / "wr-share-wr_2025.json"
+            path.write_text(json.dumps({"targets": 40, "target_share": 0.22}))
+            roster_cache = {("Share U", 2025): [{"fullName": "Share WR", "year": 3}]}
+            player = {"player_id": "wr-share-wr", "player_name": "Share WR",
+                      "position": "WR", "school": "Share U", "class_year": 2026}
+            result = compute_breakout_for_player(player, args, roster_cache)
+            self.assertEqual(result["breakout_age"], 20)
+            self.assertTrue(result["young_breakout_flag"])
+
+
+class BreakoutStrengthTests(unittest.TestCase):
+    def test_at_threshold_strength_is_zero(self) -> None:
+        strength = _compute_breakout_strength(50, 50, {"targets": 50}, "WR")
+        self.assertAlmostEqual(strength, 0.0)
+
+    def test_double_threshold_strength_is_max(self) -> None:
+        strength = _compute_breakout_strength(100, 50, {"targets": 100}, "WR")
+        self.assertAlmostEqual(strength, 1.0)
+
+    def test_share_data_blends_with_volume(self) -> None:
+        profile = {"targets": 75, "target_share": 0.30}  # 0.30 vs 0.20 threshold
+        strength = _compute_breakout_strength(75, 50, profile, "WR")
+        # volume part: (75/50 - 1) = 0.5; share part: (0.30/0.20 - 1) = 0.5
+        self.assertAlmostEqual(strength, 0.5)
+
+
+class BreakoutConfidenceTests(unittest.TestCase):
+    def test_two_seasons_no_share(self) -> None:
+        conf = _compute_breakout_confidence(2, False)
+        self.assertAlmostEqual(conf, 0.90)
+
+    def test_one_season_no_share(self) -> None:
+        conf = _compute_breakout_confidence(1, False)
+        self.assertAlmostEqual(conf, 0.80)
+
+    def test_two_seasons_with_share(self) -> None:
+        conf = _compute_breakout_confidence(2, True)
+        self.assertAlmostEqual(conf, 1.00)
+
+    def test_confidence_range(self) -> None:
+        for s in range(3):
+            for share in (True, False):
+                conf = _compute_breakout_confidence(s, share)
+                self.assertGreaterEqual(conf, 0.7)
+                self.assertLessEqual(conf, 1.0)
+
+
 class UpdateContextEntryTests(unittest.TestCase):
+    def _breakout_data(self, age, flag, strength=0.5, confidence=0.9):
+        return {
+            "breakout_age": age,
+            "age_at_first_impact_season": age,
+            "young_breakout_flag": flag,
+            "breakout_strength": strength,
+            "breakout_confidence": confidence,
+            "seasons_available": 2,
+        }
+
     def test_young_breakout_adds_evidence_tag(self) -> None:
         existing = {"player_id": "wr-x", "evidence_tags": [], "context_flags": []}
-        result = update_context_entry(existing, {"breakout_age": 19, "age_at_first_impact_season": 19, "young_breakout_flag": True}, {})
+        result = update_context_entry(existing, self._breakout_data(19, True), {})
         self.assertIn("young_breakout", result["evidence_tags"])
 
     def test_late_breakout_does_not_add_tag(self) -> None:
         existing = {"player_id": "wr-x", "evidence_tags": [], "context_flags": []}
-        result = update_context_entry(existing, {"breakout_age": 22, "age_at_first_impact_season": 22, "young_breakout_flag": False}, {})
+        result = update_context_entry(existing, self._breakout_data(22, False), {})
         self.assertNotIn("young_breakout", result["evidence_tags"])
 
     def test_removes_stale_young_breakout_tag(self) -> None:
         existing = {"player_id": "wr-x", "evidence_tags": ["young_breakout"], "context_flags": []}
-        result = update_context_entry(existing, {"breakout_age": 22, "age_at_first_impact_season": 22, "young_breakout_flag": False}, {})
+        result = update_context_entry(existing, self._breakout_data(22, False), {})
         self.assertNotIn("young_breakout", result["evidence_tags"])
+
+    def test_new_fields_present(self) -> None:
+        existing = {"player_id": "wr-x", "evidence_tags": [], "context_flags": []}
+        result = update_context_entry(existing, self._breakout_data(19, True, 0.8, 1.0), {})
+        self.assertEqual(result["breakout_strength"], 0.8)
+        self.assertEqual(result["breakout_confidence"], 1.0)
+        self.assertEqual(result["seasons_available"], 2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Upgrade breakout age handling across the full pipeline:

Backend:
- Add position-aware breakout detection using target_share, receiving_yard_share,
  rush_share where available, with raw volume fallback for backward compatibility
- Compute breakout_strength (0-1) measuring how convincingly the threshold was
  exceeded, blending volume and share overshoot
- Compute breakout_confidence (0-1) reflecting data completeness — fewer seasons
  or missing share data lowers confidence rather than falsely implying no breakout
- Add BOAR (breakout_age_rating_0_100): position-aware composite metric with
  WR highest sensitivity, TE moderate, RB some, QB lightest treatment
- Add breakout_label for UI (Elite/Early/Average/Late/Very late breakout)
- Keep BOA as contextual production modifier, NOT a new standalone alpha pillar
- BOAR is for display and explainability, not duplicate heavy scoring weight

Frontend:
- Map breakoutAgeRating, breakoutStrength, breakoutConfidence, breakoutLabel
  through card data pipeline
- Add compact BOAR section on full player card with BOA + BOAR chips and label
- Add BOAR signal chip on board row (mobile + desktop) alongside CAP/RAS/PRD
- Color-coded by tier: elite (amber), early (teal), average (muted), late (dim)

Tests: 68 tests passing covering share detection, strength, confidence,
BOAR computation, position sensitivity, labels, and context entry merging.

https://claude.ai/code/session_01LpTpoFFLneTrP9NSqkNAnd