### PR TITLE
PR125: strengthen rookie ML lane diagnostics, missingness, and position visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,10 +179,29 @@ Default outputs are written to `exports/promoted/rookie-ml-lane/`:
 
 - `historical_labeled_dataset.json` / `.csv`
 - `feature_table.json`
+- `dataset_diagnostics.json`
+- `feature_coverage_report.json`
+- `feature_importance_report.json`
 - `evaluation_report.json`
 - `heldout_probabilities.json` / `.csv`
 
 The evaluator uses time-aware draft-class splits, logistic baselines, required feature-subset baselines, and non-ML baseline comparisons.
+
+### Trustworthiness inspection checklist (ML lane)
+
+Use the artifacts above to decide whether the lane is trustworthy enough to keep iterating:
+
+- **Historical data volume:** open `dataset_diagnostics.json` for total labeled rows, rows by position/year, split counts, and hit rates.
+- **Feature completeness:** open `feature_coverage_report.json` for per-feature null/non-null counts plus coverage by position and draft year.
+- **Thin-data warnings:** `evaluation_report.json` now includes `dataset_warnings` and `missingness_summary` (including explicit warnings for sub-60% feature coverage).
+- **Position stability:** check `test_by_position` metrics (WR/RB/TE/QB) under each model and non-ML baseline in `evaluation_report.json`.
+- **Draft-capital dominance:** inspect `draft_capital_dominance_check` in `evaluation_report.json` to see test PR-AUC deltas between `logistic_full` and:
+  - `draft_capital_only`
+  - `draft_capital_plus_production`
+  - `deterministic_grade_only`
+- **Coefficient interpretability:** use `feature_importance_report.json` for coefficient sign, absolute magnitude ranking, and normalized importance ordering for `logistic_full`.
+
+If warnings indicate very sparse position slices, weak feature coverage, or tiny pre-holdout history, treat the ML lane as directional diagnostics rather than production-grade forecasting.
 
 ## Run standalone static lab locally
 

--- a/exports/promoted/rookie-ml-lane/dataset_diagnostics.json
+++ b/exports/promoted/rookie-ml-lane/dataset_diagnostics.json
@@ -1,0 +1,64 @@
+{
+  "total_labeled_rows": 37,
+  "labeled_row_count_by_position": {
+    "QB": 2,
+    "WR": 25,
+    "TE": 10
+  },
+  "labeled_row_count_by_draft_year": {
+    "2018": 7,
+    "2019": 7,
+    "2020": 8,
+    "2021": 7,
+    "2022": 7,
+    "2023": 1
+  },
+  "labeled_row_count_by_position_draft_year": {
+    "QB|2018": 1,
+    "QB|2019": 1,
+    "WR|2018": 4,
+    "WR|2020": 7,
+    "WR|2021": 5,
+    "WR|2022": 5,
+    "WR|2019": 4,
+    "TE|2018": 2,
+    "TE|2019": 2,
+    "TE|2020": 1,
+    "TE|2021": 2,
+    "TE|2022": 2,
+    "TE|2023": 1
+  },
+  "split_row_counts": {
+    "train": 29,
+    "validation": 7,
+    "test": 1
+  },
+  "split_row_counts_by_position": {
+    "train": {
+      "QB": 2,
+      "WR": 20,
+      "TE": 7
+    },
+    "validation": {
+      "WR": 5,
+      "TE": 2
+    },
+    "test": {
+      "TE": 1
+    }
+  },
+  "target_hit_rate_overall": 0.621622,
+  "target_hit_rate_by_position": {
+    "QB": 0.5,
+    "TE": 0.5,
+    "WR": 0.68
+  },
+  "target_hit_rate_by_draft_year": {
+    "2018": 0.714286,
+    "2019": 0.571429,
+    "2020": 0.625,
+    "2021": 0.571429,
+    "2022": 0.571429,
+    "2023": 1.0
+  }
+}

--- a/exports/promoted/rookie-ml-lane/evaluation_report.json
+++ b/exports/promoted/rookie-ml-lane/evaluation_report.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-04-16T01:54:22.691568+00:00",
+  "generated_at": "2026-04-16T02:09:19.777265+00:00",
   "lane": "parallel_ml_evaluation_only",
   "split_strategy": "time_aware_by_draft_class",
   "split_years": {
@@ -18,6 +18,110 @@
   },
   "n_labeled_rows": 37,
   "n_test_rows": 1,
