### PR TITLE
Add slot_rate and dominator_rating for Barrett-method slot WR analysis

### DIFF
--- a/data/processed/2026_prospect_context.json
+++ b/data/processed/2026_prospect_context.json
@@ -348,7 +348,9 @@
       "one_d_rate": 0.098,
       "td_rate": 0.017,
       "avoided_tackle_rate": 0.14,
-      "yac_per_reception": 4.8
+      "yac_per_reception": 4.8,
+      "slot_rate": null,
+      "slot_yprr": null
     },
     "dob": "2005-01-19",
     "breakout_strength": 0.16,
@@ -460,7 +462,9 @@
       "ngs_model_rank_class": 1,
       "ngs_model_score": 86.19,
       "adjusted_ctt_rank_class": 3,
-      "yprr_2025": 2.37
+      "yprr_2025": 2.37,
+      "slot_rate": null,
+      "slot_yprr": null
     },
     "dob": "2004-08-12",
     "breakout_strength": 1.0,
@@ -555,7 +559,9 @@
       "man_ctt_pct": 0.1786,
       "zone_ctt_pct": 0.1212,
       "passer_rating_when_targeted": 130.0,
-      "wide_pct": 0.279
+      "wide_pct": 0.279,
+      "slot_rate": 0.721,
+      "slot_yprr": null
     },
     "dob": "2004-06-04",
     "breakout_strength": 0.48,
@@ -643,7 +649,9 @@
       "one_d_rate": 0.097,
       "td_rate": 0.023,
       "avoided_tackle_rate": 0.21,
-      "yac_per_reception": 6.6
+      "yac_per_reception": 6.6,
+      "slot_rate": null,
+      "slot_yprr": null
     },
     "dob": "2004-09-24",
     "breakout_strength": 0.52,
@@ -790,7 +798,9 @@
       "one_d_rate": 0.081,
       "td_rate": 0.014,
       "avoided_tackle_rate": 0.167,
-      "yac_per_reception": 4.9
+      "yac_per_reception": 4.9,
+      "slot_rate": null,
+      "slot_yprr": null
     },
     "dob": "2003-07-25",
     "breakout_strength": null,
@@ -830,7 +840,9 @@
       "one_d_rate": 0.099,
       "td_rate": 0.016,
       "avoided_tackle_rate": 0.067,
-      "yac_per_reception": 3.4
+      "yac_per_reception": 3.4,
+      "slot_rate": null,
+      "slot_yprr": null
     },
     "dob": "2003-10-23",
     "breakout_strength": 0.0,
@@ -921,7 +933,9 @@
       "contested_catch_rate_2025": 0.769,
       "td_rate_2025": 0.1774,
       "adot": 14.4,
-      "drop_rate": 0.031
+      "drop_rate": 0.031,
+      "slot_rate": null,
+      "slot_yprr": null
     },
     "dob": "2003-12-06",
     "breakout_strength": 0.8,
@@ -980,7 +994,9 @@
       "one_d_rate": 0.089,
       "td_rate": 0.011,
       "avoided_tackle_rate": 0.166,
-      "yac_per_reception": 5.8
+      "yac_per_reception": 5.8,
+      "slot_rate": null,
+      "slot_yprr": null
     },
     "dob": "2004-06-07",
     "breakout_strength": 0.22,
@@ -1042,7 +1058,9 @@
       "one_d_rate": 0.127,
       "td_rate": 0.032,
       "avoided_tackle_rate": 0.122,
-      "yac_per_reception": 5.1
+      "yac_per_reception": 5.1,
+      "slot_rate": null,
+      "slot_yprr": null
     },
     "dob": "2003-05-28",
     "breakout_strength": 0.52,
@@ -1273,7 +1291,9 @@
       "one_d_rate": 0.095,
       "td_rate": 0.018,
       "avoided_tackle_rate": 0.15,
-      "yac_per_reception": 5.3
+      "yac_per_reception": 5.3,
+      "slot_rate": null,
+      "slot_yprr": null
     },
     "dob": "2004-07-14",
     "breakout_strength": 0.58,
@@ -1826,7 +1846,11 @@
     "dob": "2002-12-02",
     "breakout_strength": null,
     "breakout_confidence": null,
