### PR TITLE
Polish compare redesign visual parity and edge labeling

### DIFF
--- a/cards/rookies/compare/index.html
+++ b/cards/rookies/compare/index.html
@@ -23,13 +23,15 @@
       </div>
     </header>
 
-    <main class="page">
-      <div class="section-title" style="margin-top: 12px">TIBER Rookie Compare</div>
-      <h1>Rookie decision surface</h1>
-      <p class="meta">Compare any two rookies across 2022–2026 classes with deterministic grade + evidence deltas.</p>
+    <main class="page compare-page">
+      <section class="compare-page-hero">
+        <div class="section-title">TIBER Rookie Compare</div>
+        <h1>Rookie decision surface</h1>
+        <p class="meta">Compare any two rookies across 2022–2026 classes with deterministic grade + evidence deltas.</p>
+      </section>
 
-      <section id="compare-selector-root" style="margin-top: 12px">Loading compare controls…</section>
-      <section id="compare-root" style="margin-top: 12px">Loading comparison…</section>
+      <section id="compare-selector-root" class="compare-selector-shell">Loading compare controls…</section>
+      <section id="compare-root" class="compare-results-shell">Loading comparison…</section>
     </main>
 
     <!-- ── Site footer ───────────────────────────────────────────────────────── -->

--- a/components/rookies/RookieCompareSelector.js
+++ b/components/rookies/RookieCompareSelector.js
@@ -35,20 +35,20 @@ function buildOptions(cards, selectedSlug) {
 
 export function renderRookieCompareSelector({ cards, leftSlug, rightSlug }) {
   return `
-    <form id="compare-selector" class="compare-selector">
-      <label class="control-field">
-        <span class="control-label">Left rookie</span>
+    <form id="compare-selector" class="compare-selector compare-selector-redesign">
+      <label class="control-field compare-control-panel compare-control-panel-left">
+        <span class="control-label">Player A</span>
         <select name="left" data-compare-control="left">
           ${buildOptions(cards, leftSlug)}
         </select>
       </label>
-      <label class="control-field">
-        <span class="control-label">Right rookie</span>
+      <button type="button" id="swap-compare-sides" class="compare-button compare-button-swap" aria-label="Swap compare sides">⇄</button>
+      <label class="control-field compare-control-panel compare-control-panel-right">
+        <span class="control-label">Player B</span>
         <select name="right" data-compare-control="right">
           ${buildOptions(cards, rightSlug)}
         </select>
       </label>
-      <button type="button" id="swap-compare-sides" class="compare-button">Swap</button>
     </form>
   `;
 }

--- a/components/rookies/RookieCompareView.js
+++ b/components/rookies/RookieCompareView.js
@@ -158,13 +158,14 @@ function render3ColRow(leftHtml, labelHtml, rightHtml, winner, delta) {
   const absD = Math.abs(delta ?? 0);
   const edgeCls = winner === 'left' ? ' edge-left' : winner === 'right' ? ' edge-right' : '';
   const strongCls = absD >= 4 ? ' is-strong-edge' : absD >= 1.5 ? ' is-lean-edge' : '';
+  const centerLabel = `<span class="compare-3col-label">${labelHtml}</span>`;
   const edgeTag = winner && winner !== 'tie'
     ? `<span class="compare-3col-edge-tag compare-3col-edge-${esc(winner)}">${winner === 'left' ? '◀' : '▶'} ${absD >= 4 ? 'STRONG' : 'EDGE'}</span>`
     : '';
   return `
     <div class="compare-3col-row${edgeCls}${strongCls}">
       <div class="compare-3col-left">${leftHtml}</div>
-      <div class="compare-3col-center">${labelHtml}${edgeTag}</div>
+      <div class="compare-3col-center">${centerLabel}${edgeTag}</div>
       <div class="compare-3col-right">${rightHtml}</div>
     </div>`;
 }
@@ -343,6 +344,14 @@ function renderPprSideBySide(leftCard, rightCard) {
 
 export function renderRookieCompareView(container, leftCard, rightCard) {
   const compared = compareRookies(leftCard, rightCard);
+  const deltaClass = compared.overallDelta == null
+    ? 'delta-chip-neutral'
+    : compared.overallDelta > 0
+      ? 'delta-chip-left'
+      : compared.overallDelta < 0
+        ? 'delta-chip-right'
+        : 'delta-chip-neutral';
+  const deltaPrefix = compared.overallDelta != null && compared.overallDelta > 0 ? '+' : '';
 
   container.innerHTML = `
     <section class="compare-layout">
@@ -353,7 +362,7 @@ export function renderRookieCompareView(container, leftCard, rightCard) {
           <strong>${esc(compared.verdict.headline)}</strong>
           <p class="meta">${esc(compared.verdict.detail)}</p>
         </div>
-        <div class="delta-chip">Grade Δ ${compared.overallDelta == null ? 'N/A' : esc(compared.overallDelta.toFixed(1))}</div>
+        <div class="delta-chip ${deltaClass}">Grade Δ ${compared.overallDelta == null ? 'N/A' : `${deltaPrefix}${esc(compared.overallDelta.toFixed(1))}`}</div>
       </div>
 
       <div class="compare-grid">

--- a/components/rookies/rookieCardStyles.css
+++ b/components/rookies/rookieCardStyles.css
@@ -695,6 +695,31 @@ body {
   padding: 12px;
 }
 .delta-chip { color: var(--text); font-weight: 700; border: 1px solid var(--border); border-radius: 999px; padding: 6px 10px; }
+.verdict-lean-left {
+  border-color: rgba(107, 159, 212, 0.45);
+  background: linear-gradient(90deg, rgba(59, 130, 246, 0.12), rgba(16, 12, 9, 0.95));
+}
+.verdict-lean-right {
+  border-color: rgba(232, 133, 61, 0.45);
+  background: linear-gradient(90deg, rgba(232, 133, 61, 0.14), rgba(16, 12, 9, 0.95));
+}
+.verdict-close {
+  border-color: rgba(255, 255, 255, 0.16);
+}
+.delta-chip-left {
+  color: #a8c9f2;
+  border-color: rgba(107, 159, 212, 0.5);
+  background: rgba(59, 130, 246, 0.14);
+}
+.delta-chip-right {
+  color: #f7bc90;
+  border-color: rgba(232, 133, 61, 0.55);
+  background: rgba(232, 133, 61, 0.14);
+}
+.delta-chip-neutral {
+  color: #d8cbbd;
+  border-color: rgba(255,255,255,0.24);
+}
 .compare-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px,1fr)); gap: 12px; }
 .compare-player { border: 1px solid var(--border); border-radius: 12px; padding: 12px; background: var(--panel); }
 .compare-name { margin: 6px 0; }
@@ -741,16 +766,16 @@ body {
   flex-direction: column;
   gap: 5px;
 }
-.compare-top-edge-left  { background: var(--accent-glow); border-color: var(--border-accent); }
-.compare-top-edge-right { background: var(--teal-glow); border-color: rgba(78,205,196,0.35); }
+.compare-top-edge-left  { background: rgba(59, 130, 246, 0.13); border-color: rgba(107, 159, 212, 0.45); }
+.compare-top-edge-right { background: rgba(232, 133, 61, 0.14); border-color: rgba(232, 133, 61, 0.45); }
 .compare-top-edge-label { font-size: 11px; color: var(--muted); text-transform: uppercase; letter-spacing: .07em; }
 .compare-top-edge-values { display: flex; align-items: baseline; gap: 6px; font-size: 15px; font-weight: 700; }
-.compare-top-edge-winner { color: var(--accent-soft); }
+.compare-top-edge-winner { color: var(--text); }
 .compare-top-edge-vs { font-size: 11px; color: var(--muted); font-weight: 400; }
 .compare-top-edge-other { color: var(--muted); font-weight: 400; font-size: 13px; }
 .compare-top-edge-badge { font-size: 10px; font-weight: 700; letter-spacing: .06em; color: var(--muted); text-transform: uppercase; }
-.compare-top-edge-left .compare-top-edge-badge  { color: var(--accent-soft); }
-.compare-top-edge-right .compare-top-edge-badge { color: var(--teal); }
+.compare-top-edge-left .compare-top-edge-badge  { color: #a8c9f2; }
+.compare-top-edge-right .compare-top-edge-badge { color: #f0ab74; }
 
 /* ── 3-column comparison table ────────────────────────────────────────────── */
 .compare-3col-table {

--- a/components/rookies/rookieCardStyles.css
+++ b/components/rookies/rookieCardStyles.css
@@ -675,6 +675,42 @@ body {
   gap: 10px;
   align-items: end;
 }
+.compare-page-hero {
+  margin-top: 12px;
+  margin-bottom: 12px;
+}
+.compare-selector-shell {
+  position: sticky;
+  top: 12px;
+  z-index: 4;
+  margin-top: 12px;
+}
+.compare-results-shell {
+  margin-top: 12px;
+}
+.compare-selector-redesign {
+  grid-template-columns: minmax(220px, 1fr) auto minmax(220px, 1fr);
+  align-items: center;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: rgba(16, 12, 9, 0.95);
+  padding: 10px;
+}
+.compare-control-panel {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 8px;
+}
+.compare-button-swap {
+  width: 44px;
+  height: 44px;
+  border-radius: 999px;
+  font-size: 18px;
+  line-height: 1;
+  font-weight: 700;
+  align-self: center;
+}
 .compare-button {
   height: 42px;
   border-radius: 10px;
@@ -897,6 +933,16 @@ body {
 
 /* ── Compare responsive ───────────────────────────────────────────────────── */
 @media (max-width: 600px) {
+  .compare-selector-shell {
+    position: static;
+  }
+  .compare-selector-redesign {
+    grid-template-columns: 1fr;
+  }
+  .compare-button-swap {
+    width: 100%;
+    border-radius: 10px;
+  }
   .compare-3col-name-row,
   .compare-3col-row { grid-template-columns: 1fr 120px 1fr; }
   .compare-radar-row { grid-template-columns: 1fr; }


### PR DESCRIPTION
### Motivation
- Bring the active compare UI in `components/rookies/*` closer to the prototype visual intent so the production compare surface matches the spec'd redesign.
- Fix inconsistent typography/hierarchy in 3-column comparison rows where center labels were rendered without the `.compare-3col-label` wrapper.
- Surface winner/neutral state more clearly by adding side-aware delta styling and aligning top-edge highlight card colors with left/right semantics.

### Description
- Wrap center labels in the 3-col comparison rows with a `compare-3col-label` span so score and evidence rows share consistent styling (`components/rookies/RookieCompareView.js`).
- Add `deltaClass` / `deltaPrefix` logic and apply it to the delta chip so the grade delta shows side-aware visual variants and a plus sign for positive deltas (`components/rookies/RookieCompareView.js`).
- Introduce CSS rules for verdict-strip states (`verdict-lean-left`, `verdict-lean-right`, `verdict-close`) and delta chip variants (`delta-chip-left`, `delta-chip-right`, `delta-chip-neutral`) and update top-edge card colors and badge tones for left/right semantics (`components/rookies/rookieCardStyles.css`).
- Small cosmetic adjustments to top-edge highlight card winner text color so it reads against the new card backgrounds (`components/rookies/rookieCardStyles.css`).

### Testing
- Ran the full test suite with `pytest -q` which passed: `210 passed in 0.76s`.
- Attempted to fetch the Anthropic design handoff with `curl -I -L 'https://api.anthropic.com/v1/design/h/gLhyNSBEgkRIVvuBm5XChQ?open_file=Compare+Redesign+v2.html'` from the environment and received `403 Forbidden`, so the external design file could not be retrieved here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea2b81ca0c83328f65392a153dbe99)