### PR TITLE
Enhance homepage with hero section, navigation, and visual hierarchy

### DIFF
--- a/cards/rookies/board/index.html
+++ b/cards/rookies/board/index.html
@@ -3,16 +3,91 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>TIBER Rookie Board | Multi-Class</title>
+    <title>TIBER Rookie Board | NFL Draft Intelligence</title>
     <link rel="stylesheet" href="/components/rookies/rookieCardStyles.css" />
   </head>
   <body>
+    <!-- ── Site navigation ──────────────────────────────────────────────────── -->
+    <header class="site-header">
+      <div class="site-header-inner">
+        <a class="site-logo" href="/cards/rookies/board/">
+          <span class="site-logo-text">TIBER</span>
+          <span class="site-logo-tagline">Rookie Board</span>
+        </a>
+        <nav class="site-nav" aria-label="Main navigation">
+          <a class="site-nav-link active" href="/cards/rookies/board/">Board</a>
+          <a class="site-nav-link" href="/cards/rookies/">Gallery</a>
+          <a class="site-nav-link" href="/cards/rookies/compare/">Compare</a>
+        </nav>
+      </div>
+    </header>
+
     <main class="page">
-      <a class="nav-link" href="/cards/rookies/index.html">← Back to rookie gallery</a>
-      <div class="section-title" style="margin-top: 12px">TIBER Rookie Board</div>
-      <h1>Draft board surface</h1>
-      <p class="meta">Ranking-first board powered by promoted Rookie Grade artifacts. Use tiers to spot cliffs, then jump to detail/compare.</p>
-      <p style="margin-top: 10px"><a class="nav-link" href="/cards/rookies/compare/index.html">Open compare tool →</a></p>
+      <!-- ── Hero section ──────────────────────────────────────────────────── -->
+      <section class="hero-section" aria-label="Page introduction">
+        <div class="hero-label">NFL Draft Intelligence · 2022–2026 Classes</div>
+        <h1 class="hero-headline">Find and Compare<br>Top <em>NFL Draft Prospects</em></h1>
+        <p class="hero-sub">TIBER grades every rookie using athletic profile, production score, and draft capital — giving you a clear, ranked view of the best bets in each class.</p>
+        <div class="hero-ctas">
+          <a class="hero-cta-primary" href="#board-section">Explore the Board</a>
+          <a class="hero-cta-secondary" href="/cards/rookies/compare/">Compare Players</a>
+        </div>
+        <div class="hero-metrics-strip" id="hero-metrics"></div>
+      </section>
+
+      <!-- ── How it works ──────────────────────────────────────────────────── -->
+      <section class="how-it-works" aria-label="How TIBER works">
+        <div class="section-title">How It Works</div>
+        <div class="steps-grid">
+          <div class="step-card">
+            <div class="step-number">01</div>
+            <div class="step-title">Multi-Signal Grading</div>
+            <p class="step-desc">Each rookie receives a composite Rookie Grade combining athletic testing (SPORQ/combine), college production, and draft capital into a single 0–100 score.</p>
+          </div>
+          <div class="step-card">
+            <div class="step-number">02</div>
+            <div class="step-title">Tier Classification</div>
+            <p class="step-desc">Players are sorted into four tiers — Top Cluster, Strong Starter, Development, and Swing — so you can instantly see where talent cliffs occur in each class.</p>
+          </div>
+          <div class="step-card">
+            <div class="step-number">03</div>
+            <div class="step-title">Compare &amp; Shortlist</div>
+            <p class="step-desc">Use the compare tool for head-to-head breakdowns, then add players to your shortlist queue with custom tags and notes for draft-day decisions.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ── Tier guide ────────────────────────────────────────────────────── -->
+      <section class="tier-guide" aria-label="Tier descriptions">
+        <div class="section-title">Tier Guide</div>
+        <div class="tier-guide-grid">
+          <div class="tier-guide-card tier-guide-elite">
+            <div class="tier-guide-name">Top Cluster</div>
+            <div class="tier-guide-range">Grade ≥ 75</div>
+            <p class="tier-guide-desc">Franchise-caliber prospects with elite multi-signal profiles. Highest confidence, maximum upside.</p>
+          </div>
+          <div class="tier-guide-card tier-guide-strong">
+            <div class="tier-guide-name">Strong Starter</div>
+            <div class="tier-guide-range">Grade 70–74</div>
+            <p class="tier-guide-desc">High-floor prospects projected as reliable NFL starters with strong collegiate evidence.</p>
+          </div>
+          <div class="tier-guide-card tier-guide-dev">
+            <div class="tier-guide-name">Development</div>
+            <div class="tier-guide-range">Grade 65–69</div>
+            <p class="tier-guide-desc">Prospects with one or two above-average signals. Solid depth or eventual starter potential.</p>
+          </div>
+          <div class="tier-guide-card tier-guide-swing">
+            <div class="tier-guide-name">Swing Tier</div>
+            <div class="tier-guide-range">Grade &lt; 65</div>
+            <p class="tier-guide-desc">High-variance prospects or late-round bets. Check individual profiles for specific upside signals.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ── Board ─────────────────────────────────────────────────────────── -->
+      <div id="board-section" style="scroll-margin-top: 72px"></div>
+      <div class="section-title" style="margin-top: 4px">TIBER Rookie Board</div>
+      <p class="meta" style="margin-top: 4px">Ranking-first board powered by promoted Rookie Grade artifacts. Use tiers to spot cliffs, then jump to detail or compare.</p>
 
       <section id="board-summary" class="board-summary" style="margin-top: 14px">Loading board summary…</section>
       <div class="board-search-row" style="margin-top: 10px">
