### PR TITLE
PR1: apply capped production fallback when age-adjusted production is missing

### DIFF
--- a/scripts/compute_rookie_alpha.py
+++ b/scripts/compute_rookie_alpha.py
@@ -1123,7 +1123,14 @@ def rookie_alpha_score(player: PlayerInputs) -> float:
     ath = player.athletic_score_0_100 if player.athletic_score_0_100 is not None else (
         player.ras_score_0_100 if player.ras_score_0_100 is not None else 50.0
     )
-    production = player.production_score_0_100 if player.production_score_0_100 is not None else 50.0
+    if player.production_score_0_100 is None:
+        production = 50.0
+    elif player.age_adjusted_production_0_100 is None:
+        # Evidence-discipline fallback: if age-adjusted production is missing,
+        # do not preserve full raw production credit.
+        production = player.production_score_0_100 * 0.85
+    else:
+        production = player.production_score_0_100
     draft = player.draft_capital_proxy_0_100 if player.draft_capital_proxy_0_100 is not None else 50.0
     return clamp_0_100((0.35 * ath) + (0.45 * production) + (0.20 * draft))
 

--- a/tests/test_compute_rookie_alpha.py
+++ b/tests/test_compute_rookie_alpha.py
@@ -58,6 +58,32 @@ class RookieAlphaTests(unittest.TestCase):
             ras_score_0_100=80.0,
             production_score_0_100=60.0,
             draft_capital_proxy_0_100=70.0,
+            age_adjusted_production_0_100=58.0,
+        )
+        self.assertAlmostEqual(rookie_alpha_score(player), 69.0)
+
+    def test_rookie_alpha_applies_production_fallback_when_age_adjusted_missing(self) -> None:
+        player = PlayerInputs(
+            player_id="p1",
+            player_name="Player 1",
+            position="WR",
+            ras_score_0_100=80.0,
+            production_score_0_100=60.0,
+            draft_capital_proxy_0_100=70.0,
+            age_adjusted_production_0_100=None,
+        )
+        # effective production = 60 * 0.85 = 51
+        self.assertAlmostEqual(rookie_alpha_score(player), 64.95)
+
+    def test_rookie_alpha_keeps_production_when_age_adjusted_present(self) -> None:
+        player = PlayerInputs(
+            player_id="p1",
+            player_name="Player 1",
+            position="WR",
+            ras_score_0_100=80.0,
+            production_score_0_100=60.0,
+            draft_capital_proxy_0_100=70.0,
+            age_adjusted_production_0_100=58.0,
         )
         self.assertAlmostEqual(rookie_alpha_score(player), 69.0)
 


### PR DESCRIPTION
### Motivation
- Prevent players with missing age-adjusted production from receiving full raw production credit which created a missing-data loophole that benefits under-evidenced Bell-style profiles. 

### Description
- Changed `scripts/compute_rookie_alpha.py` in `rookie_alpha_score` so that when `production_score_0_100` exists but `age_adjusted_production_0_100` is `None`, `production` is set to `production * 0.85`, and behavior is unchanged when age-adjusted production is present. 
- Updated `tests/test_compute_rookie_alpha.py` to add a regression test for the null age-adjusted fallback and to keep the baseline alpha test aligned with an explicit age-adjusted input. 
- No other refactors or UI/export changes were introduced. 

### Testing
- Ran `pytest -q tests/test_compute_rookie_alpha.py` which executed the focused suite and reported `36 passed` (all tests succeeded). 
- The change is covered by unit tests that assert the capped fallback value and the unchanged behavior when age-adjusted production is present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2409ee7508332836c3a8213a0bd49)