### PR TITLE
Port PR153 design language to canonical rookie player card

### DIFF
--- a/cards/rookies/player.html
+++ b/cards/rookies/player.html
@@ -24,9 +24,9 @@
     </header>
 
     <main class="page">
-      <section id="detail-actions" style="margin-top: 12px"></section>
-      <section id="card-root" style="margin-top: 12px">Loading rookie card…</section>
-      <section id="sporq-comps-root" style="margin-top: 0"></section>
+      <section id="detail-actions" class="detail-actions-shell"></section>
+      <section id="card-root" class="card-root-shell">Loading rookie card…</section>
+      <section id="sporq-comps-root" class="sporq-shell"></section>
     </main>
 
     <!-- ── Site footer ───────────────────────────────────────────────────────── -->
@@ -78,10 +78,10 @@
         ].filter(Boolean);
 
         actionsRoot.innerHTML = `
-          <div class="rookie-card" style="padding: 12px 14px; display: flex; justify-content: space-between; gap: 10px; align-items: center;">
-            <div>
+          <div class="detail-actions-panel">
+            <div class="detail-actions-copy">
               <div class="meta">Shortlist status for ${card.identity.name}: <strong>${queued ? 'Queued' : 'Not queued'}</strong></div>
-              ${queued && annotationBits.length ? `<div class="meta" style="margin-top: 4px;">${annotationBits.join(' • ')}</div>` : ''}
+              ${queued && annotationBits.length ? `<div class="meta detail-actions-note">${annotationBits.join(' • ')}</div>` : ''}
             </div>
             <button type="button" class="queue-toggle ${queued ? 'is-queued' : ''}" id="detail-queue-toggle">${queued ? 'Remove from queue' : 'Add to queue'}</button>
           </div>

--- a/components/rookies/RookieCard.js
+++ b/components/rookies/RookieCard.js
@@ -96,7 +96,7 @@ function renderRadarChart(athleticScore, production, draftCapital, athleticSourc
   }).join('');
 
   return `
-    <section class="metrics radar-section">
+    <div class="radar-section">
       <div class="section-title">Model Input Radar</div>
       <svg class="radar-chart" viewBox="0 0 200 200" role="img" aria-label="Radar chart for athletic, production, and draft capital scores">
         ${rings}