-    "seasons_available": 0
+    "seasons_available": 0,
+    "advanced_receiving_stats": {
+      "slot_rate": null,
+      "slot_yprr": null
+    }
   },
   {
     "player_id": "wr-vinny-anthony-ii",
@@ -1853,7 +1877,11 @@
     "dob": "2003-06-27",
     "breakout_strength": null,
     "breakout_confidence": null,
-    "seasons_available": 1
+    "seasons_available": 1,
+    "advanced_receiving_stats": {
+      "slot_rate": null,
+      "slot_yprr": null
+    }
   },
   {
     "player_id": "wr-dillon-bell",
@@ -1879,7 +1907,11 @@
     "dob": "2003-11-06",
     "breakout_strength": null,
     "breakout_confidence": null,
-    "seasons_available": 0
+    "seasons_available": 0,
+    "advanced_receiving_stats": {
+      "slot_rate": null,
+      "slot_yprr": null
+    }
   },
   {
     "player_id": "wr-skyler-bell",
@@ -1921,7 +1953,9 @@
       "one_d_rate": 0.086,
       "td_rate": 0.018,
       "avoided_tackle_rate": 0.136,
-      "yac_per_reception": 6.4
+      "yac_per_reception": 6.4,
+      "slot_rate": null,
+      "slot_yprr": null
     },
     "dob": "2002-07-05",
     "breakout_strength": 1.0,
@@ -1965,7 +1999,11 @@
     "dob": "2002-10-17",
     "breakout_strength": null,
     "breakout_confidence": null,
-    "seasons_available": 0
+    "seasons_available": 0,
+    "advanced_receiving_stats": {
+      "slot_rate": null,
+      "slot_yprr": null
+    }
   },
   {
     "player_id": "wr-germie-bernard",
@@ -2004,7 +2042,9 @@
       "one_d_rate": 0.091,
       "td_rate": 0.011,
       "avoided_tackle_rate": 0.237,
-      "yac_per_reception": 6.4
+      "yac_per_reception": 6.4,
+      "slot_rate": null,
+      "slot_yprr": null
     },
     "dob": "2003-12-02",
     "breakout_strength": 0.82,
@@ -2051,7 +2091,9 @@
       "one_d_rate": 0.096,
       "td_rate": 0.011,
       "avoided_tackle_rate": 0.213,
-      "yac_per_reception": 8.0
+      "yac_per_reception": 8.0,
+      "slot_rate": null,
+      "slot_yprr": null
     },
     "dob": "2004-03-29",
     "breakout_strength": 0.34,
@@ -2088,7 +2130,11 @@
     "dob": "2003-12-12",
     "breakout_strength": null,
     "breakout_confidence": null,
-    "seasons_available": 0
+    "seasons_available": 0,
+    "advanced_receiving_stats": {
+      "slot_rate": null,
+      "slot_yprr": null
+    }
   },
   {
     "player_id": "wr-deion-burks",
@@ -2130,7 +2176,9 @@
       "one_d_rate": 0.067,
       "td_rate": 0.011,
       "avoided_tackle_rate": 0.23,
-      "yac_per_reception": 4.7
+      "yac_per_reception": 4.7,
+      "slot_rate": null,
+      "slot_yprr": null
     },
     "dob": "2003-01-08",
     "breakout_strength": null,
@@ -2163,7 +2211,11 @@
     "dob": "2001-03-05",
     "breakout_strength": null,
     "breakout_confidence": null,
-    "seasons_available": 1
+    "seasons_available": 1,
+    "advanced_receiving_stats": {
+      "slot_rate": null,
+      "slot_yprr": null
+    }
   },
   {
     "player_id": "wr-josh-cameron",
@@ -2204,7 +2256,9 @@
       "one_d_rate": 0.083,
       "td_rate": 0.014,
       "avoided_tackle_rate": 0.165,
-      "yac_per_reception": 5.1
+      "yac_per_reception": 5.1,
+      "slot_rate": null,
+      "slot_yprr": null
     },
     "dob": "2003-03-18",
     "breakout_strength": 0.98,
@@ -2248,7 +2302,9 @@
       "one_d_rate": 0.09,
       "td_rate": 0.009,
       "avoided_tackle_rate": 0.255,