+  "dataset_warnings": [
+    "Test slice for WR is sparse (n=0); position metrics may be unstable.",
+    "Test slice for RB is sparse (n=0); position metrics may be unstable.",
+    "Test slice for TE is sparse (n=1); position metrics may be unstable.",
+    "Test slice for QB is sparse (n=0); position metrics may be unstable.",
+    "Weak feature coverage below threshold (60%): age_at_draft, breakout_age, deterministic_grade_0_100, early_declare_flag, production_0_100.",
+    "Deterministic grade is unavailable for many historical rows."
+  ],
+  "missingness_summary": {
+    "coverage_threshold": 0.6,
+    "weak_features_overall": [
+      {
+        "feature": "age_at_draft",
+        "coverage_pct_overall": 0.0
+      },
+      {
+        "feature": "breakout_age",
+        "coverage_pct_overall": 0.0
+      },
+      {
+        "feature": "production_0_100",
+        "coverage_pct_overall": 0.405405
+      },
+      {
+        "feature": "early_declare_flag",
+        "coverage_pct_overall": 0.0
+      },
+      {
+        "feature": "deterministic_grade_0_100",
+        "coverage_pct_overall": 0.0
+      }
+    ],
+    "thin_positions": {
+      "QB": [
+        "age_at_draft",
+        "breakout_age",
+        "deterministic_grade_0_100",
+        "early_declare_flag"
+      ],
+      "TE": [
+        "age_at_draft",
+        "breakout_age",
+        "deterministic_grade_0_100",
+        "early_declare_flag",
+        "production_0_100"
+      ],
+      "WR": [
+        "age_at_draft",
+        "breakout_age",
+        "deterministic_grade_0_100",
+        "early_declare_flag",
+        "production_0_100"
+      ]
+    },
+    "thin_draft_years": {
+      "2018": [
+        "age_at_draft",
+        "breakout_age",
+        "deterministic_grade_0_100",
+        "early_declare_flag",
+        "production_0_100"
+      ],
+      "2019": [
+        "age_at_draft",
+        "breakout_age",
+        "deterministic_grade_0_100",
+        "early_declare_flag",
+        "production_0_100"
+      ],
+      "2020": [
+        "age_at_draft",
+        "breakout_age",
+        "deterministic_grade_0_100",
+        "early_declare_flag"
+      ],
+      "2021": [
+        "age_at_draft",
+        "breakout_age",
+        "deterministic_grade_0_100",
+        "early_declare_flag",
+        "production_0_100"
+      ],
+      "2022": [
+        "age_at_draft",
+        "breakout_age",
+        "deterministic_grade_0_100",
+        "early_declare_flag"
+      ],
+      "2023": [
+        "age_at_draft",
+        "breakout_age",
+        "deterministic_grade_0_100",
+        "early_declare_flag",
+        "production_0_100"
+      ]
+    },
+    "warnings": [
+      "age_at_draft coverage below 60% (overall=0.0)",
+      "breakout_age coverage below 60% (overall=0.0)",
+      "early_declare_flag coverage below 60% (overall=0.0)",
+      "deterministic_grade_0_100 coverage below 60% (overall=0.0)",
+      "production_0_100 coverage below 60% (overall=0.405405)"
+    ]
+  },
   "ml_models": {
     "draft_capital_only": {
       "validation": {
@@ -37,6 +141,44 @@
         "precision_at_k": 1.0,
         "n": 1,
         "positives": 1
+      },
+      "test_by_position": {
+        "WR": {
+          "roc_auc": null,
+          "pr_auc": null,
+          "log_loss": null,
+          "calibration_mae": null,
+          "precision_at_k": null,
+          "n": 0,
+          "positives": 0
+        },
+        "RB": {
+          "roc_auc": null,
+          "pr_auc": null,
+          "log_loss": null,
+          "calibration_mae": null,
+          "precision_at_k": null,
+          "n": 0,
+          "positives": 0
+        },
+        "TE": {
+          "roc_auc": null,
+          "pr_auc": 1.0,
+          "log_loss": 0.47579382003318166,
+          "calibration_mae": 0.3786084124624647,
+          "precision_at_k": 1.0,
+          "n": 1,
+          "positives": 1
+        },
+        "QB": {
+          "roc_auc": null,
+          "pr_auc": null,
+          "log_loss": null,
+          "calibration_mae": null,
+          "precision_at_k": null,
+          "n": 0,
+          "positives": 0
+        }
       },
       "features": [
         "draft_capital_proxy_0_100"
@@ -65,6 +207,44 @@
         "n": 1,
         "positives": 1
       },
+      "test_by_position": {
+        "WR": {
+          "roc_auc": null,
+          "pr_auc": null,
+          "log_loss": null,
+          "calibration_mae": null,
+          "precision_at_k": null,
+          "n": 0,
+          "positives": 0
+        },
+        "RB": {
+          "roc_auc": null,
+          "pr_auc": null,
+          "log_loss": null,
+          "calibration_mae": null,
+          "precision_at_k": null,
+          "n": 0,
+          "positives": 0
+        },
+        "TE": {
+          "roc_auc": null,
+          "pr_auc": 1.0,
+          "log_loss": 0.47579382003318166,
+          "calibration_mae": 0.3786084124624647,
+          "precision_at_k": 1.0,
+          "n": 1,
+          "positives": 1
+        },
+        "QB": {
+          "roc_auc": null,
+          "pr_auc": null,
+          "log_loss": null,
+          "calibration_mae": null,
+          "precision_at_k": null,
+          "n": 0,
+          "positives": 0
+        }
+      },
       "features": [
         "draft_capital_proxy_0_100"
       ],
@@ -91,6 +271,44 @@
         "precision_at_k": 1.0,
         "n": 1,
         "positives": 1
+      },
+      "test_by_position": {
+        "WR": {
+          "roc_auc": null,
+          "pr_auc": null,
+          "log_loss": null,
+          "calibration_mae": null,
+          "precision_at_k": null,
+          "n": 0,
+          "positives": 0
+        },
+        "RB": {
+          "roc_auc": null,
+          "pr_auc": null,
+          "log_loss": null,
+          "calibration_mae": null,
+          "precision_at_k": null,
+          "n": 0,
+          "positives": 0
+        },
+        "TE": {
+          "roc_auc": null,
+          "pr_auc": 1.0,
+          "log_loss": 0.4776796109744288,
+          "calibration_mae": 0.3797791228847148,
+          "precision_at_k": 1.0,
+          "n": 1,
+          "positives": 1
+        },
+        "QB": {
+          "roc_auc": null,
+          "pr_auc": null,
+          "log_loss": null,
+          "calibration_mae": null,
+          "precision_at_k": null,
+          "n": 0,
+          "positives": 0
+        }
       },
       "features": [
         "draft_capital_proxy_0_100",
@@ -121,6 +339,44 @@
         "n": 1,
         "positives": 1
       },
+      "test_by_position": {
+        "WR": {
+          "roc_auc": null,
+          "pr_auc": null,
+          "log_loss": null,
+          "calibration_mae": null,
+          "precision_at_k": null,
+          "n": 0,
+          "positives": 0
+        },
+        "RB": {
+          "roc_auc": null,
+          "pr_auc": null,
+          "log_loss": null,
+          "calibration_mae": null,
+          "precision_at_k": null,
+          "n": 0,
+          "positives": 0
+        },
+        "TE": {
+          "roc_auc": null,
+          "pr_auc": 1.0,
+          "log_loss": 0.6223479801146581,
+          "calibration_mae": 0.46331716356077424,
+          "precision_at_k": 1.0,
+          "n": 1,
+          "positives": 1
+        },
+        "QB": {
+          "roc_auc": null,
+          "pr_auc": null,
+          "log_loss": null,
+          "calibration_mae": null,
+          "precision_at_k": null,
+          "n": 0,
+          "positives": 0
+        }
+      },
       "features": [
         "draft_capital_proxy_0_100",
         "production_0_100",
@@ -140,22 +396,110 @@
   },
   "non_ml_baselines": {
     "draft_capital_rescaled": {
-      "roc_auc": null,
-      "pr_auc": 1.0,
-      "log_loss": 0.2744368457017603,
-      "calibration_mae": 0.24,
-      "precision_at_k": 1.0,
-      "n": 1,
-      "positives": 1
+      "test": {
+        "roc_auc": null,
+        "pr_auc": 1.0,
+        "log_loss": 0.2744368457017603,
+        "calibration_mae": 0.24,
+        "precision_at_k": 1.0,
+        "n": 1,
+        "positives": 1
+      },
+      "test_by_position": {
+        "WR": {
+          "roc_auc": null,
+          "pr_auc": null,
+          "log_loss": null,
+          "calibration_mae": null,
+          "precision_at_k": null,
+          "n": 0,
+          "positives": 0
+        },
+        "RB": {
+          "roc_auc": null,
+          "pr_auc": null,
+          "log_loss": null,
+          "calibration_mae": null,
+          "precision_at_k": null,
+          "n": 0,
+          "positives": 0
+        },
+        "TE": {
+          "roc_auc": null,
+          "pr_auc": 1.0,
+          "log_loss": 0.2744368457017603,
+          "calibration_mae": 0.24,
+          "precision_at_k": 1.0,
+          "n": 1,
+          "positives": 1
+        },
+        "QB": {
+          "roc_auc": null,
+          "pr_auc": null,
+          "log_loss": null,
+          "calibration_mae": null,
+          "precision_at_k": null,
+          "n": 0,
+          "positives": 0
+        }
+      }
     },
     "deterministic_grade_rescaled": {
-      "roc_auc": null,
-      "pr_auc": 1.0,
-      "log_loss": 0.6931471805599453,
-      "calibration_mae": 0.5,
-      "precision_at_k": 1.0,
-      "n": 1,
-      "positives": 1
+      "test": {
+        "roc_auc": null,
+        "pr_auc": 1.0,
+        "log_loss": 0.6931471805599453,
+        "calibration_mae": 0.5,
+        "precision_at_k": 1.0,
+        "n": 1,
+        "positives": 1
+      },
+      "test_by_position": {
+        "WR": {
+          "roc_auc": null,
+          "pr_auc": null,
+          "log_loss": null,
+          "calibration_mae": null,
+          "precision_at_k": null,
+          "n": 0,
+          "positives": 0
+        },
+        "RB": {
+          "roc_auc": null,
+          "pr_auc": null,
+          "log_loss": null,
+          "calibration_mae": null,
+          "precision_at_k": null,
+          "n": 0,
+          "positives": 0
+        },
+        "TE": {
+          "roc_auc": null,
+          "pr_auc": 1.0,
+          "log_loss": 0.6931471805599453,
+          "calibration_mae": 0.5,
+          "precision_at_k": 1.0,
+          "n": 1,
+          "positives": 1
+        },
+        "QB": {
+          "roc_auc": null,
+          "pr_auc": null,
+          "log_loss": null,
+          "calibration_mae": null,
+          "precision_at_k": null,
+          "n": 0,
+          "positives": 0
+        }
+      }
+    }
+  },
+  "draft_capital_dominance_check": {
+    "draft_capital_only": {
+      "test_pr_auc_delta_vs_logistic_full": 0.0
+    },
+    "draft_capital_plus_production": {
+      "test_pr_auc_delta_vs_logistic_full": 0.0
     }
   },
   "winning_model_by_test_pr_auc": "draft_capital_only"

--- a/exports/promoted/rookie-ml-lane/feature_coverage_report.json
+++ b/exports/promoted/rookie-ml-lane/feature_coverage_report.json
@@ -1,0 +1,168 @@
+{
+  "total_rows": 37,
+  "weak_coverage_threshold": 0.6,
+  "features": {
+    "draft_capital_proxy_0_100": {
+      "non_null_count": 37,
+      "null_count": 0,
+      "coverage_pct_overall": 1.0,
+      "coverage_pct_by_position": {
+        "QB": 1.0,
+        "TE": 1.0,
+        "WR": 1.0
+      },
+      "coverage_pct_by_draft_year": {
+        "2018": 1.0,
+        "2019": 1.0,
+        "2020": 1.0,
+        "2021": 1.0,
+        "2022": 1.0,
+        "2023": 1.0
+      }
+    },
+    "age_at_draft": {
+      "non_null_count": 0,
+      "null_count": 37,
+      "coverage_pct_overall": 0.0,
+      "coverage_pct_by_position": {
+        "QB": 0.0,
+        "TE": 0.0,
+        "WR": 0.0
+      },
+      "coverage_pct_by_draft_year": {
+        "2018": 0.0,
+        "2019": 0.0,
+        "2020": 0.0,
+        "2021": 0.0,
+        "2022": 0.0,
+        "2023": 0.0
+      }
+    },
+    "breakout_age": {
+      "non_null_count": 0,
+      "null_count": 37,
+      "coverage_pct_overall": 0.0,
+      "coverage_pct_by_position": {
+        "QB": 0.0,
+        "TE": 0.0,
+        "WR": 0.0
+      },
+      "coverage_pct_by_draft_year": {
+        "2018": 0.0,
+        "2019": 0.0,
+        "2020": 0.0,
+        "2021": 0.0,
+        "2022": 0.0,
+        "2023": 0.0
+      }
+    },
+    "production_0_100": {
+      "non_null_count": 15,
+      "null_count": 22,
+      "coverage_pct_overall": 0.405405,
+      "coverage_pct_by_position": {
+        "QB": 1.0,
+        "TE": 0.0,
+        "WR": 0.52
+      },
+      "coverage_pct_by_draft_year": {
+        "2018": 0.142857,
+        "2019": 0.142857,
+        "2020": 0.625,
+        "2021": 0.428571,
+        "2022": 0.714286,
+        "2023": 0.0
+      }
+    },
+    "athleticism_0_100": {
+      "non_null_count": 33,
+      "null_count": 4,
+      "coverage_pct_overall": 0.891892,
+      "coverage_pct_by_position": {
+        "QB": 1.0,
+        "TE": 1.0,
+        "WR": 0.84
+      },
+      "coverage_pct_by_draft_year": {
+        "2018": 1.0,
+        "2019": 1.0,
+        "2020": 1.0,
+        "2021": 0.714286,
+        "2022": 0.714286,
+        "2023": 1.0
+      }
+    },
+    "size_context_0_100": {
+      "non_null_count": 37,
+      "null_count": 0,
+      "coverage_pct_overall": 1.0,
+      "coverage_pct_by_position": {
+        "QB": 1.0,
+        "TE": 1.0,
+        "WR": 1.0
+      },
+      "coverage_pct_by_draft_year": {
+        "2018": 1.0,
+        "2019": 1.0,
+        "2020": 1.0,
+        "2021": 1.0,
+        "2022": 1.0,
+        "2023": 1.0
+      }
+    },
+    "speed_proxy_0_100": {
+      "non_null_count": 33,
+      "null_count": 4,
+      "coverage_pct_overall": 0.891892,
+      "coverage_pct_by_position": {
+        "QB": 1.0,
+        "TE": 1.0,
+        "WR": 0.84
+      },
+      "coverage_pct_by_draft_year": {
+        "2018": 1.0,
+        "2019": 1.0,
+        "2020": 1.0,
+        "2021": 0.714286,
+        "2022": 0.714286,
+        "2023": 1.0
+      }
+    },
+    "early_declare_flag": {
+      "non_null_count": 0,
+      "null_count": 37,
+      "coverage_pct_overall": 0.0,
+      "coverage_pct_by_position": {
+        "QB": 0.0,
+        "TE": 0.0,
+        "WR": 0.0
+      },
+      "coverage_pct_by_draft_year": {
+        "2018": 0.0,
+        "2019": 0.0,
+        "2020": 0.0,
+        "2021": 0.0,
+        "2022": 0.0,
+        "2023": 0.0
+      }
+    },
+    "deterministic_grade_0_100": {
+      "non_null_count": 0,
+      "null_count": 37,
+      "coverage_pct_overall": 0.0,
+      "coverage_pct_by_position": {
+        "QB": 0.0,
+        "TE": 0.0,
+        "WR": 0.0
+      },
+      "coverage_pct_by_draft_year": {
+        "2018": 0.0,
+        "2019": 0.0,
+        "2020": 0.0,
+        "2021": 0.0,
+        "2022": 0.0,
+        "2023": 0.0
+      }
+    }
+  }
+}

--- a/exports/promoted/rookie-ml-lane/feature_importance_report.json
+++ b/exports/promoted/rookie-ml-lane/feature_importance_report.json
@@ -1,0 +1,45 @@
+{
+  "model_name": "logistic_full",
+  "features_ranked": [
+    {
+      "feature": "production_0_100",
+      "coefficient": -0.43724,
+      "sign": "negative",
+      "abs_magnitude": 0.43724,
+      "normalized_importance": 1.0,
+      "abs_magnitude_rank": 1
+    },
+    {
+      "feature": "size_context_0_100",
+      "coefficient": 0.408358,
+      "sign": "positive",
+      "abs_magnitude": 0.408358,
+      "normalized_importance": 0.933945,
+      "abs_magnitude_rank": 2
+    },
+    {
+      "feature": "draft_capital_proxy_0_100",
+      "coefficient": -0.005627,
+      "sign": "negative",
+      "abs_magnitude": 0.005627,
+      "normalized_importance": 0.012869,
+      "abs_magnitude_rank": 3
+    },
+    {
+      "feature": "athleticism_0_100",
+      "coefficient": 0.00539,
+      "sign": "positive",
+      "abs_magnitude": 0.00539,
+      "normalized_importance": 0.012327,
+      "abs_magnitude_rank": 4
+    },
+    {
+      "feature": "speed_proxy_0_100",
+      "coefficient": 0.00539,
+      "sign": "positive",
+      "abs_magnitude": 0.00539,
+      "normalized_importance": 0.012327,
+      "abs_magnitude_rank": 5
+    }
+  ]
+}

--- a/scripts/compute_rookie_ml_lane.py
+++ b/scripts/compute_rookie_ml_lane.py
@@ -42,6 +42,11 @@ BASELINE_MODEL_FEATURES = {
     "logistic_full": FULL_MODEL_FEATURE_COLUMNS,
 }
 
+TRACKED_POSITIONS = ["WR", "RB", "TE", "QB"]
+WEAK_COVERAGE_THRESHOLD = 0.60
+SPARSE_POSITION_THRESHOLD = 8
+MIN_PRIOR_CLASS_COUNT = 2
+
 
 @dataclass
 class SplitBundle:
@@ -384,6 +389,201 @@ def evaluate(y_true: list[int], y_prob: list[float], k: int = 5) -> dict[str, fl
     }
 
 
+def _rate(num: int, denom: int) -> float | None:
+    if denom <= 0:
+        return None
+    return round(num / denom, 6)
+
+
+def _safe_round(value: float | None, digits: int = 6) -> float | None:
+    if value is None:
+        return None
+    return round(value, digits)
+
+
+def _counts_by_keys(
+    rows: list[dict[str, Any]],
+    key_names: list[str],
+) -> dict[str, int]:
+    out: dict[str, int] = {}
+    for row in rows:
+        key = "|".join(str(row.get(name) or "") for name in key_names)
+        out[key] = out.get(key, 0) + 1
+    return out
+
+
+def build_dataset_diagnostics(labeled: list[dict[str, Any]], split: SplitBundle) -> dict[str, Any]:
+    by_position = _counts_by_keys(labeled, ["position"])
+    by_year = _counts_by_keys(labeled, ["draft_year"])
+    by_position_year = _counts_by_keys(labeled, ["position", "draft_year"])
+    train_by_position = _counts_by_keys(split.train, ["position"])
+    val_by_position = _counts_by_keys(split.validation, ["position"])
+    test_by_position = _counts_by_keys(split.test, ["position"])
+
+    def _hit_rate(rows: list[dict[str, Any]]) -> float | None:
+        if not rows:
+            return None
+        hits = sum(int(r["hit_label"]) for r in rows)
+        return _rate(hits, len(rows))
+
+    hit_by_position: dict[str, float | None] = {}
+    for position in sorted({str(r.get("position") or "") for r in labeled}):
+        subset = [r for r in labeled if str(r.get("position") or "") == position]
+        hit_by_position[position] = _hit_rate(subset)
+
+    hit_by_year: dict[str, float | None] = {}
+    for year in sorted({int(r.get("draft_year") or 0) for r in labeled}):
+        subset = [r for r in labeled if int(r.get("draft_year") or 0) == year]
+        hit_by_year[str(year)] = _hit_rate(subset)
+
+    return {
+        "total_labeled_rows": len(labeled),
+        "labeled_row_count_by_position": by_position,
+        "labeled_row_count_by_draft_year": by_year,
+        "labeled_row_count_by_position_draft_year": by_position_year,
+        "split_row_counts": {
+            "train": len(split.train),
+            "validation": len(split.validation),
+            "test": len(split.test),
+        },
+        "split_row_counts_by_position": {
+            "train": train_by_position,
+            "validation": val_by_position,
+            "test": test_by_position,
+        },
+        "target_hit_rate_overall": _hit_rate(labeled),
+        "target_hit_rate_by_position": hit_by_position,
+        "target_hit_rate_by_draft_year": hit_by_year,
+    }
+
+
+def build_feature_coverage_report(rows: list[dict[str, Any]], feature_names: list[str]) -> dict[str, Any]:
+    positions = sorted({str(r.get("position") or "") for r in rows})
+    years = sorted({int(r.get("draft_year") or 0) for r in rows})
+    report: dict[str, Any] = {
+        "total_rows": len(rows),
+        "weak_coverage_threshold": WEAK_COVERAGE_THRESHOLD,
+        "features": {},
+    }
+    for feature in feature_names:
+        non_null = sum(1 for r in rows if _to_float(r.get(feature)) is not None)
+        null = len(rows) - non_null
+        by_position: dict[str, float | None] = {}
+        by_year: dict[str, float | None] = {}
+        for pos in positions:
+            subset = [r for r in rows if str(r.get("position") or "") == pos]
+            present = sum(1 for r in subset if _to_float(r.get(feature)) is not None)
+            by_position[pos] = _rate(present, len(subset))
+        for year in years:
+            subset = [r for r in rows if int(r.get("draft_year") or 0) == year]
+            present = sum(1 for r in subset if _to_float(r.get(feature)) is not None)
+            by_year[str(year)] = _rate(present, len(subset))
+        report["features"][feature] = {
+            "non_null_count": non_null,
+            "null_count": null,
+            "coverage_pct_overall": _rate(non_null, len(rows)),
+            "coverage_pct_by_position": by_position,
+            "coverage_pct_by_draft_year": by_year,
+        }
+    return report
+
+
+def build_data_warnings(
+    split: SplitBundle,
+    coverage: dict[str, Any],
+    diagnostics: dict[str, Any],
+) -> list[str]:
+    warnings: list[str] = []
+    if len(split.years.get("train", [])) < MIN_PRIOR_CLASS_COUNT:
+        warnings.append("Insufficient prior draft classes for robust pre-holdout training signal.")
+
+    for position in TRACKED_POSITIONS:
+        n = int(diagnostics["split_row_counts_by_position"]["test"].get(position, 0))
+        if n < SPARSE_POSITION_THRESHOLD:
+            warnings.append(f"Test slice for {position} is sparse (n={n}); position metrics may be unstable.")
+
+    weak_features = []
+    for feature, detail in coverage.get("features", {}).items():
+        overall = detail.get("coverage_pct_overall")
+        if overall is not None and float(overall) < WEAK_COVERAGE_THRESHOLD:
+            weak_features.append(feature)
+    if weak_features:
+        warnings.append(
+            "Weak feature coverage below threshold "
+            f"({int(WEAK_COVERAGE_THRESHOLD * 100)}%): {', '.join(sorted(weak_features))}."
+        )
+
+    det_cov = coverage.get("features", {}).get("deterministic_grade_0_100", {}).get("coverage_pct_overall")
+    if det_cov is not None and float(det_cov) < WEAK_COVERAGE_THRESHOLD:
+        warnings.append("Deterministic grade is unavailable for many historical rows.")
+
+    return warnings
+
+
+def evaluate_by_position(rows: list[dict[str, Any]], probs: list[float]) -> dict[str, Any]:
+    slices: dict[str, Any] = {}
+    for position in TRACKED_POSITIONS:
+        idxs = [i for i, r in enumerate(rows) if str(r.get("position") or "").upper() == position]
+        y = [int(rows[i]["hit_label"]) for i in idxs]
+        p = [probs[i] for i in idxs]
+        slices[position] = evaluate(y, p) if idxs else {"roc_auc": None, "pr_auc": None, "log_loss": None, "calibration_mae": None, "precision_at_k": None, "n": 0, "positives": 0}
+    return slices
+
+
+def build_feature_importance_report(
+    model_name: str,
+    feature_names: list[str],
+    coefficients: dict[str, float],
+) -> dict[str, Any]:
+    rows = []
+    max_abs = max((abs(float(coefficients.get(name, 0.0))) for name in feature_names), default=0.0)
+    for name in feature_names:
+        coef = float(coefficients.get(name, 0.0))
+        abs_coef = abs(coef)
+        rows.append(
+            {
+                "feature": name,
+                "coefficient": round(coef, 6),
+                "sign": "positive" if coef > 0 else "negative" if coef < 0 else "neutral",
+                "abs_magnitude": round(abs_coef, 6),
+                "normalized_importance": round((abs_coef / max_abs), 6) if max_abs > 0 else 0.0,
+            }
+        )
+    rows.sort(key=lambda r: r["abs_magnitude"], reverse=True)
+    for i, row in enumerate(rows, start=1):
+        row["abs_magnitude_rank"] = i
+    return {"model_name": model_name, "features_ranked": rows}
+
+
+def build_missingness_summary(coverage: dict[str, Any]) -> dict[str, Any]:
+    weak_features: list[dict[str, Any]] = []
+    weak_by_position: dict[str, list[str]] = {}
+    weak_by_year: dict[str, list[str]] = {}
+    for feature, detail in coverage.get("features", {}).items():
+        overall = detail.get("coverage_pct_overall")
+        if overall is not None and float(overall) < WEAK_COVERAGE_THRESHOLD:
+            weak_features.append({"feature": feature, "coverage_pct_overall": overall})
+
+        for position, pct in detail.get("coverage_pct_by_position", {}).items():
+            if pct is not None and float(pct) < WEAK_COVERAGE_THRESHOLD:
+                weak_by_position.setdefault(position, []).append(feature)
+        for year, pct in detail.get("coverage_pct_by_draft_year", {}).items():
+            if pct is not None and float(pct) < WEAK_COVERAGE_THRESHOLD:
+                weak_by_year.setdefault(year, []).append(feature)
+
+    warnings = [
+        f"{item['feature']} coverage below {int(WEAK_COVERAGE_THRESHOLD * 100)}% (overall={item['coverage_pct_overall']})"
+        for item in sorted(weak_features, key=lambda x: x["coverage_pct_overall"])
+    ]
+    return {
+        "coverage_threshold": WEAK_COVERAGE_THRESHOLD,
+        "weak_features_overall": weak_features,
+        "thin_positions": {k: sorted(v) for k, v in weak_by_position.items()},
+        "thin_draft_years": {k: sorted(v) for k, v in weak_by_year.items()},
+        "warnings": warnings,
+    }
+
+
 def deterministic_non_ml_baseline(rows: list[dict[str, Any]], key: str) -> list[float]:
     probs = []
     for row in rows:
@@ -420,7 +620,7 @@ def run_model(
     model_name: str,
     feature_names: list[str],
     split: SplitBundle,
-) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+) -> tuple[dict[str, Any], list[dict[str, Any]], list[float]]:
     train = split.train
     validation = split.validation
     test = split.test
