### PR TITLE
PR3: add evidence completeness scoring and cap displayed consensus delta

### DIFF
--- a/scripts/compute_rookie_alpha.py
+++ b/scripts/compute_rookie_alpha.py
@@ -210,6 +210,12 @@ POSITIONAL_SCORE_CURVES: dict[str, list[float]] = {
 }
 _POSITIONAL_CURVE_TAIL_STEP = 0.5   # score drop per rank beyond the table
 _POSITIONAL_CURVE_FLOOR = 28.0      # minimum consensus score for any rank
+CONSENSUS_DELTA_CAP_BANDS: tuple[tuple[float, float, str], ...] = (
+    (0.80, 30.0, ">=0.80"),
+    (0.60, 18.0, "0.60-0.79"),
+    (0.40, 10.0, "0.40-0.59"),
+    (0.00, 5.0, "<0.40"),
+)
 
 
 def positional_rank_to_score(position: str, rank: int) -> float:
@@ -224,6 +230,62 @@ def positional_rank_to_score(position: str, rank: int) -> float:
         return curve[rank - 1]
     extra = rank - len(curve)
     return max(_POSITIONAL_CURVE_FLOOR, curve[-1] - extra * _POSITIONAL_CURVE_TAIL_STEP)
+
+
+def compute_evidence_completeness_score(
+    player: PlayerInputs,
+    raw_context: dict[str, Any] | None = None,
+) -> float:
+    """Compute evidence completeness score on [0.0, 1.0]."""
+    raw_context = raw_context or {}
+    score = 0.0
+
+    seasons_available = raw_context.get("seasons_available")
+    if seasons_available is not None:
+        try:
+            if int(seasons_available) > 0:
+                score += 0.25
+        except (TypeError, ValueError):
+            pass
+
+    advanced_receiving_present = any(
+        raw_context.get(field) is not None
+        for field in (
+            "career_yards_per_route_run",
+            "best_season_yprr",
+            "career_receiving_market_share",
+        )
+    )
+    if advanced_receiving_present:
+        score += 0.15
+
+    if raw_context.get("one_d_rr") is not None:
+        score += 0.10
+
+    if raw_context.get("dob_seeded") is True:
+        score += 0.10
+
+    if player.athletic_source == "RAS":
+        score += 0.15
+
+    if raw_context.get("power4_early_contributor_flag") is True:
+        score += 0.15
+
+    flags = raw_context.get("context_flags") or []
+    low_confidence_flagged = raw_context.get("low_confidence_seed") is True or "low_confidence_seed" in flags
+    if not low_confidence_flagged:
+        score += 0.10
+
+    return round(clamp_0_100(score * 100.0) / 100.0, 2)
+
+
+def cap_consensus_delta_by_completeness(raw_delta: float, completeness_score: float) -> tuple[float, float, str]:
+    """Return (capped_delta, cap_limit, cap_tier_label) for display semantics."""
+    bounded_completeness = max(0.0, min(1.0, completeness_score))
+    for threshold, cap, label in CONSENSUS_DELTA_CAP_BANDS:
+        if bounded_completeness >= threshold:
+            return max(-cap, min(cap, raw_delta)), cap, label
+    return max(-5.0, min(5.0, raw_delta)), 5.0, "<0.40"
 
 
 def load_positional_consensus(path: Path) -> dict[str, dict]:
@@ -1393,12 +1455,28 @@ def write_outputs(
             blended_rank = round(mean(pos_ranks))
             sources_count: int | None = len(pos_ranks)
             consensus_score_pos: float | None = round(positional_rank_to_score(p.position, blended_rank), 1)
-            consensus_delta_pos: float | None = round(alpha - consensus_score_pos, 1)
+            consensus_delta_pos_raw: float | None = round(alpha - consensus_score_pos, 1)
+            evidence_completeness_score = compute_evidence_completeness_score(
+                player=p,
+                raw_context=context_by_id.get(p.player_id),
+            )
+            consensus_delta_pos, consensus_delta_cap_limit, consensus_delta_cap_tier = cap_consensus_delta_by_completeness(
+                raw_delta=consensus_delta_pos_raw,
+                completeness_score=evidence_completeness_score,
+            )
+            consensus_delta_pos = round(consensus_delta_pos, 1)
         else:
             blended_rank = None
             sources_count = None
             consensus_score_pos = None
+            consensus_delta_pos_raw = None
             consensus_delta_pos = None
+            evidence_completeness_score = compute_evidence_completeness_score(
+                player=p,
+                raw_context=context_by_id.get(p.player_id),
+            )
+            consensus_delta_cap_limit = None
+            consensus_delta_cap_tier = None
 
         row_payload = {
             "player_id": p.player_id,
@@ -1432,6 +1510,10 @@ def write_outputs(
                 "consensus_position_rank_blended": blended_rank,
                 "consensus_position_rank_sources_count": sources_count,
                 "consensus_score_positional_0_100": consensus_score_pos,
+                "evidence_completeness_score": evidence_completeness_score,
+                "consensus_delta_positional_raw": consensus_delta_pos_raw,
+                "consensus_delta_positional_cap_limit": consensus_delta_cap_limit,
+                "consensus_delta_positional_cap_tier": consensus_delta_cap_tier,
                 "consensus_delta_positional": consensus_delta_pos,
                 # Legacy field — kept for backward compat; semantics are misleading
                 # (compares alpha against overall draft capital, not positional consensus)
@@ -1485,7 +1567,7 @@ def write_outputs(
             "name": "tiber-rookie-alpha",
             "stage": "pre-draft",
             "label": "pre-draft v0",
-            "model_version": "rookie-alpha-predraft-v0.4.0",
+            "model_version": "rookie-alpha-predraft-v0.5.0",
             "formula": {
                 "ras_weight": 0.35,
                 "production_weight": 0.45,
@@ -1539,6 +1621,10 @@ def write_outputs(
                 "rookie_alpha_0_100",
                 "consensus_position_rank_blended",
                 "consensus_score_positional_0_100",
+                "evidence_completeness_score",
+                "consensus_delta_positional_raw",
+                "consensus_delta_positional_cap_limit",
+                "consensus_delta_positional_cap_tier",
                 "consensus_delta_positional",
                 "market_investment_delta_legacy",
                 "talent_rank",
@@ -1565,6 +1651,10 @@ def write_outputs(
                     "rookie_alpha_0_100": row["scores"]["rookie_alpha_0_100"],
                     "consensus_position_rank_blended": row["scores"].get("consensus_position_rank_blended") or "",
                     "consensus_score_positional_0_100": row["scores"].get("consensus_score_positional_0_100") or "",
+                    "evidence_completeness_score": row["scores"].get("evidence_completeness_score") if row["scores"].get("evidence_completeness_score") is not None else "",
+                    "consensus_delta_positional_raw": row["scores"].get("consensus_delta_positional_raw") if row["scores"].get("consensus_delta_positional_raw") is not None else "",
+                    "consensus_delta_positional_cap_limit": row["scores"].get("consensus_delta_positional_cap_limit") if row["scores"].get("consensus_delta_positional_cap_limit") is not None else "",
+                    "consensus_delta_positional_cap_tier": row["scores"].get("consensus_delta_positional_cap_tier") or "",
                     "consensus_delta_positional": row["scores"].get("consensus_delta_positional") if row["scores"].get("consensus_delta_positional") is not None else "",
                     "market_investment_delta_legacy": row["scores"].get("market_investment_delta_legacy") or "",
                     "talent_rank": row["talent_rank"],

--- a/tests/test_compute_rookie_alpha.py
+++ b/tests/test_compute_rookie_alpha.py
@@ -8,6 +8,8 @@ from scripts.compute_rookie_alpha import (
     SPORQ_TRUST,
     _extract_sporq,
     _ras_confidence,
+    cap_consensus_delta_by_completeness,
+    compute_evidence_completeness_score,
     load_context_by_player_id,
     coerce_float,
     compute_ras_scores,
@@ -219,7 +221,7 @@ class RookieAlphaTests(unittest.TestCase):
             self.assertEqual(manifest["output_files"][1]["sha256"], sha256_file(out_csv))
             self.assertEqual(manifest["input_files"][0]["row_count"], 0)
             self.assertEqual(manifest["export_metadata"]["coverage_summary"], manifest["coverage_summary"])
-            self.assertEqual(manifest["model_version"], "rookie-alpha-predraft-v0.4.0")
+            self.assertEqual(manifest["model_version"], "rookie-alpha-predraft-v0.5.0")
 
     def test_context_is_additive_and_optional(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -570,6 +572,95 @@ class SporqTrustConfigTests(unittest.TestCase):
     def test_rb_qb_are_ignore(self) -> None:
         self.assertEqual(SPORQ_TRUST["RB"], "ignore")
         self.assertEqual(SPORQ_TRUST["QB"], "ignore")
+
+
+class ConsensusEvidenceGuardrailTests(unittest.TestCase):
+    def test_completeness_score_high_and_low_profiles(self) -> None:
+        high_player = PlayerInputs("high", "High", "WR", 85.0, 75.0, 80.0, athletic_source="RAS")
+        high_ctx = {
+            "seasons_available": 3,
+            "career_yards_per_route_run": 2.7,
+            "one_d_rr": 0.34,
+            "dob_seeded": True,
+            "power4_early_contributor_flag": True,
+            "context_flags": [],
+        }
+        low_player = PlayerInputs("low", "Low", "WR", None, 75.0, 80.0, athletic_source="SPORQ")
+        low_ctx = {
+            "seasons_available": 0,
+            "context_flags": ["low_confidence_seed"],
+        }
+        self.assertAlmostEqual(compute_evidence_completeness_score(high_player, high_ctx), 1.0)
+        self.assertAlmostEqual(compute_evidence_completeness_score(low_player, low_ctx), 0.0)
+
+    def test_cap_bands_and_sign_preservation(self) -> None:
+        self.assertEqual(cap_consensus_delta_by_completeness(40.0, 0.80), (30.0, 30.0, ">=0.80"))
+        self.assertEqual(cap_consensus_delta_by_completeness(-40.0, 0.80), (-30.0, 30.0, ">=0.80"))
+        self.assertEqual(cap_consensus_delta_by_completeness(40.0, 0.70), (18.0, 18.0, "0.60-0.79"))
+        self.assertEqual(cap_consensus_delta_by_completeness(-40.0, 0.50), (-10.0, 10.0, "0.40-0.59"))
+        self.assertEqual(cap_consensus_delta_by_completeness(40.0, 0.20), (5.0, 5.0, "<0.40"))
+
+    def test_raw_vs_capped_export_semantics(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            combine = tmp_path / "combine.json"
+            production = tmp_path / "production.json"
+            draft = tmp_path / "draft.json"
+            context = tmp_path / "context.json"
+            positional = tmp_path / "positional_consensus.json"
+            out_json = tmp_path / "out.json"
+            out_csv = tmp_path / "out.csv"
+            out_manifest = tmp_path / "manifest.json"
+            for p in (combine, production, draft):
+                p.write_text("[]\n", encoding="utf-8")
+            context.write_text(
+                '[{"player_id":"wr1","player_name":"WR One","position":"WR","seasons_available":0,'
+                '"context_flags":["low_confidence_seed"]}]',
+                encoding="utf-8",
+            )
+            positional.write_text(
+                '{"sources":[{"source":"test","entries":[{"player_id":"wr1","positional_rank":5}]}]}',
+                encoding="utf-8",
+            )
+
+            player = PlayerInputs(
+                player_id="wr1",
+                player_name="WR One",
+                position="WR",
+                ras_score_0_100=99.0,
+                production_score_0_100=99.0,
+                draft_capital_proxy_0_100=99.0,
+                athletic_score_0_100=99.0,
+                athletic_source="RAS",
+            )
+            write_outputs(
+                players=[player],
+                merge_diagnostics=MergeDiagnostics(0, 0, {"missing_combine": 0, "missing_production": 0, "missing_draft_proxy": 0, "total_excluded": 0}),
+                season=2026,
+                combine_path=combine,
+                production_path=production,
+                draft_proxy_path=draft,
+                output_json=out_json,
+                output_csv=out_csv,
+                output_manifest=out_manifest,
+                context_path=context,
+                context_by_id=load_context_by_player_id(context),
+                positional_consensus_path=positional,
+                positional_consensus_by_id={"wr1": {"ranks": [5], "sources": ["test"]}},
+            )
+            scores = load_json(out_json)["players"][0]["scores"]
+            self.assertGreater(scores["consensus_delta_positional_raw"], 30.0)
+            self.assertEqual(scores["consensus_delta_positional"], 5.0)
+            self.assertEqual(scores["consensus_delta_positional_cap_tier"], "<0.40")
+            self.assertEqual(scores["consensus_delta_positional_cap_limit"], 5.0)
+
+    def test_bell_style_incomplete_evidence_restrains_large_delta(self) -> None:
+        player = PlayerInputs("bell", "Bell", "WR", 90.0, 90.0, 90.0, athletic_source="RAS")
+        sparse_ctx = {"seasons_available": 0, "context_flags": ["low_confidence_seed"]}
+        completeness = compute_evidence_completeness_score(player, sparse_ctx)
+        capped, _, _ = cap_consensus_delta_by_completeness(27.0, completeness)
+        self.assertEqual(completeness, 0.15)
+        self.assertEqual(capped, 5.0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Prevent weakly supported profiles from surfacing outsized consensus deltas while preserving raw disagreement signals for inspection.
- Provide an explicit, inspectable evidence-completeness layer so display semantics can be safely constrained without mutating core alpha logic.

### Description
- Files changed: `scripts/compute_rookie_alpha.py` and `tests/test_compute_rookie_alpha.py`.
- Added `compute_evidence_completeness_score(player, raw_context)` which assembles a 0.0–1.0 completeness score using an additive scheme: `seasons_available > 0 +0.25`, advanced receiving stats +0.15, `one_d_rr` +0.10, `dob_seeded` +0.10, full RAS (`athletic_source == 'RAS'`) +0.15, `power4_early_contributor_flag` +0.15, and no `low_confidence_seed` +0.10, with clamping to [0.0,1.0].
- Introduced cap bands and `cap_consensus_delta_by_completeness(raw_delta, completeness_score)` applying magnitude caps only (sign preserved): completeness >=0.80 → ±30, 0.60–0.79 → ±18, 0.40–0.59 → ±10, <0.40 → ±5.
- Preserved raw disagreement and added inspectable export fields by keeping `consensus_delta_positional` as the capped/display value and adding `consensus_delta_positional_raw`, `consensus_delta_positional_cap_limit`, `consensus_delta_positional_cap_tier`, and `evidence_completeness_score`; bumped `model_version` to `rookie-alpha-predraft-v0.5.0`.

### Testing
- Added focused unit tests in `tests/test_compute_rookie_alpha.py` covering completeness assembly, each cap band (including sign preservation), raw vs capped export semantics, and the Bell-style regression shape.
- Ran the test suite with `python -m unittest tests.test_compute_rookie_alpha` and all tests passed (47 tests, OK).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2a71ceff883328282f34b8abf5986)