### PR TITLE
test: update runtime smoke routes to 2026 seed-pool slugs

### DIFF
--- a/tests/runtime-server.smoke.test.cjs
+++ b/tests/runtime-server.smoke.test.cjs
@@ -31,12 +31,12 @@ test('standalone runtime smoke routes', async (t) => {
   const htmlRoutes = [
     '/cards/rookies/index.html',
     '/cards/rookies/board/index.html',
-    '/cards/rookies/player.html?slug=wr-malik-ford',
-    '/cards/rookies/compare/index.html?left=wr-malik-ford&right=te-owen-hale',
+    '/cards/rookies/player.html?slug=wr-jordyn-tyson',
+    '/cards/rookies/compare/index.html?left=wr-jordyn-tyson&right=te-kenyon-sadiq',
     '/cards/rookies',
     '/cards/rookies/board',
-    '/cards/rookies/player?slug=wr-malik-ford',
-    '/cards/rookies/compare?left=wr-malik-ford&right=te-owen-hale',
+    '/cards/rookies/player?slug=wr-jordyn-tyson',
+    '/cards/rookies/compare?left=wr-jordyn-tyson&right=te-kenyon-sadiq',
   ];
 
   for (const route of htmlRoutes) {


### PR DESCRIPTION
### Motivation
- Replace stale placeholder slugs in the runtime smoke test so the test and docs use the current seed-pool entries `wr-jordyn-tyson` and `te-kenyon-sadiq`.

### Description
- Updated `tests/runtime-server.smoke.test.cjs` to use `wr-jordyn-tyson` for player routes and `wr-jordyn-tyson`/`te-kenyon-sadiq` for compare routes, with no changes to runtime logic or route handling.

### Testing
- Ran `npm run test:runtime-smoke` and the smoke test completed successfully (pass).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea944aeef48332841a9e8121a734be)