### PR TITLE
Audit cleanup: fix naming inconsistencies and stale references

### DIFF
--- a/components/rookies/RookieBoardRow.js
+++ b/components/rookies/RookieBoardRow.js
@@ -28,8 +28,8 @@ const PPR_BAND_CLASS = {
 };
 
 /**
- * Renders a compact 3-bar SVG showing RAS / Production / Draft Capital (0–100).
- * Bars are colour-coded: RAS = steel blue, Production = teal, Draft = coral.
+ * Renders a compact 3-bar SVG showing Athletic / Production / Draft Capital (0–100).
+ * Bars are colour-coded: Athletic (RAS/SPORQ/partial) = steel blue, Production = teal, Draft = coral.
  */
 function athChipLabel(source) {
   if (source === 'SPORQ') return 'SPORQ';

--- a/components/rookies/RookieCard.js
+++ b/components/rookies/RookieCard.js
@@ -55,7 +55,7 @@ function renderRadarChart(athleticScore, production, draftCapital, athleticSourc
   const centerX = 100;
   const centerY = 100;
   const radius = 80;
-  const athLabel = athleticSource === 'SPORQ' ? 'ATH (SPORQ)' : athleticSource === 'COMBINE_FALLBACK' ? 'ATH (partial)' : 'ATH';
+  const athLabel = athleticSource === 'SPORQ' ? 'ATH (SPORQ)' : athleticSource === 'COMBINE_FALLBACK' ? 'ATH (partial)' : 'RAS';
   const axes = [
     { label: athLabel, angle: -Math.PI / 2, value: athleticScore },
     { label: 'Production', angle: Math.PI / 6, value: production },

--- a/lib/rookies/deriveRookieProfileSummary.js
+++ b/lib/rookies/deriveRookieProfileSummary.js
@@ -10,11 +10,11 @@ function scoreBandLabel(rookieGrade) {
   return SCORE_BANDS.find((band) => rookieGrade >= band.min).label;
 }
 
-function buildArchetypeLabel(position, ras, production, draftCapital) {
+function buildArchetypeLabel(position, athleticScore, production, draftCapital) {
   const rolePrefix = position ? `${position} profile` : 'Rookie profile';
   const candidates = [
     { key: 'production', value: production, label: 'production-led' },
-    { key: 'athletic', value: ras, label: 'traits-led' },
+    { key: 'athletic', value: athleticScore, label: 'traits-led' },
     { key: 'capital', value: draftCapital, label: 'capital-backed' },
   ].filter((candidate) => Number.isFinite(candidate.value));
 
@@ -26,10 +26,10 @@ function buildArchetypeLabel(position, ras, production, draftCapital) {
   return `${rolePrefix} (${topLabel})`;
 }
 
-function topSignalPhrase({ ras, production, draftCapital }) {
+function topSignalPhrase({ athleticScore, production, draftCapital }) {
   const candidates = [
     { value: production, phrase: production >= 80 ? 'strong production signal' : 'production signal present' },
-    { value: ras, phrase: ras >= 75 ? 'above-baseline athletic signal' : 'athletic signal present' },
+    { value: athleticScore, phrase: athleticScore >= 75 ? 'above-baseline athletic signal' : 'athletic signal present' },
     { value: draftCapital, phrase: draftCapital >= 75 ? 'favorable capital signal' : 'capital signal present' },
   ].filter((candidate) => Number.isFinite(candidate.value));
 
@@ -38,10 +38,10 @@ function topSignalPhrase({ ras, production, draftCapital }) {
   return candidates[0].phrase;
 }
 
-export function deriveRookieProfileSummary({ identity, rookieGrade, ras, production, draftCapital, missingInputs = [] }) {
-  const archetype = buildArchetypeLabel(identity?.position, ras, production, draftCapital);
+export function deriveRookieProfileSummary({ identity, rookieGrade, athleticScore, production, draftCapital, missingInputs = [] }) {
+  const archetype = buildArchetypeLabel(identity?.position, athleticScore, production, draftCapital);
   const band = scoreBandLabel(rookieGrade);
-  const signalPhrase = topSignalPhrase({ ras, production, draftCapital });
+  const signalPhrase = topSignalPhrase({ athleticScore, production, draftCapital });
   const missingNote = missingInputs.length ? `missing ${missingInputs.length} model input${missingInputs.length === 1 ? '' : 's'}` : 'full model inputs available';
 
   return {

--- a/lib/rookies/exportCsv.js
+++ b/lib/rookies/exportCsv.js
@@ -29,7 +29,7 @@ export function buildBoardCsv(rows) {
   const headers = [
     'board_rank', 'class_rank', 'name', 'position', 'school', 'draft_class',
     'tier', 'rookie_grade', 'athletic_score', 'production_score', 'draft_capital_score',
-    'consensus_delta', 'evidence_tier', 'breakout_age',
+    'consensus_delta_positional', 'evidence_tier', 'breakout_age',
   ];
   const data = rows.map((row, i) => ({
     board_rank: i + 1,
@@ -43,7 +43,7 @@ export function buildBoardCsv(rows) {
     athletic_score: row.athleticScore?.toFixed(1) ?? '',
     production_score: row.productionScore?.toFixed(1) ?? '',
     draft_capital_score: row.draftCapitalScore?.toFixed(1) ?? '',
-    consensus_delta: row.consensusDelta ?? '',
+    consensus_delta_positional: row.consensusDelta ?? '',
     evidence_tier: row.evidenceTier ?? '',
     breakout_age: row.breakoutAge ?? '',
   }));

--- a/lib/rookies/mapRookieToCard.js
+++ b/lib/rookies/mapRookieToCard.js
@@ -128,7 +128,7 @@ export function mapRookieToCard({ alphaPlayer, combineRow, productionRow, draftR
   const profileContext = deriveRookieProfileSummary({
     identity,
     rookieGrade,
-    ras: athleticScore,
+    athleticScore,
     production,
     draftCapital,
     missingInputs: missingModelInputs,


### PR DESCRIPTION
- exportCsv.js: rename CSV header consensus_delta → consensus_delta_positional
  to match the canonical export field name (market_investment_delta_legacy is
  the deprecated predecessor; this column has always carried positional data)
- deriveRookieProfileSummary.js: rename ras parameter → athleticScore since the
  value passed is the resolved athletic score (RAS/SPORQ/COMBINE_FALLBACK), not
  strictly RAS; update call site in mapRookieToCard.js
- RookieCard.js: radar chart athLabel else-case was 'ATH' while every other
  surface (board chip, metric bar, mapRookieToCard) uses 'RAS' — align to 'RAS'
- RookieBoardRow.js: update mini-chart comment to say 'Athletic' instead of 'RAS'
  since the first bar represents the resolved athletic source

No score logic changed. No data changed. Display text and CSV header only.

https://claude.ai/code/session_01AfyZSQ9DYivAtHqa93kZus