### PR TITLE
PR2: make WR athletic scoring honest for partial RAS and SPORQ-aware cases

### DIFF
--- a/scripts/compute_rookie_alpha.py
+++ b/scripts/compute_rookie_alpha.py
@@ -1323,7 +1323,7 @@ def write_outputs(
 
         # When SPORQ is used as the athletic score, suppress its ceiling bonus
         # to avoid double-counting athleticism in the alpha formula.
-        sporq_used = p.athletic_source == "SPORQ"
+        sporq_used = p.athletic_source in {"SPORQ", "RAS_SPORQ_BLEND"}
 
         ceiling_bonus = 0.0
         for em in ctx_exc:

--- a/scripts/compute_rookie_alpha.py
+++ b/scripts/compute_rookie_alpha.py
@@ -532,6 +532,11 @@ def _extract_sporq(context: dict[str, Any] | None) -> tuple[float | None, str | 
     return None, None
 
 
+def _is_valid_percentile(value: float | None) -> bool:
+    """Return True when value is a bounded percentile [0, 100]."""
+    return value is not None and 0.0 <= value <= 100.0
+
+
 def _ras_confidence(component_count: int) -> float:
     """Confidence for a full RAS score based on how many combine components were used.
 
@@ -544,6 +549,65 @@ def _ras_confidence(component_count: int) -> float:
     if component_count >= 3:
         return 0.85
     return 0.80  # minimum (2 components — rare but possible)
+
+
+def resolve_wr_athletic_input(
+    ras_score: float | None,
+    ras_metric_count: int,
+    sporq_val: float | None,
+) -> tuple[float, str, float, str | None, bool]:
+    """Resolve WR athletic score/confidence with honest partial-data handling.
+
+    Cases:
+      1) Full RAS available -> use RAS with normal confidence
+      2) Partial RAS (3-4 metrics) + valid SPORQ -> 55/45 blend, conf 0.75
+      3) Partial RAS (3-4 metrics) only -> partial RAS, conf 0.70
+      4) No usable RAS + valid SPORQ -> SPORQ, conf 0.65
+      5) Neither -> neutral 50.0, conf 0.50
+    """
+    has_partial_ras = ras_score is not None and ras_metric_count in (3, 4)
+    has_full_ras = ras_score is not None and not has_partial_ras
+    valid_sporq = _is_valid_percentile(sporq_val)
+
+    if has_full_ras:
+        confidence = _ras_confidence(ras_metric_count)
+        return (
+            float(ras_score),
+            "RAS",
+            confidence,
+            f"RAS {ras_score:.1f} from {ras_metric_count} combine metrics",
+            False,
+        )
+
+    if has_partial_ras and valid_sporq:
+        blended = 0.55 * float(ras_score) + 0.45 * float(sporq_val)
+        return (
+            round(blended, 4),
+            "RAS_SPORQ_BLEND",
+            0.75,
+            f"Partial RAS ({ras_metric_count} metrics) blended with SPORQ ({ras_score:.1f} / {sporq_val:.1f})",
+            True,
+        )
+
+    if has_partial_ras:
+        return (
+            float(ras_score),
+            "RAS_PARTIAL",
+            0.70,
+            f"Partial RAS {ras_score:.1f} from {ras_metric_count} combine metrics (no SPORQ supplement)",
+            False,
+        )
+
+    if valid_sporq:
+        return (
+            float(sporq_val),
+            "SPORQ",
+            0.65,
+            f"SPORQ {sporq_val:.0f}th percentile (no usable RAS available)",
+            True,
+        )
+
+    return (50.0, "NEUTRAL_DEFAULT", 0.50, "No usable RAS/SPORQ; neutral athletic default", False)
 
 
 def resolve_athletic_input(
@@ -564,6 +628,13 @@ def resolve_athletic_input(
       3. COMBINE_FALLBACK (partial combine data, low confidence)
       4. None (no athletic data)
     """
+    sporq_val, sporq_ctx = _extract_sporq(context)
+    trust = SPORQ_TRUST.get(position, "ignore")
+
+    # WR-specific honesty logic: partial RAS and SPORQ-aware blending/default.
+    if position == "WR":
+        return resolve_wr_athletic_input(ras_score, ras_metric_count, sporq_val)
+
     # 1. RAS is the primary source
     if ras_score is not None:
         confidence = _ras_confidence(ras_metric_count)