-      "yac_per_reception": 6.1
+      "yac_per_reception": 6.1,
+      "slot_rate": null,
+      "slot_yprr": null
     },
     "dob": "2003-09-10",
     "breakout_strength": 0.88,
@@ -2293,7 +2349,9 @@
       "one_d_rate": 0.109,
       "td_rate": 0.031,
       "avoided_tackle_rate": 0.3,
-      "yac_per_reception": 6.3
+      "yac_per_reception": 6.3,
+      "slot_rate": null,
+      "slot_yprr": null
     },
     "dob": "2003-12-14",
     "breakout_strength": 0.98,
@@ -2351,7 +2409,9 @@
       "one_d_rate": 0.097,
       "td_rate": 0.018,
       "avoided_tackle_rate": 0.182,
-      "yac_per_reception": 4.7
+      "yac_per_reception": 4.7,
+      "slot_rate": null,
+      "slot_yprr": null
     },
     "dob": "2002-01-04",
     "breakout_strength": null,
@@ -2383,7 +2443,11 @@
     "dob": "2003-09-09",
     "breakout_strength": null,
     "breakout_confidence": null,
-    "seasons_available": 0
+    "seasons_available": 0,
+    "advanced_receiving_stats": {
+      "slot_rate": null,
+      "slot_yprr": null
+    }
   },
   {
     "player_id": "wr-malachi-fields",
@@ -2424,7 +2488,9 @@
       "one_d_rate": 0.09,
       "td_rate": 0.012,
       "avoided_tackle_rate": 0.176,
-      "yac_per_reception": 4.7
+      "yac_per_reception": 4.7,
+      "slot_rate": null,
+      "slot_yprr": null
     },
     "dob": "2002-07-02",
     "breakout_strength": 0.58,
@@ -2467,7 +2533,11 @@
     "dob": "2003-01-21",
     "breakout_strength": null,
     "breakout_confidence": null,
-    "seasons_available": 0
+    "seasons_available": 0,
+    "advanced_receiving_stats": {
+      "slot_rate": null,
+      "slot_yprr": null
+    }
   },
   {
     "player_id": "wr-chris-hilton-jr",
@@ -2493,7 +2563,11 @@
     "dob": "2002-10-11",
     "breakout_strength": null,
     "breakout_confidence": null,
-    "seasons_available": 0
+    "seasons_available": 0,
+    "advanced_receiving_stats": {
+      "slot_rate": null,
+      "slot_yprr": null
+    }
   },
   {
     "player_id": "wr-jordan-hudson",
@@ -2528,7 +2602,9 @@
       "one_d_rate": 0.09,
       "td_rate": 0.022,
       "avoided_tackle_rate": 0.2,
-      "yac_per_reception": 5.1
+      "yac_per_reception": 5.1,
+      "slot_rate": null,
+      "slot_yprr": null
     },
     "dob": "2003-11-22",
     "breakout_strength": null,
@@ -2573,7 +2649,9 @@
       "one_d_rate": 0.103,
       "td_rate": 0.017,
       "avoided_tackle_rate": 0.205,
-      "yac_per_reception": 4.6
+      "yac_per_reception": 4.6,
+      "slot_rate": null,
+      "slot_yprr": null
     },
     "dob": "2004-07-02",
     "breakout_strength": 1.0,
@@ -2605,7 +2683,11 @@
     "dob": "2001-12-22",
     "breakout_strength": null,
     "breakout_confidence": null,
-    "seasons_available": 0
+    "seasons_available": 0,
+    "advanced_receiving_stats": {
+      "slot_rate": null,
+      "slot_yprr": null
+    }
   },
   {
     "player_id": "wr-bryce-lance",
@@ -2647,7 +2729,9 @@
       "one_d_rate": 0.13,
       "td_rate": 0.036,
       "avoided_tackle_rate": 0.126,
-      "yac_per_reception": 5.1
+      "yac_per_reception": 5.1,
+      "slot_rate": null,
+      "slot_yprr": null
     },
     "dob": "2001-09-20",
     "breakout_strength": 0.46,
@@ -2691,7 +2775,9 @@
       "one_d_rate": 0.108,
       "td_rate": 0.026,
       "avoided_tackle_rate": 0.202,
-      "yac_per_reception": 3.8
+      "yac_per_reception": 3.8,
+      "slot_rate": null,
+      "slot_yprr": null
     },
     "dob": "2004-08-05",
     "breakout_strength": null,
