### PR TITLE
Adjust CFBD 429 handling for first-request throttling

### DIFF
--- a/scripts/compute_production_scores.py
+++ b/scripts/compute_production_scores.py
@@ -7,6 +7,7 @@ import argparse
 import json
 import logging
 import os
+import random
 import re
 import time
 from dataclasses import dataclass
@@ -135,7 +136,12 @@ def fetch_cfbd_category(year: int, category: str, max_retries: int = 5) -> list[
                 retry_after_seconds: int | None = None
                 if retry_after_header and retry_after_header.isdigit():
                     retry_after_seconds = int(retry_after_header)
-                wait = retry_after_seconds if retry_after_seconds is not None else 10 * (2 ** attempt)  # 10s, 20s, 40s, 80s, 160s
+                if retry_after_seconds is not None:
+                    wait = retry_after_seconds
+                else:
+                    base_wait = max(30, 10 * (2 ** attempt))
+                    jitter = random.randint(1, 5)
+                    wait = base_wait + jitter
                 logging.warning(
                     "Rate limited (429) for %s year=%s attempt %d — retrying in %ds",
                     category, year, attempt + 1, wait,
@@ -586,6 +592,7 @@ def main() -> int:
         raise SystemExit(f"Seed input must be a JSON array: {args.seed_input}")
 
     cfbd_year = args.season - 1
+    time.sleep(5)
     passing_rows = fetch_cfbd_category(cfbd_year, "passing")
     time.sleep(3)
     rushing_rows = fetch_cfbd_category(cfbd_year, "rushing")


### PR DESCRIPTION
### Motivation
- CFBD can aggressively throttle initial requests from the same key/IP, causing repeated runs to fail or collide. 
- Honor explicit `Retry-After` values when provided so upstream guidance is followed exactly. 
- Reduce synchronized retries across repeated runs by increasing fallback backoff and adding small random jitter.

### Description
- Added `import random` and updated `fetch_cfbd_category()` to continue honoring numeric `Retry-After` headers when present. 
- When `Retry-After` is absent, the fallback wait is now `max(30, 10 * (2 ** attempt))` plus a `random.randint(1, 5)` second jitter. 
- Inserted a `time.sleep(5)` pause in `main()` before the first CFBD fetch for the `passing` category to ease first-request throttling. 
- No scoring formulas, output schema, or downstream transforms were changed; only request pacing and retry timing were adjusted in `scripts/compute_production_scores.py`.

### Testing
- `python -m py_compile scripts/compute_production_scores.py` ran successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69debb710b348332931c2c00a1dc6ed4)