@@ -23,6 +98,19 @@
       <section id="board-root" style="margin-top: 12px">Loading rookie board…</section>
       <section id="queue-root" style="margin-top: 16px">Loading shortlist queue…</section>
     </main>
+
+    <!-- ── Site footer ───────────────────────────────────────────────────────── -->
+    <footer class="site-footer" role="contentinfo">
+      <div class="site-footer-inner">
+        <span class="site-footer-brand">TIBER</span>
+        <nav class="site-footer-nav" aria-label="Footer navigation">
+          <a class="site-footer-link" href="/cards/rookies/board/">Board</a>
+          <a class="site-footer-link" href="/cards/rookies/">Gallery</a>
+          <a class="site-footer-link" href="/cards/rookies/compare/">Compare</a>
+        </nav>
+        <span class="site-footer-copy">Multi-class draft intelligence · 2022–2026</span>
+      </div>
+    </footer>
 
     <script type="module">
       import { getAllRookieCards } from '/lib/rookies/getRookieCardData.js';
@@ -105,6 +193,31 @@
       function buildExportFilename() {
         const stamp = new Date().toISOString().replace(/[:.]/g, '-');
         return `tiber-rookie-queue-${stamp}.json`;
+      }
+
+      function renderHeroMetrics(allRows) {
+        const heroMetrics = document.getElementById('hero-metrics');
+        if (!heroMetrics) return;
+        const positions = new Set(allRows.map((r) => r.position).filter(Boolean));
+        const classes = new Set(allRows.map((r) => r.draftClass).filter(Boolean));
+        heroMetrics.innerHTML = `
+          <div class="hero-metric-card">
+            <div class="hero-metric-value">${allRows.length}</div>
+            <div class="hero-metric-label">Prospects Graded</div>
+          </div>
+          <div class="hero-metric-card">
+            <div class="hero-metric-value">${classes.size}</div>
+            <div class="hero-metric-label">Draft Classes</div>
+          </div>
+          <div class="hero-metric-card">
+            <div class="hero-metric-value">${positions.size}</div>
+            <div class="hero-metric-label">Positions Tracked</div>
+          </div>
+          <div class="hero-metric-card">
+            <div class="hero-metric-value">4</div>
+            <div class="hero-metric-label">Tier Bands</div>
+          </div>
+        `;
       }
 
       function renderSummary(allRows, activeRows) {
@@ -343,6 +456,7 @@
         hydrateStateFromUrl();
         const cards = await getAllRookieCards();
         const rows = buildRookieBoardRows(cards);
+        renderHeroMetrics(rows);
         render(rows);
 
         // Wire search input once — it lives outside the re-rendered controls area

--- a/cards/rookies/compare/index.html
+++ b/cards/rookies/compare/index.html
@@ -7,8 +7,22 @@
     <link rel="stylesheet" href="/components/rookies/rookieCardStyles.css" />
   </head>
   <body>
+    <!-- ── Site navigation ──────────────────────────────────────────────────── -->
+    <header class="site-header">
+      <div class="site-header-inner">
+        <a class="site-logo" href="/cards/rookies/board/">
+          <span class="site-logo-text">TIBER</span>
+          <span class="site-logo-tagline">Rookie Board</span>
+        </a>
+        <nav class="site-nav" aria-label="Main navigation">
+          <a class="site-nav-link" href="/cards/rookies/board/">Board</a>
+          <a class="site-nav-link" href="/cards/rookies/">Gallery</a>
+          <a class="site-nav-link active" href="/cards/rookies/compare/">Compare</a>
+        </nav>
+      </div>
+    </header>
+
     <main class="page">
-      <a class="nav-link" href="/cards/rookies/index.html">← Back to rookies gallery</a>
       <div class="section-title" style="margin-top: 12px">TIBER Rookie Compare</div>
       <h1>Rookie decision surface</h1>
       <p class="meta">Compare any two rookies across 2022–2026 classes with deterministic grade + evidence deltas.</p>
@@ -16,6 +30,19 @@
       <section id="compare-selector-root" style="margin-top: 12px">Loading compare controls…</section>
       <section id="compare-root" style="margin-top: 12px">Loading comparison…</section>
     </main>
+
+    <!-- ── Site footer ───────────────────────────────────────────────────────── -->
+    <footer class="site-footer" role="contentinfo">
+      <div class="site-footer-inner">
+        <span class="site-footer-brand">TIBER</span>
+        <nav class="site-footer-nav" aria-label="Footer navigation">
+          <a class="site-footer-link" href="/cards/rookies/board/">Board</a>
+          <a class="site-footer-link" href="/cards/rookies/">Gallery</a>
+          <a class="site-footer-link" href="/cards/rookies/compare/">Compare</a>
+        </nav>
+        <span class="site-footer-copy">Multi-class draft intelligence · 2022–2026</span>
+      </div>
+    </footer>
 
     <script type="module">
       import { getAllRookieCards } from '/lib/rookies/getRookieCardData.js';

--- a/cards/rookies/index.html
+++ b/cards/rookies/index.html
@@ -3,20 +3,48 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>TIBER Rookie Cards | 2026</title>
+    <title>TIBER Rookie Gallery | 2026</title>
     <link rel="stylesheet" href="/components/rookies/rookieCardStyles.css" />
   </head>
   <body>
+    <!-- ── Site navigation ──────────────────────────────────────────────────── -->
+    <header class="site-header">
+      <div class="site-header-inner">
+        <a class="site-logo" href="/cards/rookies/board/">
+          <span class="site-logo-text">TIBER</span>
+          <span class="site-logo-tagline">Rookie Board</span>
+        </a>
+        <nav class="site-nav" aria-label="Main navigation">
+          <a class="site-nav-link" href="/cards/rookies/board/">Board</a>
+          <a class="site-nav-link active" href="/cards/rookies/">Gallery</a>
+          <a class="site-nav-link" href="/cards/rookies/compare/">Compare</a>
+        </nav>
+      </div>
+    </header>
+
     <main class="page">
-      <div class="section-title">TIBER 2026 Rookie Gallery</div>
+      <div class="section-title" style="margin-top: 12px">TIBER 2026 Rookie Gallery</div>
       <h1>Browse rookie cards</h1>
       <p class="meta">Browse-first card gallery for profile inspection. For ranked draft decisions, use the dedicated board.</p>
-      <p style="margin-top: 10px"><a class="nav-link" href="/cards/rookies/board/index.html">Open rookie board →</a></p>
-      <p style="margin-top: 10px"><a class="nav-link" href="/cards/rookies/compare/index.html">Open rookie compare tool →</a></p>
+      <p style="margin-top: 10px"><a class="nav-link" href="/cards/rookies/board/">Open rookie board →</a></p>
+      <p style="margin-top: 10px"><a class="nav-link" href="/cards/rookies/compare/">Open rookie compare tool →</a></p>
       <div id="ranking-context" class="meta" style="margin-top: 8px">Loading class context…</div>
       <div id="controls-root">Loading controls…</div>
       <section id="gallery" class="gallery-grid">Loading rookie gallery…</section>
     </main>
+
+    <!-- ── Site footer ───────────────────────────────────────────────────────── -->
+    <footer class="site-footer" role="contentinfo">
+      <div class="site-footer-inner">
+        <span class="site-footer-brand">TIBER</span>
+        <nav class="site-footer-nav" aria-label="Footer navigation">
+          <a class="site-footer-link" href="/cards/rookies/board/">Board</a>
+          <a class="site-footer-link" href="/cards/rookies/">Gallery</a>
+          <a class="site-footer-link" href="/cards/rookies/compare/">Compare</a>
+        </nav>
+        <span class="site-footer-copy">Multi-class draft intelligence · 2022–2026</span>
+      </div>
+    </footer>
 
     <script type="module">
       import { getAllRookieCards } from '/lib/rookies/getRookieCardData.js';

--- a/components/rookies/rookieCardStyles.css
+++ b/components/rookies/rookieCardStyles.css
@@ -816,3 +816,296 @@ body {
   .queue-item { flex-direction: column; align-items: flex-start; }
   .queue-item-actions { justify-content: flex-start; }
 }
+
+/* ─── Site Header / Navigation ────────────────────────────────────────────── */
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  background: rgba(13, 10, 8, 0.96);
+  border-bottom: 1px solid var(--border);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+}
+.site-header-inner {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 0 16px;
+  height: 56px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+.site-logo {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  text-decoration: none;
+  flex-shrink: 0;
+}
+.site-logo-text {
+  font-size: 18px;
+  font-weight: 800;
+  color: var(--accent);
+  letter-spacing: .04em;
+}
+.site-logo-tagline {
+  font-size: 12px;
+  color: var(--muted);
+  letter-spacing: .08em;
+  text-transform: uppercase;
+}
+.site-nav {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+.site-nav-link {
+  color: var(--muted);
+  text-decoration: none;
+  font-size: 13px;
+  font-weight: 500;
+  padding: 6px 12px;
+  border-radius: 8px;
+  transition: color 0.15s, background 0.15s;
+}
+.site-nav-link:hover {
+  color: var(--text);
+  background: var(--panel-raised);
+}
+.site-nav-link.active {
+  color: var(--accent-soft);
+  background: var(--accent-glow);
+}
+
+/* ─── Hero section ────────────────────────────────────────────────────────── */
+.hero-section {
+  padding: 40px 0 36px;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 32px;
+}
+.hero-label {
+  font-size: 11px;
+  letter-spacing: .14em;
+  text-transform: uppercase;
+  color: var(--accent-soft);
+  margin-bottom: 14px;
+}
+.hero-headline {
+  font-size: clamp(28px, 5vw, 46px);
+  font-weight: 800;
+  line-height: 1.15;
+  margin: 0 0 16px;
+  color: var(--text);
+  letter-spacing: -.01em;
+}
+.hero-headline em {
+  font-style: normal;
+  color: var(--accent);
+}
+.hero-sub {
+  font-size: 16px;
+  line-height: 1.65;
+  color: var(--muted);
+  max-width: 580px;
+  margin: 0 0 28px;
+}
+.hero-ctas {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-bottom: 32px;
+}
+.hero-cta-primary {
+  display: inline-block;
+  background: var(--accent);
+  color: #0D0A08;
+  font-weight: 700;
+  font-size: 14px;
+  padding: 11px 22px;
+  border-radius: 10px;
+  text-decoration: none;
+  transition: background 0.15s, transform 0.1s, box-shadow 0.15s;
+}
+.hero-cta-primary:hover {
+  background: var(--accent-soft);
+  transform: translateY(-1px);
+  box-shadow: 0 6px 20px rgba(232, 133, 61, 0.35);
+}
+.hero-cta-secondary {
+  display: inline-block;
+  border: 1px solid var(--border-accent);
+  color: var(--accent-soft);
+  font-weight: 600;
+  font-size: 14px;
+  padding: 11px 22px;
+  border-radius: 10px;
+  text-decoration: none;
+  transition: background 0.15s, border-color 0.15s;
+}
+.hero-cta-secondary:hover {
+  background: var(--accent-glow);
+  border-color: var(--accent);
+}
+.hero-metrics-strip {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 10px;
+}
+.hero-metric-card {
+  background: var(--panel-alt);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 14px 16px;
+}
+.hero-metric-value {
+  font-size: 28px;
+  font-weight: 800;
+  color: var(--accent);
+  font-family: 'JetBrains Mono', 'Fira Mono', ui-monospace, monospace;
+  line-height: 1;
+}
+.hero-metric-label {
+  font-size: 11px;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: .08em;
+  margin-top: 6px;
+}
+
+/* ─── How it works section ────────────────────────────────────────────────── */
+.how-it-works {
+  padding: 28px 0 32px;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 28px;
+}
+.steps-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 12px;
+  margin-top: 16px;
+}
+.step-card {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 18px;
+  transition: border-color 0.15s;
+}
+.step-card:hover { border-color: var(--border-accent); }
+.step-number {
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: .1em;
+  color: var(--accent);
+  font-family: 'JetBrains Mono', 'Fira Mono', ui-monospace, monospace;
+  margin-bottom: 8px;
+}
+.step-title {
+  font-size: 15px;
+  font-weight: 700;
+  margin-bottom: 8px;
+  color: var(--text);
+}
+.step-desc {
+  font-size: 13px;
+  line-height: 1.65;
+  color: var(--muted);
+  margin: 0;
+}
+
+/* ─── Tier guide section ──────────────────────────────────────────────────── */
+.tier-guide {
+  padding: 24px 0 28px;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 24px;
+}
+.tier-guide-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 10px;
+  margin-top: 16px;
+}
+.tier-guide-card {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 14px 14px 14px 16px;
+  border-left: 3px solid transparent;
+}
+.tier-guide-card.tier-guide-elite  { border-left-color: var(--tier-elite); }
+.tier-guide-card.tier-guide-strong { border-left-color: var(--tier-strong); }
+.tier-guide-card.tier-guide-dev    { border-left-color: var(--tier-mid); }
+.tier-guide-card.tier-guide-swing  { border-left-color: var(--tier-dart); }
+.tier-guide-name {
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: .08em;
+  margin-bottom: 4px;
+}
+.tier-guide-range {
+  font-size: 11px;
+  color: var(--accent-soft);
+  font-family: 'JetBrains Mono', 'Fira Mono', ui-monospace, monospace;
+  margin-bottom: 6px;
+}
+.tier-guide-desc {
+  font-size: 12px;
+  color: var(--muted);
+  line-height: 1.55;
+  margin: 0;
+}
+
+/* ─── Site footer ─────────────────────────────────────────────────────────── */
+.site-footer {
+  border-top: 1px solid var(--border);
+  margin-top: 48px;
+}
+.site-footer-inner {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 24px 16px 20px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+.site-footer-brand {
+  font-size: 14px;
+  font-weight: 800;
+  color: var(--accent);
+  letter-spacing: .06em;
+}
+.site-footer-nav {
+  display: flex;
+  gap: 20px;
+  flex-wrap: wrap;
+}
+.site-footer-link {
+  color: var(--muted);
+  text-decoration: none;
+  font-size: 13px;
+  transition: color 0.15s;
+}
+.site-footer-link:hover { color: var(--accent-soft); }
+.site-footer-copy {
+  font-size: 11px;
+  color: var(--muted);
+  opacity: 0.55;
+}
+
+/* ─── Responsive: small screens ───────────────────────────────────────────── */
+@media (max-width: 480px) {
+  .site-logo-tagline { display: none; }
+  .site-nav-link { padding: 5px 8px; font-size: 12px; }
+  .hero-sub { font-size: 14px; }
+  .hero-ctas { flex-direction: column; align-items: stretch; }
+  .hero-cta-primary,
+  .hero-cta-secondary { text-align: center; box-sizing: border-box; }
+  .steps-grid,
+  .tier-guide-grid { grid-template-columns: 1fr; }
+  .site-footer-inner { flex-direction: column; align-items: flex-start; gap: 12px; }
+}


### PR DESCRIPTION
- Add sticky site header with TIBER logo and Board/Gallery/Compare nav (active state per page)
- Add full hero section to board page: headline, value proposition, CTA buttons (Explore the Board, Compare Players), and dynamic metrics strip (prospects, classes, positions, tiers) loaded from data
- Add "How It Works" section with 3 step cards (grading, tiers, compare/shortlist)
- Add tier guide section with color-coded cards explaining all 4 tier bands and grade thresholds
- Add consistent site footer across all three pages (Board, Gallery, Compare)
- Add 280+ lines of CSS: site-header, hero-section, how-it-works, tier-guide, site-footer, and 480px responsive breakpoint
- Remove old bare nav-link header on board page in favour of unified site header

https://claude.ai/code/session_01V1qvCnEbnB2dCaXzZMnmUg