@@ -104,7 +104,7 @@ function renderRadarChart(athleticScore, production, draftCapital, athleticSourc
         <polygon points="${dataPoints}" fill="rgba(59, 130, 246, 0.25)" stroke="#3b82f6" stroke-width="2" />
         ${labels}
       </svg>
-    </section>
+    </div>
   `;
 }
 
@@ -273,77 +273,98 @@ export function renderRookieCard(container, card) {
     const includeProductionSpecials = selectedMetricFamily === 'all' || selectedMetricFamily === 'production';
 
     container.innerHTML = `
-    <article class="rookie-card">
-      <div class="header-grid">
-        <div>
-          <div class="section-title">TIBER Rookie Card</div>
-          <h1 class="player-name">
-            ${renderTeamLogos(card.identity.school, card.identity.nflTeam)}${esc(card.identity.name)}
-          </h1>
-          <div class="meta">${esc(identityBits || 'Profile context not available')}</div>
-          <div class="meta">${esc(card.summary.profileSummary ?? card.summary.identityNote ?? 'Identity summary unavailable')}</div>
+    <article class="rookie-card rookie-card-layout">
+      <section class="hero-panel">
+        <div class="hero-top">
+          <div class="hero-left">
+            <div class="section-title">TIBER Rookie Card · Canonical Artifact Surface</div>
+            <h1 class="player-name">
+              <span class="avatar-pos pos-${esc(card.identity.position)}">${esc(card.identity.position)}</span>
+              ${renderTeamLogos(card.identity.school, card.identity.nflTeam)}${esc(card.identity.name)}
+            </h1>
+            <div class="meta">${esc(identityBits || 'Profile context not available')}</div>
+            <p class="profile-summary">${esc(card.summary.profileSummary ?? card.summary.identityNote ?? 'Identity summary unavailable')}</p>
+          </div>
+          <div class="hero-score">
+            <div class="section-title">Rookie Grade</div>
+            <div class="score">${esc(heroScore)}</div>
+            <div class="meta">Class #${esc(card.summary.classRank ?? 'N/A')} · ${esc(card.identity.position)} #${esc(card.summary.posRank ?? 'N/A')}</div>
+            ${renderEvidenceTierBadge(card)}
+          </div>
         </div>
-        <div class="hero-score">
-          <div class="section-title">Rookie Grade</div>
-          <div class="score">${esc(heroScore)}</div>
-          <div class="meta">Class rank #${esc(card.summary.classRank ?? 'N/A')}</div>
+        <div class="identity-strip">
+          ${pill('Archetype', card.summary.archetype)}
+          ${pill('Projection', card.summary.projection)}
+          ${pill('Breakout', breakoutPillValue(card))}
+          ${pill('Evidence Tier', EVIDENCE_TIER_LABELS[card.evidenceTier] ?? null)}
+        </div>
+      </section>
+
+      <section class="card-actions-row">
+        <a class="nav-link" href="/cards/rookies/board/">← Back to board</a>
+        <a class="nav-link" href="/cards/rookies/compare/?left=${esc(card.slug)}">Compare this profile →</a>
+      </section>
+
+      <div class="card-columns">
+        <div class="card-col">
+          <section class="metrics card-panel">
+            <div class="section-title">Model Scores</div>
+            <div class="meta">Deterministic model components from canonical artifacts.</div>
+            <div class="core-row model-score-grid">
+              ${card.scores.map(scoreCell).join('')}
+            </div>
+          </section>
+
+          <section class="metrics card-panel">
+            <div class="section-title">Position-aware Evidence</div>
+            <div class="meta">${esc(card.evidence?.readinessLabel ?? 'Evidence readiness unavailable')}</div>
+            <div class="metric-family-filters" aria-label="Filter evidence metrics by family">
+              ${metricFamilies.map((family) => `
+                <button type="button" class="metric-family-btn ${selectedMetricFamily === family ? 'is-active' : ''}" data-metric-family="${esc(family)}" aria-pressed="${selectedMetricFamily === family ? 'true' : 'false'}">${esc(metricFamilyLabel(family))}</button>
+              `).join('')}
+            </div>
+            ${includeProductionSpecials ? renderAgeAdjMetric(card.ageAdjustedProduction) : ''}
+            ${includeProductionSpecials ? renderBoarMetricRow(card) : ''}
+            ${filteredEvidenceMetrics.map(metricRow).join('') || '<div class="meta">No evidence metrics available.</div>'}
+          </section>
+
+          <section class="metrics card-panel">
+            <div class="section-title">Season Stats</div>
+            ${seasonsTable}
+          </section>
+        </div>
+
+        <div class="card-col">
+          <section class="card-panel">
+            ${renderRadarChart(card.scores[1]?.value, card.scores[2]?.value, card.scores[3]?.value, card.athleticSource)}
+          </section>
+
+          ${renderPprProjection(card.pprProjection)}
+
+          <section class="metrics card-panel">
+            <div class="section-title">Projection Comps</div>
+            <div class="comp-grid">
+              <div class="comp-card"><div class="pill-label">High-end</div><div class="comp-name">${esc(card.comps.high ?? 'N/A')}</div></div>
+              <div class="comp-card"><div class="pill-label">Low-end</div><div class="comp-name">${esc(card.comps.low ?? 'N/A')}</div></div>
+            </div>
+          </section>
+
+          <section class="metrics card-panel">
+            <div class="section-title">Translation & Evidence Signals</div>
+            <div class="meta">${esc(evidenceSummary ?? 'Translation summary unavailable in current artifacts.')}</div>
+            ${translationFlags.length
+              ? `<div class="tags tags-translation">${translationFlags.map((flag) => `<span class="tag">${esc(String(flag).replace(/_/g, ' '))}</span>`).join('')}</div>`
+              : '<div class="meta">No translation evidence tags available.</div>'}
+            ${contextFlags.length
+              ? `<div class="tags tags-context">${contextFlags.map((flag) => `<span class="tag tag-context">${esc(String(flag).replace(/_/g, ' '))}</span>`).join('')}</div>`
+              : ''}
+          </section>
+
+          ${card.tags.length
+            ? `<section class="metrics card-panel"><div class="section-title">Scouting Tags</div><div class="tags">${card.tags.map((tag) => `<span class="tag">${esc(tag)}</span>`).join('')}</div></section>`
+            : ''}
         </div>
       </div>
-
-      <section class="identity-strip">
-        ${pill('Archetype', card.summary.archetype)}
-        ${pill('Projection', card.summary.projection)}
-        ${pill('High-end comp', card.comps.high)}
-        ${pill('Low-end comp', card.comps.low)}
-        ${pill('Breakout', breakoutPillValue(card))}
-        ${pill('Evidence Tier', EVIDENCE_TIER_LABELS[card.evidenceTier] ?? null)}
-      </section>
-      ${renderEvidenceTierBadge(card)}
-
-      <section class="metrics">
-        <div class="section-title">Model Scores</div>
-        <div class="meta">Deterministic model components from canonical artifacts.</div>
-        <div class="core-row model-score-grid">
-        ${card.scores.map(scoreCell).join('')}
-        </div>
-      </section>
-
-      ${renderRadarChart(card.scores[1]?.value, card.scores[2]?.value, card.scores[3]?.value, card.athleticSource)}
-
-      ${renderPprProjection(card.pprProjection)}
-
-      <section class="metrics">
-        <div class="section-title">Position-aware Evidence</div>
-        <div class="meta">${esc(card.evidence?.readinessLabel ?? 'Evidence readiness unavailable')}</div>
-        <div class="metric-family-filters" aria-label="Filter evidence metrics by family">
-          ${metricFamilies.map((family) => `
-            <button type="button" class="metric-family-btn ${selectedMetricFamily === family ? 'is-active' : ''}" data-metric-family="${esc(family)}" aria-pressed="${selectedMetricFamily === family ? 'true' : 'false'}">${esc(metricFamilyLabel(family))}</button>
-          `).join('')}
-        </div>
-        ${includeProductionSpecials ? renderAgeAdjMetric(card.ageAdjustedProduction) : ''}
-        ${includeProductionSpecials ? renderBoarMetricRow(card) : ''}
-        ${filteredEvidenceMetrics.map(metricRow).join('') || '<div class="meta">No evidence metrics available.</div>'}
-      </section>
-
-      <section class="metrics">
-        <div class="section-title">Why this profile translates (deterministic)</div>
-        <div class="meta">${esc(evidenceSummary ?? 'Translation summary unavailable in current artifacts.')}</div>
-        ${translationFlags.length
-          ? `<div class="tags">${translationFlags.map((flag) => `<span class="tag">${esc(String(flag).replace(/_/g, ' '))}</span>`).join('')}</div>`
-          : '<div class="meta">No translation evidence tags available.</div>'}
-        ${contextFlags.length
-          ? `<div class="meta">Context flags: ${esc(contextFlags.map((flag) => String(flag).replace(/_/g, ' ')).join(' • '))}</div>`
-          : ''}
-      </section>
-
-      <section class="metrics">
-        <div class="section-title">Season Stats</div>
-        ${seasonsTable}
-      </section>
-
-      ${card.tags.length
-        ? `<section class="tags">${card.tags.map((tag) => `<span class="tag">${esc(tag)}</span>`).join('')}</section>`
-        : ''}
     </article>
   `;
 

--- a/components/rookies/RookieCard.js
+++ b/components/rookies/RookieCard.js
@@ -250,6 +250,7 @@ export function renderRookieCard(container, card) {
   const translationFlags = Array.isArray(card.translationFlags) ? card.translationFlags : [];
   const contextFlags = Array.isArray(card.contextSignals?.contextFlags) ? card.contextSignals.contextFlags : [];
   const evidenceSummary = card.contextSignals?.evidenceSummary ?? null;
+  const quickPprMedian = card.pprProjection?.median ?? null;
   let selectedMetricFamily = 'all';
 
   const seasonsTable = card.seasons.length
@@ -277,7 +278,7 @@ export function renderRookieCard(container, card) {
       <section class="hero-panel">
         <div class="hero-top">
           <div class="hero-left">
-            <div class="section-title">TIBER Rookie Card · Canonical Artifact Surface</div>
+            <div class="section-title">TIBER Rookie Card</div>
             <h1 class="player-name">
               <span class="avatar-pos pos-${esc(card.identity.position)}">${esc(card.identity.position)}</span>
               ${renderTeamLogos(card.identity.school, card.identity.nflTeam)}${esc(card.identity.name)}
@@ -295,14 +296,20 @@ export function renderRookieCard(container, card) {
         <div class="identity-strip">
           ${pill('Archetype', card.summary.archetype)}
           ${pill('Projection', card.summary.projection)}
+          ${pill('Year 1 Median PPR', quickPprMedian)}
           ${pill('Breakout', breakoutPillValue(card))}
-          ${pill('Evidence Tier', EVIDENCE_TIER_LABELS[card.evidenceTier] ?? null)}
         </div>
       </section>
 
       <section class="card-actions-row">
-        <a class="nav-link" href="/cards/rookies/board/">← Back to board</a>
-        <a class="nav-link" href="/cards/rookies/compare/?left=${esc(card.slug)}">Compare this profile →</a>
+        <div class="card-actions-copy">
+          <div class="section-title">Next Steps</div>
+          <div class="meta">Continue scouting this profile with board context or head-to-head comparison.</div>
+        </div>
+        <div class="card-actions-links">
+          <a class="nav-link nav-link-action" href="/cards/rookies/board/">← Back to board</a>
+          <a class="nav-link nav-link-action" href="/cards/rookies/compare/?left=${esc(card.slug)}">Compare this profile →</a>
+        </div>
       </section>
 
       <div class="card-columns">

--- a/components/rookies/rookieCardStyles.css
+++ b/components/rookies/rookieCardStyles.css
@@ -55,6 +55,63 @@ body {
   border-radius: 16px;
   padding: 20px;
 }
+.rookie-card-layout {
+  background: transparent;
+  border: none;
+  padding: 0;
+  display: block;
+}
+.card-root-shell { margin-top: 12px; }
+.detail-actions-shell { margin-top: 12px; }
+.sporq-shell { margin-top: 0; }
+
+.detail-actions-panel {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 12px 14px;
+  background: var(--panel);
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: center;
+}
+.detail-actions-copy { min-width: 0; }
+.detail-actions-note { margin-top: 4px; }
+
+.hero-panel {
+  background: radial-gradient(ellipse 90% 120% at 100% 0%, var(--accent-glow), transparent 55%), rgba(22, 18, 14, 0.95);
+  border: 1px solid var(--border-accent);
+  border-radius: 16px;
+  padding: 20px;
+}
+.hero-top {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: flex-start;
+}
+.hero-left { flex: 1; min-width: 0; }
+.avatar-pos {
+  display: inline-block;
+  margin-right: 10px;
+  vertical-align: middle;
+  border-radius: 6px;
+  padding: 3px 8px;
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  font-weight: 700;
+}
+.avatar-pos.pos-QB { color: var(--pos-qb); background: var(--pos-qb-bg); }
+.avatar-pos.pos-RB { color: var(--pos-rb); background: var(--pos-rb-bg); }
+.avatar-pos.pos-WR { color: var(--pos-wr); background: var(--pos-wr-bg); }
+.avatar-pos.pos-TE { color: var(--pos-te); background: var(--pos-te-bg); }
+.profile-summary {
+  margin: 10px 0 0;
+  font-size: 14px;
+  color: var(--text);
+  opacity: 0.9;
+  line-height: 1.5;
+}
 
 .header-grid { display: flex; justify-content: space-between; gap: 16px; flex-wrap: wrap; }
 .player-name { font-size: 32px; margin: 6px 0; }
@@ -77,6 +134,53 @@ body {
 /* ─── Identity / core row ─────────────────────────────────────────────────── */
 .identity-strip, .core-row, .metrics, .tags { margin-top: 16px; }
 .identity-strip, .core-row { display: grid; grid-template-columns: repeat(auto-fit, minmax(170px,1fr)); gap: 10px; }
+.card-actions-row {
+  margin-top: 12px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--panel);
+  padding: 10px 12px;
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.card-columns {
+  margin-top: 14px;
+  display: grid;
+  grid-template-columns: minmax(0, 1.35fr) minmax(0, 1fr);
+  gap: 14px;
+}
+.card-col {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+.card-panel {
+  background: rgba(22, 18, 14, 0.95);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 14px;
+}
+.comp-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+  margin-top: 8px;
+}
+.comp-card {
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 10px;
+  background: var(--panel-alt);
+}
+.comp-name { margin-top: 5px; font-weight: 700; }
+.tags-translation { margin-top: 10px; }
+.tag-context {
+  border-color: rgba(78, 205, 196, 0.35);
+  color: #9cebe5;
+  background: rgba(78, 205, 196, 0.1);
+}
 
 .pill {
   background: var(--panel-alt);
@@ -740,6 +844,10 @@ body {
 @media (max-width: 760px) {
   /* ── Full-detail card (player.html) ──────────────────────────────────────── */
   .player-name { font-size: 26px; }
+  .hero-top { flex-direction: column; }
+  .hero-score { width: 100%; min-width: 0; }
+  .card-columns { grid-template-columns: 1fr; }
+  .comp-grid { grid-template-columns: 1fr; }
 
   /* ── Board rows: switch to block, surface mobile card ───────────────────── */
   .board-row { grid-template-columns: 1fr; gap: 0; padding: 12px; }

--- a/components/rookies/rookieCardStyles.css
+++ b/components/rookies/rookieCardStyles.css
@@ -138,12 +138,39 @@ body {
   margin-top: 12px;
   border: 1px solid var(--border);
   border-radius: 12px;
-  background: var(--panel);
+  background: linear-gradient(180deg, rgba(32, 26, 20, 0.9), rgba(22, 18, 14, 0.92));
   padding: 10px 12px;
   display: flex;
   justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+.card-actions-copy {
+  min-width: 240px;
+  max-width: 620px;
+}
+.card-actions-copy .section-title { margin-bottom: 4px; }
+.card-actions-links {
+  display: flex;
   gap: 8px;
   flex-wrap: wrap;
+}
+.nav-link-action {
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--panel);
+  color: var(--accent-soft);
+  padding: 7px 12px;
+  font-size: 12px;
+  font-weight: 600;
+  text-decoration: none;
+  transition: border-color 0.15s, transform 0.15s, color 0.15s;
+}
+.nav-link-action:hover {
+  border-color: var(--border-accent);
+  color: var(--accent);
+  transform: translateY(-1px);
 }
 .card-columns {
   margin-top: 14px;
@@ -848,6 +875,8 @@ body {
   .hero-score { width: 100%; min-width: 0; }
   .card-columns { grid-template-columns: 1fr; }
   .comp-grid { grid-template-columns: 1fr; }
+  .card-actions-links { width: 100%; }
+  .nav-link-action { flex: 1 1 220px; text-align: center; }
 
   /* ── Board rows: switch to block, surface mobile card ───────────────────── */
   .board-row { grid-template-columns: 1fr; gap: 0; padding: 12px; }


### PR DESCRIPTION
### Motivation
- Apply the approved PR153 visual language (hero panel, stronger section rhythm, two-column card panels) to the live canonical rookie player card surface while preserving artifact-backed data and existing behaviors. 
- Replace the old ad-hoc layout with a clearer information architecture so model scores, radar, PPR, comps, translation, stats and tags are presented as framed, scannable panels. 

### Description
- Reworked the player route shell by updating `cards/rookies/player.html` to emit semantic shell classes used by the new layout (`detail-actions`, `card-root`, `sporq-comps` wrappers). 
- Rewrote `renderRookieCard` in `components/rookies/RookieCard.js` to a PR153-aligned structure: a dominant `hero-panel` (identity + grade + evidence badge), an identity strip, an action row, and a responsive two-column `card-columns` grid containing framed panels for model scores, evidence/metrics, radar, Year‑1 PPR, projection comps, translation/evidence signals, scouting tags and season stats. 
- Kept canonical data wiring and logic unchanged (still consumes `card` object from the artifact pipeline), preserved metric-family filtering, score bars, PPR range viz, queue integration and SPORQ comps rendering. 
- Adjusted and extended styles in `components/rookies/rookieCardStyles.css` to implement the new hero treatment, stronger borders/spacing, panel cards and responsive two-column layout; added utility classes (e.g. `hero-panel`, `card-columns`, `card-panel`, `detail-actions-panel`). 
- Removed prototype-only wiring and avoided introducing placeholder or non-functional prototype controls; all UI elements remain driven by real `card` fields. 

### Testing
- Ran the runtime smoke test with `npm run test:runtime-smoke`, which passed (standalone runtime smoke routes ok).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8250bb9f8833293274c15d3b2796d)