### PR TITLE
Upgrade compare page to prototype-level detail layout

### DIFF
--- a/components/rookies/RookieCompareView.js
+++ b/components/rookies/RookieCompareView.js
@@ -36,152 +36,181 @@ function renderEvidenceTierBadge(card) {
   return `<span class="evidence-tier-badge" title="${esc(reason)}">${esc(label)}</span>`;
 }
 
+// ── Shared overlaid radar chart ───────────────────────────────────────────────
+
 function pointForValue(cx, cy, radius, angle, value) {
   const safe = value == null ? 0 : Math.max(0, Math.min(100, Number(value) || 0));
   const r = (safe / 100) * radius;
   return `${(cx + r * Math.cos(angle)).toFixed(1)},${(cy + r * Math.sin(angle)).toFixed(1)}`;
 }
 
-function renderRadarChart(athleticScore, production, draftCapital, athleticSource) {
-  const cx = 100, cy = 100, radius = 72;
-  const athLabel = athleticSource === 'SPORQ' ? 'ATH (SPORQ)' : athleticSource === 'COMBINE_FALLBACK' ? 'ATH (partial)' : 'RAS';
+function renderSharedRadar(leftCard, rightCard) {
+  const cx = 110, cy = 110, radius = 88;
   const axes = [
-    { label: athLabel, angle: -Math.PI / 2, value: athleticScore },
-    { label: 'Prod', angle: Math.PI / 6, value: production },
-    { label: 'Capital', angle: (5 * Math.PI) / 6, value: draftCapital },
+    { angle: -Math.PI / 2,       leftVal: leftCard.athleticScore,   rightVal: rightCard.athleticScore,   label: 'ATH' },
+    { angle: Math.PI / 6,        leftVal: leftCard.productionScore,  rightVal: rightCard.productionScore,  label: 'Prod' },
+    { angle: (5 * Math.PI) / 6,  leftVal: leftCard.draftCapitalScore, rightVal: rightCard.draftCapitalScore, label: 'Capital' },
   ];
 
-  const rings = [0.25, 0.5, 0.75].map((scale) => {
-    const pts = axes.map((ax) => pointForValue(cx, cy, radius, ax.angle, scale * 100)).join(' ');
-    const isAvg = scale === 0.5;
+  const rings = [0.25, 0.5, 0.75].map((s) => {
+    const pts = axes.map((ax) => pointForValue(cx, cy, radius, ax.angle, s * 100)).join(' ');
+    const isAvg = s === 0.5;
     return `<polygon points="${pts}" fill="none" stroke="#6f8098" stroke-width="${isAvg ? 1.6 : 0.8}" ${isAvg ? 'stroke-dasharray="4 3"' : ''} />`;
   }).join('');
 
-  const dataPoints = axes.map((ax) => pointForValue(cx, cy, radius, ax.angle, ax.value)).join(' ');
-  const axesLines = axes.map((ax) => {
+  const axisLines = axes.map((ax) => {
     const end = pointForValue(cx, cy, radius, ax.angle, 100).split(',');
     return `<line x1="${cx}" y1="${cy}" x2="${end[0]}" y2="${end[1]}" stroke="#516179" stroke-width="1" />`;
   }).join('');
-  const labels = axes.map((ax) => {
-    const outer = pointForValue(cx, cy, radius + 16, ax.angle, 100).split(',');
-    const rendered = ax.value == null ? '—' : Number(ax.value).toFixed(1);
-    return `<text x="${outer[0]}" y="${outer[1]}" fill="#b5c7dd" font-size="9" text-anchor="middle">${esc(ax.label)} ${esc(rendered)}</text>`;
+
+  const axisLabels = axes.map((ax) => {
+    const outer = pointForValue(cx, cy, radius + 18, ax.angle, 100).split(',');
+    return `<text x="${outer[0]}" y="${outer[1]}" fill="#b5c7dd" font-size="9" text-anchor="middle">${esc(ax.label)}</text>`;
   }).join('');
 
-  return `<svg class="radar-chart" viewBox="0 0 200 200" role="img" aria-label="Radar chart">${rings}${axesLines}<polygon points="${dataPoints}" fill="rgba(59,130,246,0.25)" stroke="#3b82f6" stroke-width="2" />${labels}</svg>`;
-}
+  const leftPoints  = axes.map((ax) => pointForValue(cx, cy, radius, ax.angle, ax.leftVal)).join(' ');
+  const rightPoints = axes.map((ax) => pointForValue(cx, cy, radius, ax.angle, ax.rightVal)).join(' ');
 
-function renderPprInline(ppr) {
-  if (!ppr) return '';
-  const bandClass = {
-    Elite: 'ppr-band-elite',
-    Starter: 'ppr-band-starter',
-    Contributor: 'ppr-band-contributor',
-    Lottery: 'ppr-band-lottery',
-  }[ppr.band] ?? 'ppr-band-lottery';
-  return `<div class="compare-ppr-inline">
-    <span class="ppr-stat-label">Yr1 PPR</span>
-    <span class="compare-ppr-range">${esc(ppr.floor)}–${esc(ppr.ceiling)}</span>
-    <span class="meta">med</span>
-    <strong class="compare-ppr-median">${esc(ppr.median)}</strong>
-    <span class="ppr-band ${bandClass}">${esc(ppr.band)}</span>
-  </div>`;
-}
+  const leftName  = leftCard.identity.name;
+  const rightName = rightCard.identity.name;
+  const athLabel  = leftCard.athleticSource === 'SPORQ' ? 'ATH (SPORQ)' : leftCard.athleticSource === 'COMBINE_FALLBACK' ? 'ATH (partial)' : 'RAS';
 
-function renderPlayerPanel(card, sideLabel) {
-  const grade = card?.summary?.rookieGrade == null ? 'N/A' : card.summary.rookieGrade.toFixed(1);
-  const rank = card?.summary?.classRank == null ? 'N/A' : `#${card.summary.classRank}`;
-  const posRank = card?.summary?.posRank != null ? ` · ${esc(card.identity.position)} #${card.summary.posRank}` : '';
-  const identityBits = [
-    card.identity.positionLabel ?? card.identity.position,
-    card.identity.schoolDisplay ?? card.identity.school,
-    `Class ${card.identity.classYear}`,
-    card.identity.height,
-    card.identity.weight,
-  ].filter(Boolean).join(' • ');
-
-  const hasPostDraft = card.postDraftAdjustedGrade != null;
-  const translationFlags = Array.isArray(card?.translationFlags) ? card.translationFlags : [];
-  const contextFlags = Array.isArray(card?.contextSignals?.contextFlags) ? card.contextSignals.contextFlags : [];
-  const evidenceSummary = card?.contextSignals?.evidenceSummary ?? null;
+  function val(v) { return v == null ? '—' : Number(v).toFixed(1); }
 
   return `
-    <article class="compare-player compare-detail-panel">
-      <div class="section-title">${esc(sideLabel)}</div>
-      <h2 class="compare-name">
-        <span class="avatar-pos pos-${esc(card.identity.position)}">${esc(card.identity.position)}</span>
-        ${renderTeamLogos(card.identity.school, card.identity.nflTeam)}${esc(card.identity.name)}
-      </h2>
-      <div class="meta">${esc(identityBits)}</div>
-
-      <div class="compare-detail-grade">
-        <div class="compare-grade">${esc(grade)}</div>
-        <div class="meta">Class ${esc(rank)}${posRank}</div>
-        ${hasPostDraft ? `<div class="meta">Post-Draft: ${esc(card.postDraftAdjustedGrade.toFixed(1))} · Δ ${esc((card.postDraftDelta >= 0 ? '+' : '') + card.postDraftDelta.toFixed(1))}</div>` : ''}
-        ${renderEvidenceTierBadge(card)}
-      </div>
-
-      <p class="meta compare-profile-summary">${esc(card.summary.profileSummary ?? card.summary.identityNote ?? '')}</p>
-
-      <div class="compare-pills">
-        ${card.summary.archetype ? `<span class="tag">${esc(card.summary.archetype)}</span>` : ''}
-        ${card.summary.projection ? `<span class="tag">${esc(card.summary.projection)}</span>` : ''}
-        ${card.youngBreakoutFlag
-          ? `<span class="breakout-badge breakout-young">⚡ Age ${esc(card.breakoutAge)} breakout</span>`
-          : (card.breakoutAge != null ? `<span class="breakout-badge breakout-late">Age ${esc(card.breakoutAge)} breakout</span>` : '')}
-      </div>
-
-      ${renderPprInline(card.pprProjection)}
-
-      <div class="radar-section">
-        <div class="section-title">Model Input Radar</div>
-        ${renderRadarChart(card.athleticScore, card.productionScore, card.draftCapitalScore, card.athleticSource)}
-      </div>
-
-      ${evidenceSummary ? `<div class="meta compare-evidence-summary">${esc(evidenceSummary)}</div>` : ''}
-
-      ${translationFlags.length ? `<div class="tags compare-translation-tags">${translationFlags.map((f) => `<span class="tag">${esc(String(f).replace(/_/g, ' '))}</span>`).join('')}</div>` : ''}
-      ${contextFlags.length ? `<div class="tags" style="margin-top:4px">${contextFlags.map((f) => `<span class="tag tag-context">${esc(String(f).replace(/_/g, ' '))}</span>`).join('')}</div>` : ''}
-    </article>`;
-}
-
-function renderScoreRows(scoreComparisons) {
-  if (!scoreComparisons.length) return '<div class="meta">No shared scores available.</div>';
-  return `<div class="compare-score-rows">${
-    scoreComparisons.map((row) => {
-      const leftWidth = row.leftValue == null ? 0 : Math.max(0, Math.min(100, row.leftValue));
-      const rightWidth = row.rightValue == null ? 0 : Math.max(0, Math.min(100, row.rightValue));
-      const leftWins = row.winner === 'left';
-      const rightWins = row.winner === 'right';
-
-      const barLeft = row.leftValue == null
-        ? '<span class="meta">N/A</span>'
-        : `<div class="compare-score-bar-row${leftWins ? ' is-winner' : ''}">
-            <div class="compare-score-track">
-              <div class="${leftWins ? 'compare-fill-winner' : 'compare-fill-dim'}" style="width:${leftWidth}%"></div>
-            </div>
-            <span class="compare-bar-value">${row.leftValue.toFixed(1)}</span>
-          </div>`;
-
-      const barRight = row.rightValue == null
-        ? '<span class="meta">N/A</span>'
-        : `<div class="compare-score-bar-row${rightWins ? ' is-winner' : ''}">
-            <div class="compare-score-track">
-              <div class="${rightWins ? 'compare-fill-winner' : 'compare-fill-dim'}" style="width:${rightWidth}%"></div>
-            </div>
-            <span class="compare-bar-value">${row.rightValue.toFixed(1)}</span>
-          </div>`;
-
-      return `<div class="compare-score-row">
-        <div class="compare-score-label">${esc(row.label)}</div>
-        <div class="compare-score-sides">
-          <div class="compare-score-side"><span class="compare-side-tag">L</span>${barLeft}</div>
-          <div class="compare-score-side"><span class="compare-side-tag">R</span>${barRight}</div>
+    <div class="compare-radar-row">
+      <div class="compare-radar-side compare-radar-side-left">
+        <div class="compare-radar-metric">
+          <span class="compare-radar-val compare-radar-val-left">${val(leftCard.athleticScore)}</span>
+          <span class="compare-radar-label">${esc(athLabel)}</span>
         </div>
-      </div>`;
-    }).join('')
-  }</div>`;
+        <div class="compare-radar-metric">
+          <span class="compare-radar-val compare-radar-val-left">${val(leftCard.productionScore)}</span>
+          <span class="compare-radar-label">Production</span>
+        </div>
+        <div class="compare-radar-metric">
+          <span class="compare-radar-val compare-radar-val-left">${val(leftCard.draftCapitalScore)}</span>
+          <span class="compare-radar-label">Draft Capital</span>
+        </div>
+      </div>
+      <div class="compare-radar-center">
+        <svg class="compare-radar-svg" viewBox="0 0 220 220" role="img" aria-label="Overlaid radar chart">
+          ${rings}${axisLines}
+          <polygon points="${rightPoints}" fill="rgba(232,133,61,0.15)" stroke="#E8853D" stroke-width="2" />
+          <polygon points="${leftPoints}"  fill="rgba(59,130,246,0.2)"  stroke="#3b82f6" stroke-width="2" />
+          ${axisLabels}
+        </svg>
+        <div class="compare-radar-legend">
+          <span class="compare-radar-legend-item"><span class="compare-radar-dot compare-radar-dot-left"></span>${esc(leftName)}</span>
+          <span class="compare-radar-legend-item"><span class="compare-radar-dot compare-radar-dot-right"></span>${esc(rightName)}</span>
+        </div>
+      </div>
+      <div class="compare-radar-side compare-radar-side-right">
+        <div class="compare-radar-metric">
+          <span class="compare-radar-label">${esc(athLabel)}</span>
+          <span class="compare-radar-val compare-radar-val-right">${val(rightCard.athleticScore)}</span>
+        </div>
+        <div class="compare-radar-metric">
+          <span class="compare-radar-label">Production</span>
+          <span class="compare-radar-val compare-radar-val-right">${val(rightCard.productionScore)}</span>
+        </div>
+        <div class="compare-radar-metric">
+          <span class="compare-radar-label">Draft Capital</span>
+          <span class="compare-radar-val compare-radar-val-right">${val(rightCard.draftCapitalScore)}</span>
+        </div>
+      </div>
+    </div>`;
 }
+
+// ── Top-edge highlight cards ──────────────────────────────────────────────────
+
+function renderTopEdges(evidenceComparisons, scoreComparisons) {
+  const candidates = [...evidenceComparisons, ...scoreComparisons]
+    .filter((r) => r.winner !== 'tie' && Math.abs(r.delta ?? 0) >= 1.5)
+    .sort((a, b) => Math.abs(b.delta ?? 0) - Math.abs(a.delta ?? 0))
+    .slice(0, 3);
+
+  if (!candidates.length) return '';
+
+  const cards = candidates.map((row) => {
+    const isLeft  = row.winner === 'left';
+    const strength = Math.abs(row.delta ?? 0) >= 4 ? 'STRONG' : 'EDGE';
+    const leftDisplay  = row.leftDisplay  ?? (row.leftValue  != null ? row.leftValue.toFixed(1)  : 'N/A');
+    const rightDisplay = row.rightDisplay ?? (row.rightValue != null ? row.rightValue.toFixed(1) : 'N/A');
+    return `
+      <div class="compare-top-edge-card compare-top-edge-${esc(row.winner)}">
+        <div class="compare-top-edge-label">${esc(row.label)}</div>
+        <div class="compare-top-edge-values">
+          <span class="${isLeft ? 'compare-top-edge-winner' : 'compare-top-edge-other'}">${esc(String(leftDisplay))}</span>
+          <span class="compare-top-edge-vs">vs</span>
+          <span class="${!isLeft ? 'compare-top-edge-winner' : 'compare-top-edge-other'}">${esc(String(rightDisplay))}</span>
+        </div>
+        <div class="compare-top-edge-badge">${strength} → ${isLeft ? 'Left' : 'Right'}</div>
+      </div>`;
+  }).join('');
+
+  return `<div class="compare-top-edges">${cards}</div>`;
+}
+
+// ── 3-column comparison table ─────────────────────────────────────────────────
+
+function render3ColRow(leftHtml, labelHtml, rightHtml, winner, delta) {
+  const absD = Math.abs(delta ?? 0);
+  const edgeCls = winner === 'left' ? ' edge-left' : winner === 'right' ? ' edge-right' : '';
+  const strongCls = absD >= 4 ? ' is-strong-edge' : absD >= 1.5 ? ' is-lean-edge' : '';
+  const edgeTag = winner && winner !== 'tie'
+    ? `<span class="compare-3col-edge-tag compare-3col-edge-${esc(winner)}">${winner === 'left' ? '◀' : '▶'} ${absD >= 4 ? 'STRONG' : 'EDGE'}</span>`
+    : '';
+  return `
+    <div class="compare-3col-row${edgeCls}${strongCls}">
+      <div class="compare-3col-left">${leftHtml}</div>
+      <div class="compare-3col-center">${labelHtml}${edgeTag}</div>
+      <div class="compare-3col-right">${rightHtml}</div>
+    </div>`;
+}
+
+function formatScoreVal(v) {
+  if (v == null) return '<span class="compare-3col-na">—</span>';
+  const formatted = Number.isInteger(v) ? String(v) : v.toFixed(1);
+  return `<strong>${esc(formatted)}</strong>`;
+}
+
+function renderScoreSection(scoreComparisons) {
+  if (!scoreComparisons.length) return '';
+  const rows = scoreComparisons.map((r) =>
+    render3ColRow(formatScoreVal(r.leftValue), esc(r.label), formatScoreVal(r.rightValue), r.winner, r.delta)
+  ).join('');
+  return `<div class="compare-domain-header">Model Scores</div>${rows}`;
+}
+
+const DOMAIN_ORDER  = ['production', 'athletic', 'capital', 'context'];
+const DOMAIN_LABELS = { production: 'Production', athletic: 'Athletic', capital: 'Draft Capital', context: 'Context' };
+
+function renderEvidenceSections(evidenceComparisons) {
+  if (!evidenceComparisons.length) return '';
+
+  const byDomain = new Map();
+  for (const row of evidenceComparisons) {
+    const d = row.family ?? 'context';
+    if (!byDomain.has(d)) byDomain.set(d, []);
+    byDomain.get(d).push(row);
+  }
+
+  return [...byDomain.entries()]
+    .sort(([a], [b]) => {
+      const ai = DOMAIN_ORDER.indexOf(a), bi = DOMAIN_ORDER.indexOf(b);
+      return (ai < 0 ? 99 : ai) - (bi < 0 ? 99 : bi);
+    })
+    .map(([domain, rows]) => {
+      const header = DOMAIN_LABELS[domain] ?? domain.charAt(0).toUpperCase() + domain.slice(1);
+      const rowsHtml = rows.map((r) =>
+        render3ColRow(`<span>${esc(r.leftDisplay)}</span>`, esc(r.label), `<span>${esc(r.rightDisplay)}</span>`, r.winner, r.delta)
+      ).join('');
+      return `<div class="compare-domain-header">${esc(header)}</div>${rowsHtml}`;
+    }).join('');
+}
+
+// ── Player header panels ──────────────────────────────────────────────────────
 
 const STAT_LABELS = {
   completions: 'Comp', attempts: 'Att', completion_pct: 'Comp%',
@@ -194,35 +223,130 @@ const STAT_LABELS = {
 function formatStatEntry(key, value) {
   const label = STAT_LABELS[key];
   if (label === null) return null;
-  const displayLabel = label ?? key.replace(/_/g, ' ');
-  const displayValue = key === 'completion_pct' ? `${value}%` : value;
-  return `${displayLabel}: ${displayValue}`;
+  return `${label ?? key.replace(/_/g, ' ')}: ${key === 'completion_pct' ? `${value}%` : value}`;
 }
 
 function seasonSnapshot(card) {
-  if (!card?.seasons?.length) {
-    return '<div class="meta">College stats not yet available for this player.</div>';
-  }
-  const top = card.seasons.slice(0, 2);
+  if (!card?.seasons?.length) return '<div class="meta">College stats not yet available.</div>';
   return `<table class="stats-table"><thead><tr><th>Season</th><th>School</th><th>Stats</th></tr></thead><tbody>${
-    top.map((row) => {
-      const statBits = Object.entries(row.statLine).map(([k, v]) => formatStatEntry(k, v)).filter(Boolean).join(' · ');
-      return `<tr><td>${esc(row.season)}</td><td>${esc(row.team)}</td><td>${esc(statBits)}</td></tr>`;
+    card.seasons.slice(0, 2).map((row) => {
+      const bits = Object.entries(row.statLine).map(([k, v]) => formatStatEntry(k, v)).filter(Boolean).join(' · ');
+      return `<tr><td>${esc(row.season)}</td><td>${esc(row.team)}</td><td>${esc(bits)}</td></tr>`;
     }).join('')
   }</tbody></table>`;
 }
 
-function evidenceRow(row) {
-  const edgeClass = row.winner === 'left' ? 'compare-edge-left' : row.winner === 'right' ? 'compare-edge-right' : '';
-  const edge = row.winner === 'tie' ? 'Even' : row.winner === 'left' ? 'Left leads' : 'Right leads';
-  return `<tr><td>${esc(row.label)}</td><td>${esc(row.leftDisplay)}</td><td>${esc(row.rightDisplay)}</td><td class="${edgeClass}">${esc(edge)}</td></tr>`;
+function renderPlayerHeader(card, sideLabel) {
+  const grade = card?.summary?.rookieGrade == null ? 'N/A' : card.summary.rookieGrade.toFixed(1);
+  const rank  = card?.summary?.classRank == null ? 'N/A' : `#${card.summary.classRank}`;
+  const posRank = card?.summary?.posRank != null ? ` · ${esc(card.identity.position)} #${card.summary.posRank}` : '';
+  const identityBits = [
+    card.identity.positionLabel ?? card.identity.position,
+    card.identity.schoolDisplay ?? card.identity.school,
+    `Class ${card.identity.classYear}`,
+  ].filter(Boolean).join(' · ');
+
+  const hasPostDraft  = card.postDraftAdjustedGrade != null;
+  const translation   = Array.isArray(card?.translationFlags) ? card.translationFlags : [];
+  const contextFlags  = Array.isArray(card?.contextSignals?.contextFlags) ? card.contextSignals.contextFlags : [];
+  const evidenceSummary = card?.contextSignals?.evidenceSummary ?? null;
+  const ppr = card.pprProjection;
+  const pprNote = ppr ? `Yr1 PPR ${esc(ppr.floor)}–${esc(ppr.ceiling)} med ${esc(ppr.median)}` : '';
+
+  return `
+    <article class="compare-player compare-player-panel">
+      <div class="compare-player-panel-top">
+        <div class="compare-player-panel-identity">
+          <div class="section-title">${esc(sideLabel)}</div>
+          <h2 class="compare-name">
+            <span class="avatar-pos pos-${esc(card.identity.position)}">${esc(card.identity.position)}</span>
+            ${renderTeamLogos(card.identity.school, card.identity.nflTeam)}${esc(card.identity.name)}
+          </h2>
+          <div class="meta">${esc(identityBits)}</div>
+        </div>
+        <div class="compare-player-panel-grade">
+          <div class="compare-grade">${esc(grade)}</div>
+          <div class="meta">Class ${esc(rank)}${posRank}</div>
+          ${hasPostDraft ? `<div class="meta">Post ${esc(card.postDraftAdjustedGrade.toFixed(1))} Δ ${esc((card.postDraftDelta >= 0 ? '+' : '') + card.postDraftDelta.toFixed(1))}</div>` : ''}
+          ${renderEvidenceTierBadge(card)}
+        </div>
+      </div>
+
+      <p class="meta compare-profile-summary">${esc(card.summary.profileSummary ?? card.summary.identityNote ?? '')}</p>
+
+      <div class="compare-pills">
+        ${card.summary.archetype ? `<span class="tag">${esc(card.summary.archetype)}</span>` : ''}
+        ${card.summary.projection ? `<span class="tag">${esc(card.summary.projection)}</span>` : ''}
+        ${card.youngBreakoutFlag
+          ? `<span class="breakout-badge breakout-young">⚡ Age ${esc(card.breakoutAge)} breakout</span>`
+          : card.breakoutAge != null ? `<span class="breakout-badge breakout-late">Age ${esc(card.breakoutAge)} breakout</span>` : ''}
+      </div>
+
+      ${pprNote ? `<div class="meta compare-ppr-note" style="margin-top:6px">${pprNote}</div>` : ''}
+
+      <details class="compare-expandable">
+        <summary class="compare-expand-trigger">Full context ↓</summary>
+        <div class="compare-expand-content">
+          ${evidenceSummary ? `<p class="meta">${esc(evidenceSummary)}</p>` : ''}
+          ${translation.length ? `<div class="tags" style="margin-top:8px">${translation.map((f) => `<span class="tag">${esc(String(f).replace(/_/g, ' '))}</span>`).join('')}</div>` : ''}
+          ${contextFlags.length ? `<div class="tags" style="margin-top:6px">${contextFlags.map((f) => `<span class="tag tag-context">${esc(String(f).replace(/_/g, ' '))}</span>`).join('')}</div>` : ''}
+          <div style="margin-top:12px">${seasonSnapshot(card)}</div>
+        </div>
+      </details>
+    </article>`;
 }
+
+// ── PPR side-by-side ──────────────────────────────────────────────────────────
+
+function renderPprSideBySide(leftCard, rightCard) {
+  const leftPpr  = leftCard.pprProjection;
+  const rightPpr = rightCard.pprProjection;
+  if (!leftPpr && !rightPpr) return '';
+
+  function pprPanel(card, ppr) {
+    if (!ppr) return `<div class="compare-ppr-panel"><div class="meta">${esc(card.identity.name)}: No projection</div></div>`;
+    const bandClass = { Elite: 'ppr-band-elite', Starter: 'ppr-band-starter', Contributor: 'ppr-band-contributor', Lottery: 'ppr-band-lottery' }[ppr.band] ?? 'ppr-band-lottery';
+    const floor = Number(ppr.floor), median = Number(ppr.median), ceiling = Number(ppr.ceiling);
+    const maxScale = Math.max(1, Math.ceil(Math.max(floor, median, ceiling) / 25) * 25);
+    const rangeLeft  = Math.max(0, Math.min(100, (floor / maxScale) * 100));
+    const rangeWidth = Math.max(0, Math.min(100 - rangeLeft, ((ceiling - floor) / maxScale) * 100));
+    const medianLeft = Math.max(0, Math.min(100, (median / maxScale) * 100));
+    return `
+      <div class="compare-ppr-panel">
+        <div class="section-title">${esc(card.identity.name)}</div>
+        <div class="compare-ppr-values">
+          <span class="ppr-stat-label">Flr</span><strong>${esc(ppr.floor)}</strong>
+          <span class="ppr-stat-label">Med</span><strong style="color:var(--accent)">${esc(ppr.median)}</strong>
+          <span class="ppr-stat-label">Ceil</span><strong>${esc(ppr.ceiling)}</strong>
+          <span class="ppr-band ${bandClass}">${esc(ppr.band)}</span>
+        </div>
+        <div class="ppr-range-viz" style="margin-top:8px">
+          <div class="ppr-range-track">
+            <div class="ppr-range-fill" style="left:${rangeLeft}%;width:${rangeWidth}%"></div>
+            <div class="ppr-range-median-marker" style="left:${medianLeft}%"></div>
+          </div>
+        </div>
+      </div>`;
+  }
+
+  return `
+    <section class="metrics">
+      <div class="section-title">Year 1 PPR projection</div>
+      <div class="compare-ppr-grid">
+        ${pprPanel(leftCard, leftPpr)}
+        ${pprPanel(rightCard, rightPpr)}
+      </div>
+    </section>`;
+}
+
+// ── Main export ───────────────────────────────────────────────────────────────
 
 export function renderRookieCompareView(container, leftCard, rightCard) {
   const compared = compareRookies(leftCard, rightCard);
 
   container.innerHTML = `
     <section class="compare-layout">
+
       <div class="verdict-strip verdict-${esc(compared.verdict.code)}">
         <div>
           <div class="section-title">Transparent verdict</div>
@@ -233,21 +357,25 @@ export function renderRookieCompareView(container, leftCard, rightCard) {
       </div>
 
       <div class="compare-grid">
-        ${renderPlayerPanel(leftCard, 'Left')}
-        ${renderPlayerPanel(rightCard, 'Right')}
+        ${renderPlayerHeader(leftCard, 'Left')}
+        ${renderPlayerHeader(rightCard, 'Right')}
       </div>
 
-      <section class="metrics">
-        <div class="section-title">Score comparison</div>
-        ${renderScoreRows(compared.scoreComparisons)}
-      </section>
+      ${renderTopEdges(compared.evidenceComparisons, compared.scoreComparisons)}
 
-      <section class="metrics">
-        <div class="section-title">Key evidence edges</div>
-        ${compared.evidenceComparisons.length
-          ? `<table class="stats-table compare-table"><thead><tr><th>Metric</th><th>Left</th><th>Right</th><th>Edge</th></tr></thead><tbody>${compared.evidenceComparisons.map(evidenceRow).join('')}</tbody></table>`
-          : '<div class="meta">Insufficient shared evidence rows for a meaningful metric edge table.</div>'}
-      </section>
+      <div class="compare-3col-table">
+        <div class="compare-3col-name-row">
+          <div class="compare-3col-left compare-3col-name">${esc(leftCard.identity.name)}</div>
+          <div class="compare-3col-center"></div>
+          <div class="compare-3col-right compare-3col-name">${esc(rightCard.identity.name)}</div>
+        </div>
+
+        ${renderScoreSection(compared.scoreComparisons)}
+        ${renderSharedRadar(leftCard, rightCard)}
+        ${renderEvidenceSections(compared.evidenceComparisons)}
+      </div>
+
+      ${renderPprSideBySide(leftCard, rightCard)}
 
       <section class="compare-grid compare-snapshot-grid">
         <article class="rookie-card compare-snapshot">
@@ -262,11 +390,12 @@ export function renderRookieCompareView(container, leftCard, rightCard) {
 
       <section class="metrics">
         <div class="section-title">Compare notes</div>
-        <ul class="compare-notes">${compared.notes.map((note) => `<li>${esc(note)}</li>`).join('')}</ul>
-        <div style="margin-top: 12px">
+        <ul class="compare-notes">${compared.notes.map((n) => `<li>${esc(n)}</li>`).join('')}</ul>
+        <div style="margin-top:12px">
           <button type="button" class="btn" data-compare-csv-export>↓ Export comparison CSV</button>
         </div>
       </section>
+
     </section>
   `;
 }

--- a/components/rookies/rookieCardStyles.css
+++ b/components/rookies/rookieCardStyles.css
@@ -698,73 +698,160 @@ body {
 .compare-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px,1fr)); gap: 12px; }
 .compare-player { border: 1px solid var(--border); border-radius: 12px; padding: 12px; background: var(--panel); }
 .compare-name { margin: 6px 0; }
-.compare-grade { color: var(--accent); font-size: 34px; font-weight: 800; line-height: 1.1; margin-top: 8px; }
+.compare-grade { color: var(--accent); font-size: 34px; font-weight: 800; line-height: 1.1; margin-top: 4px; }
 .compare-pills { margin-top: 10px; display: flex; flex-wrap: wrap; gap: 8px; }
 .compare-table th:first-child, .compare-table td:first-child { width: 40%; }
 .compare-notes { margin: 8px 0 0; padding-left: 18px; color: var(--text); opacity: 0.85; display: grid; gap: 6px; }
 .compare-snapshot-grid { align-items: stretch; }
 .compare-snapshot { height: 100%; }
 
-/* ── Compare rebuild: rich player panels ──────────────────────────────────── */
-.compare-detail-panel { display: flex; flex-direction: column; gap: 10px; }
-.compare-detail-grade { margin-top: 2px; display: flex; flex-direction: column; gap: 4px; }
+/* ── Player header panels ─────────────────────────────────────────────────── */
+.compare-player-panel { display: flex; flex-direction: column; gap: 8px; }
+.compare-player-panel-top { display: flex; justify-content: space-between; gap: 10px; align-items: flex-start; }
+.compare-player-panel-identity { flex: 1; min-width: 0; }
+.compare-player-panel-grade { flex-shrink: 0; text-align: right; }
 .compare-profile-summary { margin: 0; line-height: 1.5; }
-.compare-evidence-summary { font-size: 12px; }
-.compare-translation-tags { margin-top: 6px; }
+.compare-ppr-note { font-size: 12px; }
 
-/* PPR inline display */
-.compare-ppr-inline {
-  display: flex;
-  align-items: center;
-  gap: 5px;
-  flex-wrap: wrap;
-  font-size: 13px;
+/* ── Expandable context ───────────────────────────────────────────────────── */
+.compare-expandable { margin-top: 8px; }
+.compare-expand-trigger {
+  display: inline-block;
+  cursor: pointer;
+  font-size: 12px;
+  color: var(--accent-soft);
+  list-style: none;
+  user-select: none;
 }
-.compare-ppr-range { font-weight: 700; font-size: 14px; }
-.compare-ppr-median { color: var(--accent); }
+.compare-expand-trigger::-webkit-details-marker { display: none; }
+.compare-expand-trigger:hover { color: var(--accent); }
+.compare-expand-content { margin-top: 10px; display: flex; flex-direction: column; gap: 6px; }
 
-/* ── Compare score bar rows ───────────────────────────────────────────────── */
-.compare-score-rows { display: flex; flex-direction: column; gap: 10px; margin-top: 8px; }
-.compare-score-row { display: flex; flex-direction: column; gap: 4px; }
-.compare-score-label {
-  font-size: 11px;
-  color: var(--muted);
-  text-transform: uppercase;
-  letter-spacing: .07em;
+/* ── Top-edge highlight cards ─────────────────────────────────────────────── */
+.compare-top-edges {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 8px;
 }
-.compare-score-sides { display: flex; flex-direction: column; gap: 4px; }
-.compare-score-side { display: flex; align-items: center; gap: 6px; }
-.compare-side-tag {
-  font-size: 10px;
-  font-weight: 700;
-  color: var(--muted);
-  min-width: 14px;
-  letter-spacing: .04em;
-  flex-shrink: 0;
-}
-.compare-score-bar-row { display: flex; align-items: center; gap: 6px; flex: 1; }
-.compare-score-bar-row.is-winner .compare-bar-value { color: var(--accent-soft); font-weight: 700; }
-.compare-score-track {
-  flex: 1;
-  height: 6px;
-  background: #0E0B08;
-  border-radius: 999px;
-  overflow: hidden;
+.compare-top-edge-card {
   border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
 }
-.compare-fill-winner { height: 100%; border-radius: 999px; background: linear-gradient(90deg, #D97757, #F0B080); }
-.compare-fill-dim { height: 100%; border-radius: 999px; background: rgba(158, 139, 122, 0.35); }
-.compare-bar-value {
-  font-family: 'JetBrains Mono', 'Fira Mono', ui-monospace, monospace;
-  font-size: 13px;
-  font-variant-numeric: tabular-nums;
-  min-width: 34px;
-  flex-shrink: 0;
+.compare-top-edge-left  { background: var(--accent-glow); border-color: var(--border-accent); }
+.compare-top-edge-right { background: var(--teal-glow); border-color: rgba(78,205,196,0.35); }
+.compare-top-edge-label { font-size: 11px; color: var(--muted); text-transform: uppercase; letter-spacing: .07em; }
+.compare-top-edge-values { display: flex; align-items: baseline; gap: 6px; font-size: 15px; font-weight: 700; }
+.compare-top-edge-winner { color: var(--accent-soft); }
+.compare-top-edge-vs { font-size: 11px; color: var(--muted); font-weight: 400; }
+.compare-top-edge-other { color: var(--muted); font-weight: 400; font-size: 13px; }
+.compare-top-edge-badge { font-size: 10px; font-weight: 700; letter-spacing: .06em; color: var(--muted); text-transform: uppercase; }
+.compare-top-edge-left .compare-top-edge-badge  { color: var(--accent-soft); }
+.compare-top-edge-right .compare-top-edge-badge { color: var(--teal); }
+
+/* ── 3-column comparison table ────────────────────────────────────────────── */
+.compare-3col-table {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: hidden;
+  background: rgba(14, 11, 9, 0.95);
+}
+.compare-3col-name-row {
+  display: grid;
+  grid-template-columns: 1fr 180px 1fr;
+  padding: 8px 12px;
+  background: #100D0A;
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--text);
+}
+.compare-3col-name { font-size: 12px; font-weight: 700; }
+.compare-3col-name-row .compare-3col-left  { text-align: right; }
+.compare-3col-name-row .compare-3col-right { text-align: left; }
+.compare-3col-row {
+  display: grid;
+  grid-template-columns: 1fr 180px 1fr;
+  align-items: center;
+  padding: 7px 12px;
+  border-top: 1px solid var(--border);
+  transition: background 0.1s;
+}
+.compare-3col-row.is-strong-edge { background: rgba(232, 133, 61, 0.04); }
+.compare-3col-row.is-lean-edge   { background: rgba(255,255,255, 0.01); }
+.compare-3col-left  { text-align: right; font-size: 14px; font-variant-numeric: tabular-nums; }
+.compare-3col-right { text-align: left;  font-size: 14px; font-variant-numeric: tabular-nums; }
+.compare-3col-row.edge-left  .compare-3col-left  { color: var(--accent-soft); }
+.compare-3col-row.edge-right .compare-3col-right { color: var(--teal); }
+.compare-3col-na { color: var(--muted); }
+.compare-3col-center {
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  padding: 0 8px;
+}
+.compare-3col-label { font-size: 11px; color: var(--muted); text-transform: uppercase; letter-spacing: .07em; }
+.compare-3col-edge-tag {
+  font-size: 9px;
+  font-weight: 800;
+  letter-spacing: .06em;
+  border-radius: 999px;
+  padding: 1px 6px;
+}
+.compare-3col-edge-left  { background: var(--accent-glow); color: var(--accent-soft); border: 1px solid var(--border-accent); }
+.compare-3col-edge-right { background: var(--teal-glow);   color: var(--teal);        border: 1px solid rgba(78,205,196,0.35); }
+
+/* Domain section headers inside the 3-col table */
+.compare-domain-header {
+  padding: 6px 12px;
+  background: rgba(20, 15, 10, 0.9);
+  font-size: 11px;
+  letter-spacing: .12em;
+  text-transform: uppercase;
+  color: var(--accent-soft);
+  font-weight: 700;
+  border-top: 1px solid var(--border);
 }
 
-/* ── Evidence edge coloring ───────────────────────────────────────────────── */
-.compare-edge-left { color: var(--accent-soft); font-weight: 600; }
-.compare-edge-right { color: var(--teal); font-weight: 600; }
+/* ── Shared overlaid radar ────────────────────────────────────────────────── */
+.compare-radar-row {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  border-top: 1px solid var(--border);
+  background: var(--panel-alt);
+  padding: 12px;
+  gap: 8px;
+}
+.compare-radar-svg { width: 180px; max-width: 100%; display: block; }
+.compare-radar-center { display: flex; flex-direction: column; align-items: center; gap: 6px; }
+.compare-radar-legend { display: flex; gap: 14px; font-size: 11px; color: var(--muted); }
+.compare-radar-legend-item { display: flex; align-items: center; gap: 4px; }
+.compare-radar-dot { width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0; }
+.compare-radar-dot-left  { background: #3b82f6; }
+.compare-radar-dot-right { background: #E8853D; }
+.compare-radar-side { display: flex; flex-direction: column; gap: 8px; }
+.compare-radar-side-left  { align-items: flex-end; text-align: right; }
+.compare-radar-side-right { align-items: flex-start; text-align: left; }
+.compare-radar-metric { display: flex; flex-direction: column; gap: 1px; }
+.compare-radar-val {
+  font-family: 'JetBrains Mono', 'Fira Mono', ui-monospace, monospace;
+  font-size: 16px;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+.compare-radar-val-left  { color: #6b9fd4; }
+.compare-radar-val-right { color: #E8853D; }
+.compare-radar-label { font-size: 10px; color: var(--muted); text-transform: uppercase; letter-spacing: .07em; }
+
+/* ── PPR side-by-side ─────────────────────────────────────────────────────── */
+.compare-ppr-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 12px; margin-top: 8px; }
+.compare-ppr-panel { background: var(--panel-alt); border: 1px solid var(--border); border-radius: 10px; padding: 12px; }
+.compare-ppr-values { display: flex; align-items: baseline; gap: 6px; font-size: 14px; margin-top: 6px; flex-wrap: wrap; }
 
 /* ── Generic button ───────────────────────────────────────────────────────── */
 .btn {
@@ -781,6 +868,17 @@ body {
 .btn:hover {
   border-color: var(--border-accent);
   color: var(--accent-soft);
+}
+
+/* ── Compare responsive ───────────────────────────────────────────────────── */
+@media (max-width: 600px) {
+  .compare-3col-name-row,
+  .compare-3col-row { grid-template-columns: 1fr 120px 1fr; }
+  .compare-radar-row { grid-template-columns: 1fr; }
+  .compare-radar-side { flex-direction: row; flex-wrap: wrap; }
+  .compare-radar-side-left, .compare-radar-side-right { align-items: flex-start; text-align: left; }
+  .compare-radar-center { width: 100%; }
+  .compare-radar-svg { width: 200px; }
 }
 
 /* ─── Queue ───────────────────────────────────────────────────────────────── */

--- a/lib/rookies/compareRookies.js
+++ b/lib/rookies/compareRookies.js
@@ -63,6 +63,7 @@ function buildEvidenceComparisons(leftCard, rightCard, samePosition) {
       const delta = numericDelta(leftMetric?.value ?? null, rightMetric?.value ?? null, direction);
       return {
         label,
+        family: leftMetric?.family ?? rightMetric?.family ?? 'context',
         leftDisplay: leftMetric?.display ?? 'N/A',
         rightDisplay: rightMetric?.display ?? 'N/A',
         leftValue: leftMetric?.value ?? null,


### PR DESCRIPTION
Replaces two-column panel pair + separate table with a richer design closer to the prototype:

- 3-column comparison table (left value | label | right value) with edge badges (EDGE / STRONG) and winner colour-coding (orange = left, teal = right) organised under per-domain section headers (Production, Athletic, Draft Capital, Context)
- Single shared overlaid radar chart showing both players on the same axes (blue polygon = left, orange = right) with flanking numeric values; replaces two separate per-player charts
- Top-edge highlight cards pulling the 2–3 largest deltas to the top of the comparison for fast scanning
- Per-player headers now include an expandable "Full context" accordion (HTML details/summary) showing evidence summary, translation flags, context flags, and season stats inline
- PPR projections rendered side-by-side with range bars
- family field added to evidence comparison rows in compareRookies.js to power domain grouping in the view

https://claude.ai/code/session_013s7gznFMJzZqZrQrP4ksS8