### PR TITLE
Rebuild rookie compare view with rich player panels and visual improvements

### DIFF
--- a/components/rookies/RookieCompareView.js
+++ b/components/rookies/RookieCompareView.js
@@ -1,5 +1,4 @@
 import { compareRookies } from '/lib/rookies/compareRookies.js';
-import { selectRookieEvidenceMetrics } from '/lib/rookies/selectRookieEvidenceMetrics.js';
 import { getCollegeLogoUrl, getNflTeamLogoUrl } from '/lib/rookies/teamLogos.js';
 
 function esc(str) {
@@ -21,37 +20,167 @@ function renderTeamLogos(school, nflTeam) {
   return `<span class="team-logos">${imgs}</span>`;
 }
 
-function gradeCell(label, card, side) {
+const EVIDENCE_TIER_LABELS = {
+  strong_supported_edge: 'Strong Supported Edge',
+  moderate_edge: 'Moderate Edge',
+  consensus_aligned: 'Consensus Aligned',
+  watchlist_outlier: 'Watchlist Outlier',
+  insufficient_evidence: 'Insufficient Evidence',
+};
+
+function renderEvidenceTierBadge(card) {
+  const tier = card.evidenceTier;
+  if (!tier) return '';
+  const label = EVIDENCE_TIER_LABELS[tier] ?? String(tier).replace(/_/g, ' ');
+  const reason = card.evidenceTierReason ?? 'Evidence tier classification';
+  return `<span class="evidence-tier-badge" title="${esc(reason)}">${esc(label)}</span>`;
+}
+
+function pointForValue(cx, cy, radius, angle, value) {
+  const safe = value == null ? 0 : Math.max(0, Math.min(100, Number(value) || 0));
+  const r = (safe / 100) * radius;
+  return `${(cx + r * Math.cos(angle)).toFixed(1)},${(cy + r * Math.sin(angle)).toFixed(1)}`;
+}
+
+function renderRadarChart(athleticScore, production, draftCapital, athleticSource) {
+  const cx = 100, cy = 100, radius = 72;
+  const athLabel = athleticSource === 'SPORQ' ? 'ATH (SPORQ)' : athleticSource === 'COMBINE_FALLBACK' ? 'ATH (partial)' : 'RAS';
+  const axes = [
+    { label: athLabel, angle: -Math.PI / 2, value: athleticScore },
+    { label: 'Prod', angle: Math.PI / 6, value: production },
+    { label: 'Capital', angle: (5 * Math.PI) / 6, value: draftCapital },
+  ];
+
+  const rings = [0.25, 0.5, 0.75].map((scale) => {
+    const pts = axes.map((ax) => pointForValue(cx, cy, radius, ax.angle, scale * 100)).join(' ');
+    const isAvg = scale === 0.5;
+    return `<polygon points="${pts}" fill="none" stroke="#6f8098" stroke-width="${isAvg ? 1.6 : 0.8}" ${isAvg ? 'stroke-dasharray="4 3"' : ''} />`;
+  }).join('');
+
+  const dataPoints = axes.map((ax) => pointForValue(cx, cy, radius, ax.angle, ax.value)).join(' ');
+  const axesLines = axes.map((ax) => {
+    const end = pointForValue(cx, cy, radius, ax.angle, 100).split(',');
+    return `<line x1="${cx}" y1="${cy}" x2="${end[0]}" y2="${end[1]}" stroke="#516179" stroke-width="1" />`;
+  }).join('');
+  const labels = axes.map((ax) => {
+    const outer = pointForValue(cx, cy, radius + 16, ax.angle, 100).split(',');
+    const rendered = ax.value == null ? '—' : Number(ax.value).toFixed(1);
+    return `<text x="${outer[0]}" y="${outer[1]}" fill="#b5c7dd" font-size="9" text-anchor="middle">${esc(ax.label)} ${esc(rendered)}</text>`;
+  }).join('');
+
+  return `<svg class="radar-chart" viewBox="0 0 200 200" role="img" aria-label="Radar chart">${rings}${axesLines}<polygon points="${dataPoints}" fill="rgba(59,130,246,0.25)" stroke="#3b82f6" stroke-width="2" />${labels}</svg>`;
+}
+
+function renderPprInline(ppr) {
+  if (!ppr) return '';
+  const bandClass = {
+    Elite: 'ppr-band-elite',
+    Starter: 'ppr-band-starter',
+    Contributor: 'ppr-band-contributor',
+    Lottery: 'ppr-band-lottery',
+  }[ppr.band] ?? 'ppr-band-lottery';
+  return `<div class="compare-ppr-inline">
+    <span class="ppr-stat-label">Yr1 PPR</span>
+    <span class="compare-ppr-range">${esc(ppr.floor)}–${esc(ppr.ceiling)}</span>
+    <span class="meta">med</span>
+    <strong class="compare-ppr-median">${esc(ppr.median)}</strong>
+    <span class="ppr-band ${bandClass}">${esc(ppr.band)}</span>
+  </div>`;
+}
+
+function renderPlayerPanel(card, sideLabel) {
   const grade = card?.summary?.rookieGrade == null ? 'N/A' : card.summary.rookieGrade.toFixed(1);
   const rank = card?.summary?.classRank == null ? 'N/A' : `#${card.summary.classRank}`;
+  const posRank = card?.summary?.posRank != null ? ` · ${esc(card.identity.position)} #${card.summary.posRank}` : '';
+  const identityBits = [
+    card.identity.positionLabel ?? card.identity.position,
+    card.identity.schoolDisplay ?? card.identity.school,
+    `Class ${card.identity.classYear}`,
+    card.identity.height,
+    card.identity.weight,
+  ].filter(Boolean).join(' • ');
+
+  const hasPostDraft = card.postDraftAdjustedGrade != null;
+  const translationFlags = Array.isArray(card?.translationFlags) ? card.translationFlags : [];
+  const contextFlags = Array.isArray(card?.contextSignals?.contextFlags) ? card.contextSignals.contextFlags : [];
+  const evidenceSummary = card?.contextSignals?.evidenceSummary ?? null;
+
   return `
-    <article class="compare-player compare-${side}">
-      <div class="section-title">${esc(label)}</div>
+    <article class="compare-player compare-detail-panel">
+      <div class="section-title">${esc(sideLabel)}</div>
       <h2 class="compare-name">
+        <span class="avatar-pos pos-${esc(card.identity.position)}">${esc(card.identity.position)}</span>
         ${renderTeamLogos(card.identity.school, card.identity.nflTeam)}${esc(card.identity.name)}
       </h2>
-      <div class="meta">${esc(card.identity.positionLabel ?? card.identity.position)} • Class ${esc(card.identity.classYear)}${card.identity.schoolDisplay ? ` • ${esc(card.identity.schoolDisplay)}` : ''}</div>
-      <div class="meta">${esc(card.summary.profileSummary ?? card.summary.identityNote ?? 'Identity summary unavailable')}</div>
-      <div class="compare-grade">${esc(grade)}</div>
-      <div class="meta">Class rank ${esc(rank)}</div>
+      <div class="meta">${esc(identityBits)}</div>
+
+      <div class="compare-detail-grade">
+        <div class="compare-grade">${esc(grade)}</div>
+        <div class="meta">Class ${esc(rank)}${posRank}</div>
+        ${hasPostDraft ? `<div class="meta">Post-Draft: ${esc(card.postDraftAdjustedGrade.toFixed(1))} · Δ ${esc((card.postDraftDelta >= 0 ? '+' : '') + card.postDraftDelta.toFixed(1))}</div>` : ''}
+        ${renderEvidenceTierBadge(card)}
+      </div>
+
+      <p class="meta compare-profile-summary">${esc(card.summary.profileSummary ?? card.summary.identityNote ?? '')}</p>
+
       <div class="compare-pills">
         ${card.summary.archetype ? `<span class="tag">${esc(card.summary.archetype)}</span>` : ''}
         ${card.summary.projection ? `<span class="tag">${esc(card.summary.projection)}</span>` : ''}
+        ${card.youngBreakoutFlag
+          ? `<span class="breakout-badge breakout-young">⚡ Age ${esc(card.breakoutAge)} breakout</span>`
+          : (card.breakoutAge != null ? `<span class="breakout-badge breakout-late">Age ${esc(card.breakoutAge)} breakout</span>` : '')}
       </div>
-    </article>
-  `;
+
+      ${renderPprInline(card.pprProjection)}
+
+      <div class="radar-section">
+        <div class="section-title">Model Input Radar</div>
+        ${renderRadarChart(card.athleticScore, card.productionScore, card.draftCapitalScore, card.athleticSource)}
+      </div>
+
+      ${evidenceSummary ? `<div class="meta compare-evidence-summary">${esc(evidenceSummary)}</div>` : ''}
+
+      ${translationFlags.length ? `<div class="tags compare-translation-tags">${translationFlags.map((f) => `<span class="tag">${esc(String(f).replace(/_/g, ' '))}</span>`).join('')}</div>` : ''}
+      ${contextFlags.length ? `<div class="tags" style="margin-top:4px">${contextFlags.map((f) => `<span class="tag tag-context">${esc(String(f).replace(/_/g, ' '))}</span>`).join('')}</div>` : ''}
+    </article>`;
 }
 
-function scoreRow(row) {
-  const left = row.leftValue == null ? 'N/A' : row.leftValue.toFixed(1);
-  const right = row.rightValue == null ? 'N/A' : row.rightValue.toFixed(1);
-  const edge = row.winner === 'tie' ? 'Even' : row.winner === 'left' ? 'Left edge' : 'Right edge';
-  return `<tr><td>${esc(row.label)}</td><td>${esc(left)}</td><td>${esc(right)}</td><td>${esc(edge)}</td></tr>`;
-}
+function renderScoreRows(scoreComparisons) {
+  if (!scoreComparisons.length) return '<div class="meta">No shared scores available.</div>';
+  return `<div class="compare-score-rows">${
+    scoreComparisons.map((row) => {
+      const leftWidth = row.leftValue == null ? 0 : Math.max(0, Math.min(100, row.leftValue));
+      const rightWidth = row.rightValue == null ? 0 : Math.max(0, Math.min(100, row.rightValue));
+      const leftWins = row.winner === 'left';
+      const rightWins = row.winner === 'right';
 
-function evidenceRow(row) {
-  const edge = row.winner === 'tie' ? 'Even' : row.winner === 'left' ? 'Left leads' : 'Right leads';
-  return `<tr><td>${esc(row.label)}</td><td>${esc(row.leftDisplay)}</td><td>${esc(row.rightDisplay)}</td><td>${esc(edge)}</td></tr>`;
+      const barLeft = row.leftValue == null
+        ? '<span class="meta">N/A</span>'
+        : `<div class="compare-score-bar-row${leftWins ? ' is-winner' : ''}">
+            <div class="compare-score-track">
+              <div class="${leftWins ? 'compare-fill-winner' : 'compare-fill-dim'}" style="width:${leftWidth}%"></div>
+            </div>
+            <span class="compare-bar-value">${row.leftValue.toFixed(1)}</span>
+          </div>`;
+
+      const barRight = row.rightValue == null
+        ? '<span class="meta">N/A</span>'
+        : `<div class="compare-score-bar-row${rightWins ? ' is-winner' : ''}">
+            <div class="compare-score-track">
+              <div class="${rightWins ? 'compare-fill-winner' : 'compare-fill-dim'}" style="width:${rightWidth}%"></div>
+            </div>
+            <span class="compare-bar-value">${row.rightValue.toFixed(1)}</span>
+          </div>`;
+
+      return `<div class="compare-score-row">
+        <div class="compare-score-label">${esc(row.label)}</div>
+        <div class="compare-score-sides">
+          <div class="compare-score-side"><span class="compare-side-tag">L</span>${barLeft}</div>
+          <div class="compare-score-side"><span class="compare-side-tag">R</span>${barRight}</div>
+        </div>
+      </div>`;
+    }).join('')
+  }</div>`;
 }
 
 const STAT_LABELS = {
@@ -75,22 +204,22 @@ function seasonSnapshot(card) {
     return '<div class="meta">College stats not yet available for this player.</div>';
   }
   const top = card.seasons.slice(0, 2);
-  return `<table class="stats-table"><thead><tr><th>Season</th><th>School</th><th>Stats</th></tr></thead><tbody>${top.map((row) => {
-    const statBits = Object.entries(row.statLine).map(([k, v]) => formatStatEntry(k, v)).filter(Boolean).join(' · ');
-    return `<tr><td>${esc(row.season)}</td><td>${esc(row.team)}</td><td>${esc(statBits)}</td></tr>`;
-  }).join('')}</tbody></table>`;
+  return `<table class="stats-table"><thead><tr><th>Season</th><th>School</th><th>Stats</th></tr></thead><tbody>${
+    top.map((row) => {
+      const statBits = Object.entries(row.statLine).map(([k, v]) => formatStatEntry(k, v)).filter(Boolean).join(' · ');
+      return `<tr><td>${esc(row.season)}</td><td>${esc(row.team)}</td><td>${esc(statBits)}</td></tr>`;
+    }).join('')
+  }</tbody></table>`;
 }
 
-function translationSignals(card) {
-  const flags = Array.isArray(card?.translationFlags) ? card.translationFlags : [];
-  if (!flags.length) return 'No deterministic translation tags available.';
-  return flags.map((flag) => String(flag).replace(/_/g, ' ')).join(' • ');
+function evidenceRow(row) {
+  const edgeClass = row.winner === 'left' ? 'compare-edge-left' : row.winner === 'right' ? 'compare-edge-right' : '';
+  const edge = row.winner === 'tie' ? 'Even' : row.winner === 'left' ? 'Left leads' : 'Right leads';
+  return `<tr><td>${esc(row.label)}</td><td>${esc(row.leftDisplay)}</td><td>${esc(row.rightDisplay)}</td><td class="${edgeClass}">${esc(edge)}</td></tr>`;
 }
 
 export function renderRookieCompareView(container, leftCard, rightCard) {
   const compared = compareRookies(leftCard, rightCard);
-  const leftHighlights = selectRookieEvidenceMetrics(leftCard, 'compact').slice(0, 3);
-  const rightHighlights = selectRookieEvidenceMetrics(rightCard, 'compact').slice(0, 3);
 
   container.innerHTML = `
     <section class="compare-layout">
@@ -104,16 +233,13 @@ export function renderRookieCompareView(container, leftCard, rightCard) {
       </div>
 
       <div class="compare-grid">
-        ${gradeCell('Left', leftCard, 'left')}
-        ${gradeCell('Right', rightCard, 'right')}
+        ${renderPlayerPanel(leftCard, 'Left')}
+        ${renderPlayerPanel(rightCard, 'Right')}
       </div>
 
       <section class="metrics">
         <div class="section-title">Score comparison</div>
-        <table class="stats-table compare-table">
-          <thead><tr><th>Score</th><th>Left</th><th>Right</th><th>Edge</th></tr></thead>
-          <tbody>${compared.scoreComparisons.map(scoreRow).join('')}</tbody>
-        </table>
+        ${renderScoreRows(compared.scoreComparisons)}
       </section>
 
       <section class="metrics">
@@ -125,15 +251,11 @@ export function renderRookieCompareView(container, leftCard, rightCard) {
 
       <section class="compare-grid compare-snapshot-grid">
         <article class="rookie-card compare-snapshot">
-          <div class="section-title">Left profile snapshot</div>
-          <div class="meta">${leftHighlights.map((metric) => `${esc(metric.evidenceLabel ?? metric.label)}: ${esc(metric.display)}`).join(' • ') || 'No evidence snippets available.'}</div>
-          <div class="meta"><strong>Translation tags:</strong> ${esc(translationSignals(leftCard))}</div>
+          <div class="section-title">Left · ${esc(leftCard.identity.name)} season stats</div>
           ${seasonSnapshot(leftCard)}
         </article>
         <article class="rookie-card compare-snapshot">
-          <div class="section-title">Right profile snapshot</div>
-          <div class="meta">${rightHighlights.map((metric) => `${esc(metric.evidenceLabel ?? metric.label)}: ${esc(metric.display)}`).join(' • ') || 'No evidence snippets available.'}</div>
-          <div class="meta"><strong>Translation tags:</strong> ${esc(translationSignals(rightCard))}</div>
+          <div class="section-title">Right · ${esc(rightCard.identity.name)} season stats</div>
           ${seasonSnapshot(rightCard)}
         </article>
       </section>

--- a/components/rookies/rookieCardStyles.css
+++ b/components/rookies/rookieCardStyles.css
@@ -705,6 +705,84 @@ body {
 .compare-snapshot-grid { align-items: stretch; }
 .compare-snapshot { height: 100%; }
 
+/* ── Compare rebuild: rich player panels ──────────────────────────────────── */
+.compare-detail-panel { display: flex; flex-direction: column; gap: 10px; }
+.compare-detail-grade { margin-top: 2px; display: flex; flex-direction: column; gap: 4px; }
+.compare-profile-summary { margin: 0; line-height: 1.5; }
+.compare-evidence-summary { font-size: 12px; }
+.compare-translation-tags { margin-top: 6px; }
+
+/* PPR inline display */
+.compare-ppr-inline {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  flex-wrap: wrap;
+  font-size: 13px;
+}
+.compare-ppr-range { font-weight: 700; font-size: 14px; }
+.compare-ppr-median { color: var(--accent); }
+
+/* ── Compare score bar rows ───────────────────────────────────────────────── */
+.compare-score-rows { display: flex; flex-direction: column; gap: 10px; margin-top: 8px; }
+.compare-score-row { display: flex; flex-direction: column; gap: 4px; }
+.compare-score-label {
+  font-size: 11px;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: .07em;
+}
+.compare-score-sides { display: flex; flex-direction: column; gap: 4px; }
+.compare-score-side { display: flex; align-items: center; gap: 6px; }
+.compare-side-tag {
+  font-size: 10px;
+  font-weight: 700;
+  color: var(--muted);
+  min-width: 14px;
+  letter-spacing: .04em;
+  flex-shrink: 0;
+}
+.compare-score-bar-row { display: flex; align-items: center; gap: 6px; flex: 1; }
+.compare-score-bar-row.is-winner .compare-bar-value { color: var(--accent-soft); font-weight: 700; }
+.compare-score-track {
+  flex: 1;
+  height: 6px;
+  background: #0E0B08;
+  border-radius: 999px;
+  overflow: hidden;
+  border: 1px solid var(--border);
+}
+.compare-fill-winner { height: 100%; border-radius: 999px; background: linear-gradient(90deg, #D97757, #F0B080); }
+.compare-fill-dim { height: 100%; border-radius: 999px; background: rgba(158, 139, 122, 0.35); }
+.compare-bar-value {
+  font-family: 'JetBrains Mono', 'Fira Mono', ui-monospace, monospace;
+  font-size: 13px;
+  font-variant-numeric: tabular-nums;
+  min-width: 34px;
+  flex-shrink: 0;
+}
+
+/* ── Evidence edge coloring ───────────────────────────────────────────────── */
+.compare-edge-left { color: var(--accent-soft); font-weight: 600; }
+.compare-edge-right { color: var(--teal); font-weight: 600; }
+
+/* ── Generic button ───────────────────────────────────────────────────────── */
+.btn {
+  border: 1px solid var(--border);
+  background: var(--panel-alt);
+  color: var(--text);
+  border-radius: 10px;
+  padding: 8px 14px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: border-color 0.15s, color 0.15s;
+}
+.btn:hover {
+  border-color: var(--border-accent);
+  color: var(--accent-soft);
+}
+
 /* ─── Queue ───────────────────────────────────────────────────────────────── */
 .queue-toggle,
 .queue-action,


### PR DESCRIPTION
## Summary
Significantly enhanced the rookie player comparison view with richer player detail panels, improved visual representations of score comparisons, and better evidence presentation. Removed dependency on `selectRookieEvidenceMetrics` and restructured the layout to provide more comprehensive player information inline.

## Key Changes

- **Rich Player Panels**: Replaced simple `gradeCell` with comprehensive `renderPlayerPanel` that displays:
  - Player identity information (position, school, class year, physical attributes)
  - Grade and ranking with post-draft adjustments
  - Evidence tier badges with tooltips
  - Profile summary and archetype/projection tags
  - Breakout age indicators
  - Year 1 PPR projections inline
  - Model input radar chart visualization
  - Translation and context flags

- **Visual Score Comparison**: Replaced table-based score comparison with `renderScoreRows` featuring:
  - Horizontal bar charts showing relative score values
  - Visual winner highlighting with gradient fills
  - Side-by-side comparison with L/R tags
  - Better handling of missing data

- **New Visualizations**:
  - `renderRadarChart`: SVG radar chart showing athletic score, production, and draft capital inputs with configurable rings and axis labels
  - `renderEvidenceTierBadge`: Evidence tier classification badges with reason tooltips
  - `renderPprInline`: Inline Year 1 PPR projection display with band classification

- **Simplified Snapshot Section**: Removed evidence metric highlights and translation signal summaries from snapshot cards, focusing on season statistics instead

- **CSS Enhancements**: Added comprehensive styling for:
  - Detail panel layouts with proper spacing
  - PPR inline display formatting
  - Score bar row visualizations with winner states
  - Evidence edge coloring (left/right distinction)
  - Generic button styles for future use

## Implementation Details

- Removed unused import of `selectRookieEvidenceMetrics`
- Evidence tier labels are now defined as a constant map for consistency
- Radar chart uses SVG with configurable rings at 25%, 50%, 75% scales
- Score comparison bars use percentage-based widths clamped to 0-100 range
- All user-facing strings properly escaped with `esc()` function
- Maintained backward compatibility with existing card data structures

https://claude.ai/code/session_013s7gznFMJzZqZrQrP4ksS8