### PR TITLE
Fix PR1: gate null age-adjusted production fallback on artifact availability

### DIFF
--- a/scripts/compute_rookie_alpha.py
+++ b/scripts/compute_rookie_alpha.py
@@ -1117,7 +1117,7 @@ def normalize_context_entry(context_row: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def rookie_alpha_score(player: PlayerInputs) -> float:
+def rookie_alpha_score(player: PlayerInputs, age_adjusted_available_for_run: bool = False) -> float:
     # Use resolved athletic score (RAS / SPORQ / COMBINE_FALLBACK), falling
     # back to raw RAS, then to 50.0 (neutral) when nothing is available.
     ath = player.athletic_score_0_100 if player.athletic_score_0_100 is not None else (
@@ -1125,7 +1125,7 @@ def rookie_alpha_score(player: PlayerInputs) -> float:
     )
     if player.production_score_0_100 is None:
         production = 50.0
-    elif player.age_adjusted_production_0_100 is None:
+    elif age_adjusted_available_for_run and player.age_adjusted_production_0_100 is None:
         # Evidence-discipline fallback: if age-adjusted production is missing,
         # do not preserve full raw production credit.
         production = player.production_score_0_100 * 0.85
@@ -1225,6 +1225,7 @@ def write_outputs(
     wr_translation_penalty_by_id: dict[str, tuple[float, str]] | None = None,
     positional_consensus_path: Path | None = None,
     positional_consensus_by_id: dict[str, dict] | None = None,
+    age_adjusted_available_for_run: bool = False,
 ) -> None:
     generated_at = datetime.now(tz=timezone.utc).replace(microsecond=0).isoformat()
     run_id = f"rookie-alpha-{season}-{generated_at}"
@@ -1235,7 +1236,7 @@ def write_outputs(
     players_with_context = 0
     missing_any = 0
     for p in players:
-        alpha = rookie_alpha_score(p)
+        alpha = rookie_alpha_score(p, age_adjusted_available_for_run=age_adjusted_available_for_run)
         ts = talent_score(p)
 
         # ------------------------------------------------------------------
@@ -1677,9 +1678,11 @@ def main() -> None:
     # Load context early — needed for context-driven production adjustments
     context_by_id = load_context_by_player_id(context_input)
 
+    age_adjusted_available_for_run = False
     if age_adjusted_input.exists():
         age_adjusted_rows = load_json(age_adjusted_input)
         if isinstance(age_adjusted_rows, list):
+            age_adjusted_available_for_run = True
             production_rows = blend_production_rows(production_rows, age_adjusted_rows)
             logging.info(
                 "Blended production scores from %s (%.0f%% age-adjusted, %.0f%% existing)",
@@ -1735,6 +1738,7 @@ def main() -> None:
         wr_translation_penalty_by_id=wr_translation_penalty_by_id,
         positional_consensus_path=positional_consensus_input,
         positional_consensus_by_id=positional_consensus_by_id,
+        age_adjusted_available_for_run=age_adjusted_available_for_run,
     )
 
 

--- a/tests/test_compute_rookie_alpha.py
+++ b/tests/test_compute_rookie_alpha.py
@@ -62,7 +62,7 @@ class RookieAlphaTests(unittest.TestCase):
         )
         self.assertAlmostEqual(rookie_alpha_score(player), 69.0)
 
-    def test_rookie_alpha_applies_production_fallback_when_age_adjusted_missing(self) -> None:
+    def test_rookie_alpha_preserves_raw_production_when_age_adjusted_run_artifact_unavailable(self) -> None:
         player = PlayerInputs(
             player_id="p1",
             player_name="Player 1",
@@ -72,8 +72,22 @@ class RookieAlphaTests(unittest.TestCase):
             draft_capital_proxy_0_100=70.0,
             age_adjusted_production_0_100=None,
         )
+        # Run-level age-adjusted artifact absent: keep raw production.
+        self.assertAlmostEqual(rookie_alpha_score(player, age_adjusted_available_for_run=False), 69.0)
+
+    def test_rookie_alpha_applies_production_fallback_when_run_has_age_adjusted_artifact(self) -> None:
+        player = PlayerInputs(
+            player_id="p1",
+            player_name="Player 1",
+            position="WR",
+            ras_score_0_100=80.0,
+            production_score_0_100=60.0,
+            draft_capital_proxy_0_100=70.0,
+            age_adjusted_production_0_100=None,
+        )
+        # Run-level artifact present but player-level age-adjusted value missing.
         # effective production = 60 * 0.85 = 51
-        self.assertAlmostEqual(rookie_alpha_score(player), 64.95)
+        self.assertAlmostEqual(rookie_alpha_score(player, age_adjusted_available_for_run=True), 64.95)
 
     def test_rookie_alpha_keeps_production_when_age_adjusted_present(self) -> None:
         player = PlayerInputs(
@@ -85,7 +99,7 @@ class RookieAlphaTests(unittest.TestCase):
             draft_capital_proxy_0_100=70.0,
             age_adjusted_production_0_100=58.0,
         )
-        self.assertAlmostEqual(rookie_alpha_score(player), 69.0)
+        self.assertAlmostEqual(rookie_alpha_score(player, age_adjusted_available_for_run=True), 69.0)
 
     def test_merge_inputs(self) -> None:
         combine_rows = [


### PR DESCRIPTION
### Motivation
- PR1 added an evidence-discipline fallback that reduced a player’s raw `production_score_0_100` by 15% when their `age_adjusted_production_0_100` was null, but it keyed only on the player-level null and therefore penalized all players in runs where no age-adjusted artifact was supplied for the run. 
- The intent is to discipline Bell-style missing-evidence cases only when the run actually expects age-adjusted input, not to change behavior for unblended runs where the artifact is absent.

### Description
- Added a run-level boolean `age_adjusted_available_for_run` and extended `rookie_alpha_score(player, age_adjusted_available_for_run: bool = False)` so the 0.85 haircut is applied only when the run-level flag is True and the player-level age-adjusted value is None.  
- Threaded the flag through `write_outputs(...)` and set `age_adjusted_available_for_run = True` in `main()` only when the `--age-adjusted-input` artifact exists and contains a list payload usable for blending.  
- Kept existing blending and logging behavior unchanged; only the gating for the evidence-discipline fallback was modified.  
- Updated/added focused unit tests in `tests/test_compute_rookie_alpha.py` to cover: unblended run + null player (no haircut), blended run + null player (0.85 haircut), and blended run + present age-adjusted value (unchanged behavior).

### Testing
- Ran the package tests for rookie alpha: `pytest -q tests/test_compute_rookie_alpha.py` and all tests passed.  
- Test result: `37 passed in 0.15s`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e259d7bd048332bfb7ca60c815cb21)