@@ -441,13 +641,14 @@ def run_model(
     metrics = {
         "validation": evaluate(y_val, val_probs),
         "test": evaluate(y_test, test_probs),
+        "test_by_position": evaluate_by_position(test, test_probs),
         "features": feature_names,
         "coefficients": {name: round(w, 6) for name, w in zip(feature_names, model.weights)},
         "bias": round(model.bias, 6),
     }
 
     scored = _attach_predictions(test, test_probs, model_name)
-    return metrics, scored
+    return metrics, scored, test_probs
 
 
 def write_json(path: Path, payload: Any) -> None:
@@ -498,7 +699,7 @@ def main() -> None:
         usable = [name for name in feature_names if any(_to_float(r.get(name)) is not None for r in split.train)]
         if not usable:
             continue
-        metrics, scored = run_model(model_name, usable, split)
+        metrics, scored, _ = run_model(model_name, usable, split)
         models_report[model_name] = metrics
         heldout_scores_by_model[model_name] = scored
 
@@ -507,15 +708,50 @@ def main() -> None:
         "deterministic_grade_rescaled": deterministic_non_ml_baseline(split.test, "deterministic_grade_0_100"),
     }
     y_test = [int(r["hit_label"]) for r in split.test]
-    non_ml_report = {name: evaluate(y_test, probs) for name, probs in non_ml.items()}
+    non_ml_report = {
+        name: {
+            "test": evaluate(y_test, probs),
+            "test_by_position": evaluate_by_position(split.test, probs),
+        }
+        for name, probs in non_ml.items()
+    }
+
+    diagnostics = build_dataset_diagnostics(labeled, split)
+    coverage = build_feature_coverage_report(labeled, FEATURE_COLUMNS)
+    warnings = build_data_warnings(split, coverage, diagnostics)
+    missingness_summary = build_missingness_summary(coverage)
 
     final_scores = heldout_scores_by_model.get("logistic_full") or next(iter(heldout_scores_by_model.values()))