@@ -2734,7 +2820,11 @@
     "dob": "2003-01-27",
     "breakout_strength": null,
     "breakout_confidence": null,
-    "seasons_available": 0
+    "seasons_available": 0,
+    "advanced_receiving_stats": {
+      "slot_rate": null,
+      "slot_yprr": null
+    }
   },
   {
     "player_id": "wr-eric-mcalister",
@@ -2776,7 +2866,9 @@
       "one_d_rate": 0.122,
       "td_rate": 0.022,
       "avoided_tackle_rate": 0.298,
-      "yac_per_reception": 7.4
+      "yac_per_reception": 7.4,
+      "slot_rate": null,
+      "slot_yprr": null
     },
     "dob": "2003-09-29",
     "breakout_strength": 1.0,
@@ -2808,7 +2900,11 @@
     "dob": "2003-01-15",
     "breakout_strength": null,
     "breakout_confidence": null,
-    "seasons_available": 0
+    "seasons_available": 0,
+    "advanced_receiving_stats": {
+      "slot_rate": null,
+      "slot_yprr": null
+    }
   },
   {
     "player_id": "wr-eric-rivers",
@@ -2846,7 +2942,9 @@
       "one_d_rate": 0.103,
       "td_rate": 0.018,
       "avoided_tackle_rate": 0.203,
-      "yac_per_reception": 5.8
+      "yac_per_reception": 5.8,
+      "slot_rate": null,
+      "slot_yprr": null
     },
     "dob": "2002-09-17",
     "breakout_strength": 0.32,
@@ -2887,7 +2985,9 @@
       "one_d_rate": 0.115,
       "td_rate": 0.016,
       "avoided_tackle_rate": 0.129,
-      "yac_per_reception": 4.7
+      "yac_per_reception": 4.7,
+      "slot_rate": null,
+      "slot_yprr": null
     },
     "dob": "2001-01-21",
     "breakout_strength": null,
@@ -2916,7 +3016,11 @@
     "breakout_strength": 0.48,
     "breakout_confidence": 0.9,
     "seasons_available": 2,
-    "power4_early_contributor_flag": true
+    "power4_early_contributor_flag": true,
+    "advanced_receiving_stats": {
+      "slot_rate": null,
+      "slot_yprr": null
+    }
   },
   {
     "player_id": "wr-j-michael-sturdivant",
@@ -2944,7 +3048,11 @@
     "dob": "2002-09-06",
     "breakout_strength": null,
     "breakout_confidence": null,
-    "seasons_available": 0
+    "seasons_available": 0,
+    "advanced_receiving_stats": {
+      "slot_rate": null,
+      "slot_yprr": null
+    }
   },
   {
     "player_id": "wr-zavion-thomas",
@@ -2971,7 +3079,11 @@
     "dob": "2004-09-14",
     "breakout_strength": null,
     "breakout_confidence": null,
-    "seasons_available": 0
+    "seasons_available": 0,
+    "advanced_receiving_stats": {
+      "slot_rate": null,
+      "slot_yprr": null
+    }
   },
   {
     "player_id": "wr-reggie-virgil",
@@ -2997,7 +3109,11 @@
     "dob": "2004-05-14",
     "breakout_strength": 0.62,
     "breakout_confidence": 0.8,
-    "seasons_available": 1
+    "seasons_available": 1,
+    "advanced_receiving_stats": {
+      "slot_rate": null,
+      "slot_yprr": null
+    }
   },
   {
     "player_id": "wr-harrison-wallace-iii",
@@ -3032,7 +3148,9 @@
       "one_d_rate": 0.089,
       "td_rate": 0.009,
       "avoided_tackle_rate": 0.117,
-      "yac_per_reception": 4.9
+      "yac_per_reception": 4.9,
+      "slot_rate": null,
+      "slot_yprr": null
     },
     "dob": "2003-04-23",
     "breakout_strength": null,
@@ -3064,7 +3182,11 @@
     "dob": "2002-10-14",
     "breakout_strength": null,
     "breakout_confidence": null,
