### PR TITLE
Add External Source Hygiene Policy and README guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ TIBER-Rookies is the **authoritative Rookie Alpha producer lab** and now also ha
 
 It is intentionally not a full draft room, not a live backend, and not a runtime dependency for TIBER-Fantasy.
 
+## External source hygiene
+
+TIBER-Rookies uses external analyst commentary only as qualitative context unless explicit written permission/licensing is documented. Do not scrape, copy, store, or model on third-party proprietary/paywalled analyst content.
+
+See [docs/legal/external-source-hygiene-policy.md](docs/legal/external-source-hygiene-policy.md) for full requirements.
+
 ## Draft-week readiness (March 27, 2026)
 
 This repository is **draft-week ready for promoted artifact handoff** when an operator can complete the documented 2026 rehearsal path:

--- a/docs/legal/external-source-hygiene-policy.md
+++ b/docs/legal/external-source-hygiene-policy.md
@@ -1,0 +1,71 @@
+# External Source Hygiene Policy
+
+## Purpose
+
+TIBER-Rookies may review external analyst work only as **qualitative research context** unless explicit written permission or licensing is in place. The project must not ingest, reproduce, or operationalize third-party proprietary analyst content as model data.
+
+## Default rule
+
+Unless licensing terms are documented, external analyst content is treated as reference-only context for human judgment.
+
+## Prohibited uses (without explicit written permission/licensing)
+
+The following are prohibited in this repository and its workflows:
+
+- Scraping third-party analyst websites or services.
+- Storing screenshots of third-party reports.
+- Copying or paraphrasing substantial proprietary scouting report text.
+- Committing paywalled text, tables, rankings, charts, or screenshots.
+- Using third-party analyst content as direct model input.
+- Creating source-specific model features derived from proprietary analysts or services.
+- Training or fine-tuning models on third-party paid/proprietary materials.
+
+## Allowed uses (with hygiene controls)
+
+The following are allowed when handled in a non-reproductive, high-level way:
+
+- Manual qualitative notes from public commentary.
+- High-level thematic tags (for example: `separation`, `YAC`, `return_value`, `injury_concern`).
+- Tracking source category metadata without reproducing protected expression.
+- Licensed-source integration only when permission terms are documented in-repo.
+
+## Safe JSON example (`external_research_signals`)
+
+Use source categories and non-verbatim qualitative flags. Do not store proprietary excerpts.
+
+```json
+{
+  "external_research_signals": [
+    {
+      "source_category": "public_commentary",
+      "theme_tags": ["separation", "YAC", "injury_concern"],
+      "qualitative_summary": "Public scouting discussion generally aligns with on-field separation and after-catch strengths, with some durability caution.",
+      "used_in_model_score": false,
+      "verbatim_stored": false,
+      "licensed": false,
+      "license_reference": null
+    }
+  ]
+}
+```
+
+If `licensed` is `true`, include a documented license/permission reference and scope before integration.
+
+## Public-writing guidance
+
+- **Okay:** “external public scouting sentiment supported the separation/YAC profile.”
+- **Avoid:** reproducing paid report language, screenshots, rankings, or detailed proprietary breakdowns.
+
+## Repo review checklist
+
+Before merging, verify all of the following:
+
+- No screenshots from paid sites.
+- No copied analyst report text.
+- No scraped data from third-party analyst services.
+- No third-party proprietary names embedded in model feature names.
+- No unexplained external ranking fields.
+
+## Legal note
+
+This policy is operational guidance and **not legal advice**. Any commercial or licensed external-source usage should be reviewed before launch.


### PR DESCRIPTION
### Motivation

- Protect the repository from accidental ingestion or reuse of third-party paid/proprietary analyst content by establishing a clear operational policy. 
- Ensure external analyst work is treated as qualitative context only unless explicit written permission or licensing is documented. 
- Prevent creation of reproducible proprietary artifacts (features, training data, screenshots, scraped content) that could expose the project to misuse.

### Description

- Add a new policy file at `docs/legal/external-source-hygiene-policy.md` that defines the default qualitative-only rule, explicit prohibitions, allowed practices with hygiene controls, a safe `external_research_signals` JSON example, public-writing guidance, a repo review checklist, and a legal disclaimer. 
- Update `README.md` with a short `External source hygiene` section that links to the new policy and summarizes the core guardrail. 
- Make clear prohibitions covering scraping, screenshots of paid reports, copying/paraphrasing proprietary scouting text, committing paywalled content, using third-party content as model input or features, and training/fine-tuning on paid/proprietary material. 
- No model logic changes, no data changes, and no third-party/proprietary content were added to the repo.

### Testing

- Ran `git diff --check` and it reported no issues. 
- Verified the README insertion and new policy file contents using file-inspection commands (`nl -ba README.md | sed -n '1,40p'` and `nl -ba docs/legal/external-source-hygiene-policy.md | sed -n '1,220p'`). 
- Confirmed repository status with `git status --short` showing the new file and README modification were staged/committed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaf004b11c8332804b0eaf07452b87)