+    full_model_metrics = models_report.get("logistic_full", {}).get("test", {})
+    baseline_delta = {}
+    for baseline in ("draft_capital_only", "draft_capital_plus_production", "deterministic_grade_only"):
+        if baseline in models_report:
+            baseline_pr_auc = models_report[baseline]["test"]["pr_auc"]
+            full_pr_auc = full_model_metrics.get("pr_auc")
+            baseline_delta[baseline] = {
+                "test_pr_auc_delta_vs_logistic_full": _safe_round(
+                    None if baseline_pr_auc is None or full_pr_auc is None else float(full_pr_auc) - float(baseline_pr_auc)
+                )
+            }
+
+    feature_importance_report = (
+        build_feature_importance_report(
+            "logistic_full",
+            models_report["logistic_full"]["features"],
+            models_report["logistic_full"]["coefficients"],
+        )
+        if "logistic_full" in models_report
+        else {"model_name": None, "features_ranked": []}
+    )
 
     output_dir = Path(args.output_dir)
     write_json(output_dir / "historical_labeled_dataset.json", labeled)
     write_csv(output_dir / "historical_labeled_dataset.csv", labeled)
     write_json(output_dir / "feature_table.json", [{k: row.get(k) for k in ["player_id", "draft_year", "position", *FEATURE_COLUMNS, "hit_label"]} for row in labeled])
 
