### PR TITLE
Add `--skip-qb` option to fetch_missing_stats backfill flow

### DIFF
--- a/scripts/fetch_missing_stats.py
+++ b/scripts/fetch_missing_stats.py
@@ -10,6 +10,7 @@ Usage:
   python3 scripts/fetch_missing_stats.py --season 2025
   python3 scripts/fetch_missing_stats.py --season 2026
   python3 scripts/fetch_missing_stats.py --season 2025 --season 2026
+  python3 scripts/fetch_missing_stats.py --season 2025 --skip-qb
   python3 scripts/fetch_missing_stats.py --all
 
 Set CFBD_API_KEY env var for higher rate limits (optional but recommended).
@@ -283,7 +284,7 @@ def build_stat_line(player: dict, cfbd_year: int,
 
 # ── main ──────────────────────────────────────────────────────────────────────
 
-def process_season(season: int, dry_run: bool = False) -> None:
+def process_season(season: int, dry_run: bool = False, skip_qb: bool = False) -> None:
     cfbd_year = season - 1  # 2026 rookies → 2025 college season
     prod_path = DATA_PROCESSED / f"{season}_college_production.json"
     stats_path = DATA_PROCESSED / f"{season}_player_stats.json"
@@ -300,6 +301,14 @@ def process_season(season: int, dry_run: bool = False) -> None:
     if not targets:
         print(f"{season}: all {len(all_players)} players already have stats — nothing to do.")
         return
+
+    if skip_qb:
+        qb_targets = [p for p in targets if str(p.get("position", "")).upper() == "QB"]
+        print(f"{season}: Skipping QBs due to --skip-qb flag ({len(qb_targets)} excluded).")
+        targets = [p for p in targets if str(p.get("position", "")).upper() != "QB"]
+        if not targets:
+            print(f"{season}: no non-QB players remain after filtering — nothing to do.")
+            return
 
     print(f"{season}: fetching stats for {len(targets)} players (cfbd year={cfbd_year}) …")
 
@@ -364,6 +373,8 @@ def parse_args() -> argparse.Namespace:
                         metavar="YEAR", help="Draft class year (e.g. 2025). Repeatable.")
     parser.add_argument("--all", action="store_true", help="Process 2022–2026")
     parser.add_argument("--dry-run", action="store_true", help="Print targets without fetching")
+    parser.add_argument("--skip-qb", action="store_true",
+                        help="Exclude QB targets before category detection/fetching")
     return parser.parse_args()
 
 
@@ -381,7 +392,7 @@ def main() -> int:
         return 1
 
     for season in seasons:
-        process_season(season, dry_run=args.dry_run)
+        process_season(season, dry_run=args.dry_run, skip_qb=args.skip_qb)
 
     return 0
 


### PR DESCRIPTION
### Motivation
- Prevent season-wide CFBD `passing` pulls for QBs from blocking backfill of non-QB players when CFBD rate-limits (429). 
- Provide operators a simple switch to exclude QBs so RB/WR/TE backfills can proceed even if QB data is temporarily unavailable.

### Description
- Add a discoverable `--skip-qb` CLI flag in the script docstring and `argparse` help (`--skip-qb`), and wire it through `main()` into `process_season`.
- Extend `process_season` signature to accept `skip_qb: bool` and filter out players with `position.upper() == "QB"` from `targets` before any dry-run output or category detection.
- Print an explicit operator-facing message when filtering is applied (`Skipping QBs due to --skip-qb flag (<n> excluded).`).
- Leave the existing category-detection/fetch logic unchanged so `passing` is not requested when no QBs remain and `rushing`/`receiving` still follow the original position-based rules.

### Testing
- Ran `python3 scripts/fetch_missing_stats.py --season 2025 --dry-run --skip-qb` which succeeded and showed only non-QB targets and the skipped-QB message.
- Ran `python3 scripts/fetch_missing_stats.py --season 2025 --dry-run` which succeeded and showed the full target list including QBs, preserving default behavior.
- Ran `python3 scripts/fetch_missing_stats.py --help` which succeeded and lists the new `--skip-qb` flag.
- Ran `python3 scripts/fetch_missing_stats.py --season 2025 --skip-qb` which reached CFBD but failed due to an environment/network tunnel `403 Forbidden`; the run confirmed that no `passing` fetch was attempted before the failure (behavior observed as expected).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd9ca189f8833298065bc89927fdbf)