@@ -576,8 +647,6 @@ def resolve_athletic_input(
         )
 
     # 2. SPORQ — position-gated
-    sporq_val, sporq_ctx = _extract_sporq(context)
-    trust = SPORQ_TRUST.get(position, "ignore")
     if sporq_val is not None and trust == "preferred":
         return (
             sporq_val,

--- a/scripts/compute_rookie_alpha.py
+++ b/scripts/compute_rookie_alpha.py
@@ -565,8 +565,8 @@ def resolve_wr_athletic_input(
       4) No usable RAS + valid SPORQ -> SPORQ, conf 0.65
       5) Neither -> neutral 50.0, conf 0.50
     """
+    has_full_ras = ras_score is not None and ras_metric_count >= 5
     has_partial_ras = ras_score is not None and ras_metric_count in (3, 4)
-    has_full_ras = ras_score is not None and not has_partial_ras
     valid_sporq = _is_valid_percentile(sporq_val)
 
     if has_full_ras:

--- a/tests/test_compute_rookie_alpha.py
+++ b/tests/test_compute_rookie_alpha.py
@@ -441,6 +441,17 @@ class ResolveAthleticInputTests(unittest.TestCase):
         self.assertIsNotNone(explainer)
         self.assertFalse(sporq_used)
 
+    def test_wr_two_metric_ras_without_sporq_is_treated_as_unusable_and_defaults_neutral(self) -> None:
+        score, source, conf, explainer, sporq_used = resolve_athletic_input(
+            "p1", "WR", ras_score=68.0, ras_metric_count=2,
+            combine_fallback_entry=None, context=None,
+        )
+        self.assertAlmostEqual(score, 50.0)
+        self.assertEqual(source, "NEUTRAL_DEFAULT")
+        self.assertAlmostEqual(conf, 0.50)
+        self.assertIsNotNone(explainer)
+        self.assertFalse(sporq_used)
+
     def test_ras_confidence_varies_by_metric_count(self) -> None:
         _, _, conf5, _, _ = resolve_athletic_input(
             "p1", "WR", ras_score=80.0, ras_metric_count=5,

--- a/tests/test_compute_rookie_alpha.py
+++ b/tests/test_compute_rookie_alpha.py
@@ -262,6 +262,57 @@ class RookieAlphaTests(unittest.TestCase):
         context_map = load_context_by_player_id(Path("/tmp/missing-context-file.json"))
         self.assertEqual(context_map, {})
 
+    def test_sporq_bonus_suppressed_when_wr_athletic_source_is_ras_sporq_blend(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            combine = tmp_path / "combine.json"
+            production = tmp_path / "production.json"
+            draft = tmp_path / "draft.json"
+            context = tmp_path / "context.json"
+            out_json = tmp_path / "out.json"
+            out_csv = tmp_path / "out.csv"
+            out_manifest = tmp_path / "manifest.json"
+            combine.write_text("[]\n", encoding="utf-8")
+            production.write_text("[]\n", encoding="utf-8")
+            draft.write_text("[]\n", encoding="utf-8")
+            context.write_text(
+                '[{"player_id":"wr1","player_name":"WR One","position":"WR","school":"School","class_year":2026,'
+                '"exceptional_metrics":[{"metric":"sporq_percentile","value":94.0,"percentile_tier":"historic",'
+                '"alpha_bonus_eligible":true,"context":"SPORQ test metric"}]}]',
+                encoding="utf-8",
+            )
+
+            player = PlayerInputs(
+                player_id="wr1",
+                player_name="WR One",
+                position="WR",
+                ras_score_0_100=72.0,
+                production_score_0_100=60.0,
+                draft_capital_proxy_0_100=70.0,
+                athletic_score_0_100=81.9,  # partial RAS + SPORQ blended athletic input
+                athletic_source="RAS_SPORQ_BLEND",
+                athletic_confidence=0.75,
+            )
+            baseline_alpha = round(rookie_alpha_score(player), 4)
+
+            write_outputs(
+                players=[player],
+                merge_diagnostics=MergeDiagnostics(0, 0, {"missing_combine": 0, "missing_production": 0, "missing_draft_proxy": 0, "total_excluded": 0}),
+                season=2026,
+                combine_path=combine,
+                production_path=production,
+                draft_proxy_path=draft,
+                output_json=out_json,
+                output_csv=out_csv,
+                output_manifest=out_manifest,
+                context_path=context,
+                context_by_id=load_context_by_player_id(context),
+            )
+            payload = load_json(out_json)
+            scores = payload["players"][0]["scores"]
+            self.assertAlmostEqual(scores["rookie_alpha_0_100"], baseline_alpha)
+            self.assertIsNone(scores["ceiling_bonus"])
+
     def test_missing_required_player_fields_are_skipped(self) -> None:
         players, _, _ = merge_inputs(
             combine_rows=[{"player_name": "No Id", "position": "WR", "forty": 4.5}],

--- a/tests/test_compute_rookie_alpha.py
+++ b/tests/test_compute_rookie_alpha.py
@@ -452,6 +452,18 @@ class ResolveAthleticInputTests(unittest.TestCase):
         self.assertIsNotNone(explainer)
         self.assertFalse(sporq_used)
 
+    def test_wr_two_metric_ras_with_sporq_uses_sporq_only_path_not_ras(self) -> None:
+        context = {"exceptional_metrics": [{"metric": "sporq_percentile", "value": 91.0}]}
+        score, source, conf, explainer, sporq_used = resolve_athletic_input(
+            "p1", "WR", ras_score=68.0, ras_metric_count=2,
+            combine_fallback_entry=None, context=context,
+        )
+        self.assertAlmostEqual(score, 91.0)
+        self.assertEqual(source, "SPORQ")
+        self.assertAlmostEqual(conf, 0.65)
+        self.assertIsNotNone(explainer)
+        self.assertTrue(sporq_used)
+
     def test_ras_confidence_varies_by_metric_count(self) -> None:
         _, _, conf5, _, _ = resolve_athletic_input(
             "p1", "WR", ras_score=80.0, ras_metric_count=5,

--- a/tests/test_compute_rookie_alpha.py
+++ b/tests/test_compute_rookie_alpha.py
@@ -359,14 +359,36 @@ class ResolveAthleticInputTests(unittest.TestCase):
         self.assertAlmostEqual(conf, 0.75)
         self.assertTrue(sporq_used)
 
-    def test_sporq_ignored_for_wr(self) -> None:
+    def test_wr_full_ras_uses_ras_with_normal_confidence(self) -> None:
         context = {"exceptional_metrics": [{"metric": "sporq_percentile", "value": 95.0}]}
         score, source, conf, explainer, sporq_used = resolve_athletic_input(
-            "p1", "WR", ras_score=None, ras_metric_count=0,
+            "p1", "WR", ras_score=88.0, ras_metric_count=5,
             combine_fallback_entry=None, context=context,
         )
-        self.assertIsNone(score)
-        self.assertIsNone(source)
+        self.assertAlmostEqual(score, 88.0)
+        self.assertEqual(source, "RAS")
+        self.assertAlmostEqual(conf, 1.0)
+        self.assertFalse(sporq_used)
+
+    def test_wr_partial_ras_with_sporq_blends_and_reduces_confidence(self) -> None:
+        context = {"exceptional_metrics": [{"metric": "sporq_percentile", "value": 95.0}]}
+        score, source, conf, explainer, sporq_used = resolve_athletic_input(
+            "p1", "WR", ras_score=70.0, ras_metric_count=4,
+            combine_fallback_entry=None, context=context,
+        )
+        self.assertAlmostEqual(score, 81.25)
+        self.assertEqual(source, "RAS_SPORQ_BLEND")
+        self.assertAlmostEqual(conf, 0.75)
+        self.assertTrue(sporq_used)
+
+    def test_wr_partial_ras_without_sporq_uses_partial_ras_with_lower_confidence(self) -> None:
+        score, source, conf, explainer, sporq_used = resolve_athletic_input(
+            "p1", "WR", ras_score=70.0, ras_metric_count=3,
+            combine_fallback_entry=None, context=None,
+        )
+        self.assertAlmostEqual(score, 70.0)
+        self.assertEqual(source, "RAS_PARTIAL")
+        self.assertAlmostEqual(conf, 0.70)
         self.assertFalse(sporq_used)
 
     def test_sporq_ignored_for_rb(self) -> None:
@@ -378,9 +400,20 @@ class ResolveAthleticInputTests(unittest.TestCase):
         self.assertIsNone(score)
         self.assertFalse(sporq_used)
 
-    def test_combine_fallback_used_when_no_ras_or_sporq(self) -> None:
+    def test_wr_sporq_only_is_used_with_moderate_confidence(self) -> None:
+        context = {"exceptional_metrics": [{"metric": "sporq_percentile", "value": 92.0}]}
         score, source, conf, explainer, sporq_used = resolve_athletic_input(
             "p1", "WR", ras_score=None, ras_metric_count=0,
+            combine_fallback_entry=None, context=context,
+        )
+        self.assertAlmostEqual(score, 92.0)
+        self.assertEqual(source, "SPORQ")
+        self.assertAlmostEqual(conf, 0.65)
+        self.assertTrue(sporq_used)
+
+    def test_combine_fallback_used_when_no_ras_or_sporq_for_non_wr(self) -> None:
+        score, source, conf, explainer, sporq_used = resolve_athletic_input(
+            "p1", "QB", ras_score=None, ras_metric_count=0,
             combine_fallback_entry=(55.0, 2), context=None,
         )
         self.assertAlmostEqual(score, 55.0)
@@ -389,23 +422,23 @@ class ResolveAthleticInputTests(unittest.TestCase):
         self.assertAlmostEqual(conf, 0.50)
         self.assertFalse(sporq_used)
 
-    def test_combine_fallback_confidence_for_one_metric(self) -> None:
+    def test_combine_fallback_confidence_for_one_metric_non_wr(self) -> None:
         _, _, conf, _, _ = resolve_athletic_input(
-            "p1", "WR", ras_score=None, ras_metric_count=0,
+            "p1", "QB", ras_score=None, ras_metric_count=0,
             combine_fallback_entry=(45.0, 1), context=None,
         )
         # confidence = 0.30 + 0.10 * min(1, 2) = 0.40
         self.assertAlmostEqual(conf, 0.40)
 
-    def test_no_data_returns_none(self) -> None:
+    def test_wr_no_signal_returns_neutral_default_with_honest_confidence(self) -> None:
         score, source, conf, explainer, sporq_used = resolve_athletic_input(
             "p1", "WR", ras_score=None, ras_metric_count=0,
             combine_fallback_entry=None, context=None,
         )
-        self.assertIsNone(score)
-        self.assertIsNone(source)
-        self.assertAlmostEqual(conf, 0.0)
-        self.assertIsNone(explainer)
+        self.assertAlmostEqual(score, 50.0)
+        self.assertEqual(source, "NEUTRAL_DEFAULT")
+        self.assertAlmostEqual(conf, 0.50)
+        self.assertIsNotNone(explainer)
         self.assertFalse(sporq_used)
 
     def test_ras_confidence_varies_by_metric_count(self) -> None:


### PR DESCRIPTION
### Motivation
- Partial WR RAS inputs were being treated with too-high confidence, producing misleadingly settled athletic evaluations.
- SPORQ can be a useful supplementary signal for WRs in some cases and should be integrated where available without overstating certainty.
- Keep the change narrow to scoring/export logic and avoid touching SPORQ ingestion or UI work (follow-ups tracked under #126).

### Description
- Added a percentile validator ` _is_valid_percentile` and a deterministic WR-specific resolver `resolve_wr_athletic_input` in `scripts/compute_rookie_alpha.py` to centralize WR athletic decisioning.
- Implemented the five-case WR behavior: full RAS (use RAS/confidence), partial RAS + SPORQ (55/45 blend, conf 0.75), partial RAS only (use partial, conf 0.70), SPORQ only (use SPORQ, conf 0.65), and neutral fallback (50.0, conf 0.50).
- Routed WR decisioning through `resolve_wr_athletic_input` inside `resolve_athletic_input` while preserving prior TE/RB/QB paths and existing RAS confidence semantics.
- Added/updated focused unit tests in `tests/test_compute_rookie_alpha.py` to cover all five WR cases and to assert confidence is exported and reduced for partial/missing signals.

### Testing
- Ran `pytest -q tests/test_compute_rookie_alpha.py`, which succeeded with `40 passed`.
- The updated test suite verifies full RAS, partial RAS + SPORQ blend, partial RAS only, SPORQ only, and neutral-fallback behavior for WRs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2741beb008332a0738c18f6c6e49d)