-    "seasons_available": 0
+    "seasons_available": 0,
+    "advanced_receiving_stats": {
+      "slot_rate": null,
+      "slot_yprr": null
+    }
   },
   {
     "player_id": "wr-kaden-wetjen",
@@ -3090,7 +3212,11 @@
     "dob": "2002-03-09",
     "breakout_strength": null,
     "breakout_confidence": null,
-    "seasons_available": 0
+    "seasons_available": 0,
+    "advanced_receiving_stats": {
+      "slot_rate": null,
+      "slot_yprr": null
+    }
   },
   {
     "player_id": "wr-colbie-young",
@@ -3118,7 +3244,11 @@
     "dob": "2002-07-24",
     "breakout_strength": null,
     "breakout_confidence": null,
-    "seasons_available": 0
+    "seasons_available": 0,
+    "advanced_receiving_stats": {
+      "slot_rate": null,
+      "slot_yprr": null
+    }
   },
   {
     "player_id": "te-dallen-bentley",
@@ -3882,7 +4012,9 @@
       "one_d_rate": 0.12,
       "td_rate": 0.024,
       "avoided_tackle_rate": 0.276,
-      "yac_per_reception": 6.3
+      "yac_per_reception": 6.3,
+      "slot_rate": null,
+      "slot_yprr": null
     },
     "first_down_per_route_run": 0.12,
     "first_down_per_route_run_tier": "strong",

--- a/scripts/compute_production_scores.py
+++ b/scripts/compute_production_scores.py
@@ -195,6 +195,19 @@ def safe_div(numerator: float, denominator: float) -> float | None:
     return numerator / denominator
 
 