+    write_json(output_dir / "dataset_diagnostics.json", diagnostics)
+    write_json(output_dir / "feature_coverage_report.json", coverage)
+    write_json(output_dir / "feature_importance_report.json", feature_importance_report)
     report = {
         "generated_at": datetime.now(timezone.utc).isoformat(),
         "lane": "parallel_ml_evaluation_only",
@@ -523,8 +759,11 @@ def main() -> None:
         "split_years": split.years,
         "n_labeled_rows": len(labeled),
         "n_test_rows": len(split.test),
+        "dataset_warnings": warnings,
+        "missingness_summary": missingness_summary,
         "ml_models": models_report,
         "non_ml_baselines": non_ml_report,
+        "draft_capital_dominance_check": baseline_delta,
         "winning_model_by_test_pr_auc": max(
             models_report.keys(),
             key=lambda name: (models_report[name]["test"]["pr_auc"] if models_report[name]["test"]["pr_auc"] is not None else -1),

--- a/tests/test_compute_rookie_ml_lane.py
+++ b/tests/test_compute_rookie_ml_lane.py
@@ -1,8 +1,18 @@
 import unittest
+import json
+import subprocess
+import tempfile
+from pathlib import Path
 
 from scripts.compute_rookie_ml_lane import (
     BASELINE_MODEL_FEATURES,
+    SplitBundle,
     _extract_hit_label,
+    build_data_warnings,
+    build_dataset_diagnostics,
+    build_feature_coverage_report,
+    build_feature_importance_report,
+    build_missingness_summary,
     build_labeled_rows,
     pr_auc,
     roc_auc,
@@ -82,6 +92,129 @@ class RookieMlLaneTests(unittest.TestCase):
 
     def test_logistic_full_excludes_deterministic_grade_feature(self) -> None:
         self.assertNotIn("deterministic_grade_0_100", BASELINE_MODEL_FEATURES["logistic_full"])
+
+    def test_dataset_diagnostics_structure(self) -> None:
+        rows = [
+            {"player_id": "a", "position": "WR", "draft_year": 2020, "hit_label": 1},
+            {"player_id": "b", "position": "RB", "draft_year": 2020, "hit_label": 0},
+            {"player_id": "c", "position": "WR", "draft_year": 2021, "hit_label": 1},
+            {"player_id": "d", "position": "RB", "draft_year": 2022, "hit_label": 0},
+        ]
+        split = time_split(rows, holdout_year=2022)
+        diagnostics = build_dataset_diagnostics(rows, split)
+        self.assertEqual(diagnostics["total_labeled_rows"], 4)
+        self.assertIn("WR", diagnostics["labeled_row_count_by_position"])
+        self.assertIn("2020", diagnostics["target_hit_rate_by_draft_year"])
+        self.assertIn("train", diagnostics["split_row_counts_by_position"])
+
+    def test_feature_coverage_report_structure(self) -> None:
+        rows = [
+            {"position": "WR", "draft_year": 2020, "draft_capital_proxy_0_100": 70, "age_at_draft": 21},
+            {"position": "RB", "draft_year": 2021, "draft_capital_proxy_0_100": None, "age_at_draft": 22},
+        ]
+        coverage = build_feature_coverage_report(rows, ["draft_capital_proxy_0_100", "age_at_draft"])
+        detail = coverage["features"]["draft_capital_proxy_0_100"]
+        self.assertEqual(detail["non_null_count"], 1)
+        self.assertEqual(detail["null_count"], 1)
+        self.assertIn("WR", detail["coverage_pct_by_position"])
+        self.assertIn("2020", detail["coverage_pct_by_draft_year"])
+
+    def test_missingness_summary_and_warnings_for_weak_coverage(self) -> None:
+        rows = [
+            {"position": "WR", "draft_year": 2020, "deterministic_grade_0_100": None},
+            {"position": "WR", "draft_year": 2021, "deterministic_grade_0_100": None},
+            {"position": "RB", "draft_year": 2022, "deterministic_grade_0_100": 80},
+        ]
+        coverage = build_feature_coverage_report(rows, ["deterministic_grade_0_100"])
+        summary = build_missingness_summary(coverage)
+        self.assertTrue(summary["warnings"])
+
+        split = SplitBundle(
+            train=[{"position": "WR", "draft_year": 2020, "hit_label": 1}],
+            validation=[{"position": "WR", "draft_year": 2021, "hit_label": 0}],
+            test=[{"position": "WR", "draft_year": 2022, "hit_label": 1}],
+            years={"train": [2020], "validation": [2021], "test": [2022]},
+        )
+        diagnostics = build_dataset_diagnostics(split.train + split.validation + split.test, split)
+        warnings = build_data_warnings(split, coverage, diagnostics)
+        self.assertTrue(any("Deterministic grade" in w for w in warnings))
+
+    def test_feature_importance_ordering(self) -> None:
+        report = build_feature_importance_report(
+            "logistic_full",
+            ["a", "b", "c"],
+            {"a": 0.1, "b": -0.5, "c": 0.2},
+        )
+        ranked = report["features_ranked"]
+        self.assertEqual(ranked[0]["feature"], "b")
+        self.assertEqual(ranked[0]["sign"], "negative")
+        self.assertEqual(ranked[0]["abs_magnitude_rank"], 1)
+
+    def test_end_to_end_report_contains_position_slices_and_deltas(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            features_path = root / "features.json"
+            outcomes_path = root / "outcomes.json"
+            alpha_dir = root / "alpha"
+            output_dir = root / "out"
+            alpha_dir.mkdir(parents=True)
+
+            positions = ["WR", "RB", "TE", "QB"]
+            features = []
+            outcomes = []
+            years = [2020, 2021, 2022, 2023]
+            for year_idx, year in enumerate(years):
+                for pos_idx, position in enumerate(positions):
+                    player_id = f"{position.lower()}-{year}"
+                    features.append(
+                        {
+                            "player_id": player_id,
+                            "player_name": player_id,
+                            "position": position,
+                            "draft_year": year,
+                            "draft_capital_proxy_0_100": 80 - (pos_idx * 5) - year_idx,
+                            "age_at_draft": 21 + pos_idx,
+                            "breakout_age": 19 + pos_idx,
+                            "production_0_100": 60 + (pos_idx * 3),
+                            "athleticism_0_100": 70 - pos_idx,
+                            "size_context_0_100": 55 + pos_idx,
+                            "speed_proxy_0_100": 65 - pos_idx,
+                            "early_declare_flag": 1 if pos_idx % 2 == 0 else 0,
+                        }
+                    )
+                    outcomes.append(
+                        {
+                            "player_id": player_id,
+                            "position": position,
+                            "top_finish_band": "TOP-24" if position in {"WR", "RB"} and year_idx % 2 == 0 else "QB15" if position == "QB" and year_idx % 2 == 0 else "TE20" if position == "TE" else "WR30",
+                        }
+                    )
+
+            features_path.write_text(json.dumps(features), encoding="utf-8")
+            outcomes_path.write_text(json.dumps(outcomes), encoding="utf-8")
+
+            cmd = [
+                "python3",
+                "scripts/compute_rookie_ml_lane.py",
+                "--historical-features",
+                str(features_path),
+                "--historical-outcomes",
+                str(outcomes_path),
+                "--rookie-alpha-dir",
+                str(alpha_dir),
+                "--holdout-year",
+                "2023",
+                "--output-dir",
+                str(output_dir),
+            ]
+            subprocess.run(cmd, check=True)
+
+            report = json.loads((output_dir / "evaluation_report.json").read_text(encoding="utf-8"))
+            self.assertIn("missingness_summary", report)
+            self.assertIn("draft_capital_dominance_check", report)
+            self.assertIn("draft_capital_only", report["draft_capital_dominance_check"])
+            self.assertIn("test_by_position", report["ml_models"]["logistic_full"])
+            self.assertEqual(set(report["ml_models"]["logistic_full"]["test_by_position"].keys()), {"WR", "RB", "TE", "QB"})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Improve trustworthiness and inspectability of the rookie ML lane by making historical-data limits, feature completeness, and position-level evaluation explicit so consumers can judge whether model gains reflect real signal or thin scaffolding.
- Provide straightforward, machine- and human-readable artifacts that summarize dataset volume, per-feature coverage, missingness warnings, position slices, draft-capital dominance checks, and clearer coefficient visibility without changing the interpretable logistic approach.

### Description
- Added diagnostics builders to `scripts/compute_rookie_ml_lane.py`: `build_dataset_diagnostics`, `build_feature_coverage_report`, `build_missingness_summary`, `build_feature_importance_report`, `build_data_warnings`, and `evaluate_by_position` (and helpers `_rate`, `_counts_by_keys`, `_safe_round`).
- Expanded model pipeline to emit new artifacts: `exports/promoted/rookie-ml-lane/dataset_diagnostics.json`, `feature_coverage_report.json`, and `feature_importance_report.json`, and added `test_by_position`, `dataset_warnings`, `missingness_summary`, and `draft_capital_dominance_check` into `evaluation_report.json` (keeps logistic coefficients faithful while adding sign/abs-rank/normalized importance).
- Kept the lane interpretable and additive: no new black-box models, deterministic baseline unchanged, and `run_model` now includes `test_by_position` slices for the logistic baselines; non-ML baselines also include `test_by_position` summaries.
- Documentation and tests updated: README includes a `Trustworthiness inspection checklist` describing the new artifacts; tests in `tests/test_compute_rookie_ml_lane.py` were extended to validate diagnostics structure, coverage reporting, missingness warnings, importance ordering, and end-to-end presence of position slices and baseline deltas.

### Testing
- Ran unit tests: `python3 -m pytest tests/test_compute_rookie_ml_lane.py` — all tests passed (`12 passed`).
- Ran the lane end-to-end: `python3 scripts/compute_rookie_ml_lane.py` — completed and wrote outputs to `exports/promoted/rookie-ml-lane/` including the new artifacts (`dataset_diagnostics.json`, `feature_coverage_report.json`, `feature_importance_report.json`, updated `evaluation_report.json`, and `heldout_probabilities.*`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e04430c5cc8332838770c5a01ca39d)