+def build_team_passing_totals(
+    passing_stats: dict[tuple[str, str], dict[str, Any]]
+) -> dict[str, dict[str, float]]:
+    """Sum passing yards and TDs per team for dominator rating computation."""
+    totals: dict[str, dict[str, float]] = {}
+    for (_, norm_team), data in passing_stats.items():
+        stats = data["stats"]
+        t = totals.setdefault(norm_team, {"pass_yards": 0.0, "pass_tds": 0.0})
+        t["pass_yards"] += stats.get("YDS", 0.0)
+        t["pass_tds"] += stats.get("TD", 0.0)
+    return totals
+
+
 def build_population(
     position: str,
     passing_stats: dict[tuple[str, str], dict[str, Any]],
@@ -475,6 +488,7 @@ def build_stat_lines(
     rushing_stats: dict[tuple[str, str], dict[str, Any]],
     receiving_stats: dict[tuple[str, str], dict[str, Any]],
     cfbd_year: int,
+    team_passing_totals: dict[str, dict[str, float]] | None = None,
 ) -> list[dict[str, Any]]:
     populations: dict[str, list[PopulationPlayer]] = {
         "QB": build_population("QB", passing_stats, rushing_stats, receiving_stats),
@@ -541,15 +555,28 @@ def build_stat_lines(
                     receiving = receiving_stats.get(key, {}).get("stats", {})
                     receptions = receiving.get("REC")
                     receiving_yards = receiving.get("YDS")
+                    receiving_tds = receiving.get("TD")
 
                     add_stat(stats, "receptions", receptions)
                     add_stat(stats, "receiving_yards", receiving_yards)
-                    add_stat(stats, "receiving_tds", receiving.get("TD"))
+                    add_stat(stats, "receiving_tds", receiving_tds)
                     add_stat(
                         stats,
                         "yards_per_reception",
                         safe_div(receiving_yards, receptions) if receiving_yards is not None and receptions is not None else None,
                     )
+                    if team_passing_totals is not None and receiving_yards is not None:
+                        school = str(row.get("school", ""))
+                        team_total = next(
+                            (team_passing_totals[a] for a in school_aliases(school) if a in team_passing_totals),
+                            None,
+                        )
+                        if team_total:
+                            denom = team_total["pass_yards"] + team_total["pass_tds"] * 20
+                            if denom > 0:
+                                p_yards = receiving_yards or 0.0
+                                p_tds = receiving_tds or 0.0
+                                add_stat(stats, "dominator_rating", (p_yards + p_tds * 20) / denom)
 
         stat_lines.append(
             {
@@ -609,7 +636,8 @@ def main() -> int:
 
     write_json(args.seed_output, updated_seed)
     write_json(args.production_output, production_rows)
-    stat_lines = build_stat_lines(seed_rows, results, passing_stats, rushing_stats, receiving_stats, cfbd_year)
+    team_passing_totals = build_team_passing_totals(passing_stats)
+    stat_lines = build_stat_lines(seed_rows, results, passing_stats, rushing_stats, receiving_stats, cfbd_year, team_passing_totals)
     write_json(args.stats_output, stat_lines)
 
     print_summary(results)

--- a/tests/test_compute_production_scores.py
+++ b/tests/test_compute_production_scores.py
@@ -3,6 +3,7 @@ import unittest
 from scripts.compute_production_scores import (
     apply_results,
     build_stat_lines,
+    build_team_passing_totals,
     compute_scores_for_seed,
     normalize_identity,
     pivot_stats,
@@ -90,6 +91,44 @@ class ComputeProductionScoresTests(unittest.TestCase):
         self.assertEqual(stat_lines[0]["stats"]["yards_per_attempt"], 12.5)
         self.assertEqual(stat_lines[1]["stats"], {})
 
+
+
+    def test_dominator_rating_wr(self) -> None:
+        passing_rows = [
+            {"player": "QB One", "team": "Oregon", "statType": "YDS", "stat": "3000"},
+            {"player": "QB One", "team": "Oregon", "statType": "TD", "stat": "20"},
+        ]
+        receiving_rows = [
+            {"player": "WR One", "team": "Oregon", "statType": "REC", "stat": "80"},
+            {"player": "WR One", "team": "Oregon", "statType": "YDS", "stat": "1000"},
+            {"player": "WR One", "team": "Oregon", "statType": "TD", "stat": "8"},
+        ]
+        seed_rows = [
+            {"player_id": "wr-one", "player_name": "WR One", "position": "WR", "school": "Oregon"},
+        ]
+        passing_stats = pivot_stats(passing_rows)
+        receiving_stats = pivot_stats(receiving_rows)
+        team_totals = build_team_passing_totals(passing_stats)
+        results = compute_scores_for_seed(seed_rows, passing_stats, {}, receiving_stats)
+        stat_lines = build_stat_lines(seed_rows, results, passing_stats, {}, receiving_stats, 2025, team_totals)
+        self.assertEqual(len(stat_lines), 1)
+        # dominator_rating = (1000 + 8*20) / (3000 + 20*20) = 1160 / 3400
+        expected = round(1160 / 3400, 1)
+        self.assertAlmostEqual(stat_lines[0]["stats"]["dominator_rating"], expected, places=1)
+
+    def test_dominator_rating_absent_without_team_totals(self) -> None:
+        receiving_rows = [
+            {"player": "WR One", "team": "Oregon", "statType": "REC", "stat": "80"},
+            {"player": "WR One", "team": "Oregon", "statType": "YDS", "stat": "1000"},
+            {"player": "WR One", "team": "Oregon", "statType": "TD", "stat": "8"},
+        ]
+        seed_rows = [
+            {"player_id": "wr-one", "player_name": "WR One", "position": "WR", "school": "Oregon"},
+        ]
+        receiving_stats = pivot_stats(receiving_rows)
+        results = compute_scores_for_seed(seed_rows, {}, {}, receiving_stats)
+        stat_lines = build_stat_lines(seed_rows, results, {}, {}, receiving_stats, 2025)
+        self.assertNotIn("dominator_rating", stat_lines[0]["stats"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
compute_production_scores.py:
- build_team_passing_totals(): aggregates CFBD passing yards + TDs by team
- build_stat_lines(): accepts optional team_passing_totals; computes dominator_rating = (rec_yds + rec_tds*20) / (team_pass_yds + team_pass_tds*20) for WR/TE rows when team totals are available
- main(): wires team_passing_totals into build_stat_lines

2026_prospect_context.json:
- All 47 WR records: slot_rate derived from wide_pct (1 - wide_pct where available, else null) and slot_yprr: null stub added to advanced_receiving_stats
- Only Makai Lemon has a non-null slot_rate (0.721) from existing wide_pct data

tests/test_compute_production_scores.py:
- test_dominator_rating_wr: verifies formula against known inputs
- test_dominator_rating_absent_without_team_totals: verifies field is absent when team_passing_totals not passed (backward compat)

https://claude.ai/code/session_01CkNfKQsT8pg1iqpW3mcaMu