### PR TITLE
Add source freshness sidecar, staleness checks, and 2025 pick validation to NFL outcomes lane

### DIFF
--- a/docs/nfl-fantasy-outcome-calibration.md
+++ b/docs/nfl-fantasy-outcome-calibration.md
@@ -22,6 +22,8 @@ No proprietary analyst rankings, projections, screenshots, or scraped paid conte
 - Cohort summaries:
   - `exports/promoted/nfl-fantasy-outcomes/context_flag_outcome_summary_v1.json`
   - `exports/promoted/nfl-fantasy-outcomes/context_flag_outcome_summary_v1.csv`
+- Source freshness sidecar:
+  - `exports/promoted/nfl-fantasy-outcomes/source_metadata_v1.json`
 
 ## PPR formula
 
@@ -55,6 +57,31 @@ The cohort summary script separates:
 
 It reports both in `incomplete_notes`, along with small-sample warnings.
 
+## Source freshness checks
+
+The build script now reports source freshness diagnostics every run:
+- `player_stats` row count
+- `draft_picks` row count
+- `latest_stats_season` (max season present in player stats rows)
+- `latest_draft_year` (max season/draft year present in draft rows)
+- detected source mode (`seasonal_source` or `weekly_aggregated`)
+
+You can optionally set an expected season floor:
+
+```bash
+python scripts/build_nfl_fantasy_outcomes.py --refresh --expected-latest-season 2025
+```
+
+If source rows lag that expectation, the script prints a loud warning.
+
+To fail fast before writing promoted outputs when stale:
+
+```bash
+python scripts/build_nfl_fantasy_outcomes.py --refresh --expected-latest-season 2025 --fail-on-stale-source
+```
+
+The sidecar metadata file includes staleness fields (`expected_latest_season`, `is_stale_relative_to_expected`) so downstream summarization can log current coverage context. Cohort interpretations are only as current as `latest_stats_season`.
+
 ## Why separate from Rookie Alpha
 
 This lane is descriptive/historical calibration and **does not alter**:
@@ -77,6 +104,23 @@ From repo root:
 python scripts/build_nfl_fantasy_outcomes.py --refresh
 python scripts/summarize_context_flag_outcomes.py
 ```
+
+Optional cohort-inclusion validation for known 2025 top-10 skill picks:
+
+```bash
+python scripts/summarize_context_flag_outcomes.py --validate-known-2025-skill-picks
+```
+
+Current expected validation set:
+- Travis Hunter (WR, 2025, pick 2)
+- Tetairoa McMillan (WR, 2025, pick 8)
+- Colston Loveland (TE, 2025, pick 10)
+
+If expected players are missing, the summarizer prints warnings with likely reasons:
+- missing 2025 draft data
+- missing 2025 player stats
+- position mismatch
+- ID join mismatch
 
 If network access is unavailable, pre-populate caches at:
 - `data/external/nflverse/player_stats.csv`

--- a/scripts/build_nfl_fantasy_outcomes.py
+++ b/scripts/build_nfl_fantasy_outcomes.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import argparse
 import csv
+from datetime import datetime, timezone
 import gzip
 import io
 import json
@@ -21,6 +22,7 @@ from typing import Any
 OUTPUT_DIR = Path("exports/promoted/nfl-fantasy-outcomes")
 OUTPUT_JSON = OUTPUT_DIR / "player_year_ppr_outcomes_v1.json"
 OUTPUT_CSV = OUTPUT_DIR / "player_year_ppr_outcomes_v1.csv"
+OUTPUT_SOURCE_METADATA = OUTPUT_DIR / "source_metadata_v1.json"
 
 CACHE_DIR = Path("data/external/nflverse")
 STATS_CACHE = CACHE_DIR / "player_stats.csv"
@@ -138,6 +140,43 @@ def detect_source_mode(stats_rows: list[dict[str, str]]) -> str:
     if WEEKLY_MODE_COLUMNS.intersection(sample_columns):
         return "weekly_aggregated"
     return "seasonal_source"
+
+
+def latest_stats_season(stats_rows: list[dict[str, str]]) -> int:
+    return max((to_int(row.get("season"), 0) for row in stats_rows), default=0)
+
+
+def latest_draft_year(draft_rows: list[dict[str, str]]) -> int:
+    return max((to_int(row.get("season") or row.get("draft_year"), 0) for row in draft_rows), default=0)
+
+
+def is_stale_source(latest_season: int, expected_latest_season: int | None) -> bool:
+    if expected_latest_season is None:
+        return False
+    return latest_season < expected_latest_season
+
+
+def build_source_metadata(
+    stats_rows: list[dict[str, str]],
+    draft_rows: list[dict[str, str]],
+    source_mode: str,
+    expected_latest_season: int | None,
+    source_notes: str,
+) -> dict[str, Any]:
+    latest_season = latest_stats_season(stats_rows)
+    latest_draft = latest_draft_year(draft_rows)
+    stale = is_stale_source(latest_season, expected_latest_season)
+    return {
+        "generated_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "player_stats_row_count": len(stats_rows),
+        "draft_picks_row_count": len(draft_rows),
+        "latest_stats_season": latest_season,
+        "latest_draft_year": latest_draft,
+        "source_mode": source_mode,
+        "expected_latest_season": expected_latest_season,
+        "is_stale_relative_to_expected": stale,
+        "source_notes": source_notes,
+    }
 
 
 def build_draft_index(draft_rows: list[dict[str, str]]) -> dict[str, dict[str, Any]]:
@@ -291,6 +330,18 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--draft-cache", type=Path, default=DRAFT_CACHE)
     parser.add_argument("--output-json", type=Path, default=OUTPUT_JSON)
     parser.add_argument("--output-csv", type=Path, default=OUTPUT_CSV)
+    parser.add_argument("--output-source-metadata", type=Path, default=OUTPUT_SOURCE_METADATA)
+    parser.add_argument(
+        "--expected-latest-season",
+        type=int,
+        default=None,
+        help="Expected latest season in player_stats. Warn/fail if source lags this season.",
+    )
+    parser.add_argument(
+        "--fail-on-stale-source",
+        action="store_true",
+        help="Exit nonzero if --expected-latest-season is set and source latest season is stale.",
+    )
     return parser.parse_args()
 
 
@@ -301,15 +352,46 @@ def main() -> None:
     draft_rows, draft_mode = load_source_rows(NFLVERSE_DRAFT_PICKS_URL, args.draft_cache, refresh=args.refresh)
 
     notes = f"player_stats={stats_mode}:{args.stats_cache}; draft_picks={draft_mode}:{args.draft_cache}"
+    source_mode = detect_source_mode(stats_rows)
+    source_metadata = build_source_metadata(
+        stats_rows=stats_rows,
+        draft_rows=draft_rows,
+        source_mode=source_mode,
+        expected_latest_season=args.expected_latest_season,
+        source_notes=notes,
+    )
+
+    print("Source freshness diagnostics:")
+    print(f"  player_stats rows loaded: {source_metadata['player_stats_row_count']}")
+    print(f"  draft_picks rows loaded:  {source_metadata['draft_picks_row_count']}")
+    print(f"  latest_stats_season:      {source_metadata['latest_stats_season']}")
+    print(f"  latest_draft_year:        {source_metadata['latest_draft_year']}")
+    print(f"  source mode detected:     {source_metadata['source_mode']}")
+
+    if source_metadata["is_stale_relative_to_expected"]:
+        print(
+            "!!! SOURCE STALENESS WARNING: "
+            f"expected_latest_season={args.expected_latest_season}, "
+            f"but latest_stats_season={source_metadata['latest_stats_season']}"
+        )
+        if args.fail_on_stale_source:
+            raise SystemExit(
+                "Failing due to stale source: "
+                f"expected_latest_season={args.expected_latest_season}, "
+                f"latest_stats_season={source_metadata['latest_stats_season']}"
+            )
+
     rows = build_player_outcome_rows(stats_rows, draft_rows, source_notes=notes)
 
     args.output_json.parent.mkdir(parents=True, exist_ok=True)
     args.output_json.write_text(json.dumps(rows, indent=2) + "\n", encoding="utf-8")
     write_csv(args.output_csv, rows, FIELDNAMES)
+    args.output_source_metadata.write_text(json.dumps(source_metadata, indent=2) + "\n", encoding="utf-8")
 
     print(f"Built {len(rows)} rows")
     print(f"JSON -> {args.output_json}")
     print(f"CSV  -> {args.output_csv}")
+    print(f"Metadata -> {args.output_source_metadata}")
 
 
 if __name__ == "__main__":

--- a/scripts/summarize_context_flag_outcomes.py
+++ b/scripts/summarize_context_flag_outcomes.py
@@ -160,7 +160,35 @@ def extract_cache_paths_from_source_notes(source_notes: str) -> tuple[Path | Non
 
 
 def normalize_name(value: str) -> str:
-    return " ".join((value or "").strip().lower().split())
+    normalized = (value or "").strip().lower().replace(".", " ")
+    return " ".join(normalized.split())
+
+
+def name_tokens(value: str) -> tuple[str, str] | None:
+    normalized = normalize_name(value)
+    if not normalized:
+        return None
+    parts = normalized.split()
+    if len(parts) < 2:
+        return None
+    first = parts[0]
+    last = parts[-1]
+    return first, last
+
+
+def name_matches_expected(candidate_name: str, expected_name: str) -> bool:
+    candidate = name_tokens(candidate_name)
+    expected = name_tokens(expected_name)
+    if not candidate or not expected:
+        return normalize_name(candidate_name) == normalize_name(expected_name)
+
+    candidate_first, candidate_last = candidate
+    expected_first, expected_last = expected
+    if candidate_last != expected_last:
+        return False
+    if candidate_first == expected_first:
+        return True
+    return candidate_first[:1] == expected_first[:1]
 
 
 def detect_missing_player_reason(
@@ -171,7 +199,7 @@ def detect_missing_player_reason(
     latest_stats_season: int,
     latest_draft_year: int,
 ) -> str:
-    expected_name = normalize_name(expected["player_name"])
+    expected_name = expected["player_name"]
     expected_draft_year = expected["draft_year"]
     expected_pick = expected["overall_pick"]
     expected_position = expected["position"]
@@ -182,17 +210,17 @@ def detect_missing_player_reason(
         return "missing 2025 player stats"
 
     draft_name_rows = [
-        row for row in draft_source_rows if normalize_name(row.get("player_name", "")) == expected_name
+        row for row in draft_source_rows if name_matches_expected(row.get("player_name", ""), expected_name)
     ]
     stats_name_rows = [
         row
         for row in stats_source_rows
-        if normalize_name(row.get("player_name", "")) == expected_name and to_int(row.get("season")) == expected_draft_year
+        if name_matches_expected(row.get("player_name", ""), expected_name) and to_int(row.get("season")) == expected_draft_year
     ]
     outcome_name_rows = [
         row
         for row in outcome_rows
-        if normalize_name(row.get("player_name", "")) == expected_name and row["draft_year"] == expected_draft_year
+        if name_matches_expected(row.get("player_name", ""), expected_name) and row["draft_year"] == expected_draft_year
     ]
 
     if not draft_name_rows:
@@ -231,7 +259,7 @@ def validate_known_2025_skill_picks(
         matching_rows = [
             row
             for row in normalized_rows
-            if normalize_name(row["player_name"]) == normalize_name(expected["player_name"])
+            if name_matches_expected(row["player_name"], expected["player_name"])
             and row["draft_year"] == expected["draft_year"]
             and row["overall_pick"] == expected["overall_pick"]
             and row["position"] == expected["position"]

--- a/scripts/summarize_context_flag_outcomes.py
+++ b/scripts/summarize_context_flag_outcomes.py
@@ -7,6 +7,7 @@ import argparse
 import csv
 import json
 import statistics
+import re
 from pathlib import Path
 from typing import Any
 
@@ -14,6 +15,12 @@ INPUT_JSON = Path("exports/promoted/nfl-fantasy-outcomes/player_year_ppr_outcome
 OUTPUT_DIR = Path("exports/promoted/nfl-fantasy-outcomes")
 OUTPUT_JSON = OUTPUT_DIR / "context_flag_outcome_summary_v1.json"
 OUTPUT_CSV = OUTPUT_DIR / "context_flag_outcome_summary_v1.csv"
+SOURCE_METADATA_JSON = OUTPUT_DIR / "source_metadata_v1.json"
+EXPECTED_2025_SKILL_PICKS = [
+    {"player_name": "Travis Hunter", "position": "WR", "draft_year": 2025, "overall_pick": 2},
+    {"player_name": "Tetairoa McMillan", "position": "WR", "draft_year": 2025, "overall_pick": 8},
+    {"player_name": "Colston Loveland", "position": "TE", "draft_year": 2025, "overall_pick": 10},
+]
 
 COHORTS = {
     "wr_top10_since_2022": {"position": "WR", "since": 2022, "max_pick": 10},
@@ -139,17 +146,133 @@ def write_csv(path: Path, rows: list[dict[str, Any]]) -> None:
         writer.writerows(rows)
 
 
+def read_csv_rows(path: Path) -> list[dict[str, str]]:
+    with path.open(encoding="utf-8") as f:
+        return list(csv.DictReader(f))
+
+
+def extract_cache_paths_from_source_notes(source_notes: str) -> tuple[Path | None, Path | None]:
+    stats_match = re.search(r"player_stats=[^:]+:([^;]+)", source_notes)
+    draft_match = re.search(r"draft_picks=[^:]+:([^;]+)", source_notes)
+    stats_path = Path(stats_match.group(1)) if stats_match else None
+    draft_path = Path(draft_match.group(1)) if draft_match else None
+    return stats_path, draft_path
+
+
+def normalize_name(value: str) -> str:
+    return " ".join((value or "").strip().lower().split())
+
+
+def detect_missing_player_reason(
+    expected: dict[str, Any],
+    outcome_rows: list[dict[str, Any]],
+    draft_source_rows: list[dict[str, str]],
+    stats_source_rows: list[dict[str, str]],
+    latest_stats_season: int,
+    latest_draft_year: int,
+) -> str:
+    expected_name = normalize_name(expected["player_name"])
+    expected_draft_year = expected["draft_year"]
+    expected_pick = expected["overall_pick"]
+    expected_position = expected["position"]
+
+    if latest_draft_year and latest_draft_year < expected_draft_year:
+        return "missing 2025 draft data"
+    if latest_stats_season and latest_stats_season < expected_draft_year:
+        return "missing 2025 player stats"
+
+    draft_name_rows = [
+        row for row in draft_source_rows if normalize_name(row.get("player_name", "")) == expected_name
+    ]
+    stats_name_rows = [
+        row
+        for row in stats_source_rows
+        if normalize_name(row.get("player_name", "")) == expected_name and to_int(row.get("season")) == expected_draft_year
+    ]
+    outcome_name_rows = [
+        row
+        for row in outcome_rows
+        if normalize_name(row.get("player_name", "")) == expected_name and row["draft_year"] == expected_draft_year
+    ]
+
+    if not draft_name_rows:
+        return "missing 2025 draft data"
+    if not stats_name_rows:
+        return "missing 2025 player stats"
+    if not outcome_name_rows:
+        return "ID join mismatch"
+
+    for row in outcome_name_rows:
+        if row["position"] != expected_position:
+            return "position mismatch"
+        if row["overall_pick"] != expected_pick:
+            return "ID join mismatch"
+    return "position mismatch"
+
+
+def validate_known_2025_skill_picks(
+    normalized_rows: list[dict[str, Any]],
+    source_metadata: dict[str, Any] | None,
+) -> list[str]:
+    latest_stats_season = to_int((source_metadata or {}).get("latest_stats_season"))
+    latest_draft_year = to_int((source_metadata or {}).get("latest_draft_year"))
+    draft_source_rows: list[dict[str, str]] = []
+    stats_source_rows: list[dict[str, str]] = []
+
+    if source_metadata and source_metadata.get("source_notes"):
+        stats_path, draft_path = extract_cache_paths_from_source_notes(source_metadata["source_notes"])
+        if stats_path and stats_path.exists():
+            stats_source_rows = read_csv_rows(stats_path)
+        if draft_path and draft_path.exists():
+            draft_source_rows = read_csv_rows(draft_path)
+
+    warnings: list[str] = []
+    for expected in EXPECTED_2025_SKILL_PICKS:
+        matching_rows = [
+            row
+            for row in normalized_rows
+            if normalize_name(row["player_name"]) == normalize_name(expected["player_name"])
+            and row["draft_year"] == expected["draft_year"]
+            and row["overall_pick"] == expected["overall_pick"]
+            and row["position"] == expected["position"]
+        ]
+        if matching_rows:
+            continue
+
+        reason = detect_missing_player_reason(
+            expected=expected,
+            outcome_rows=normalized_rows,
+            draft_source_rows=draft_source_rows,
+            stats_source_rows=stats_source_rows,
+            latest_stats_season=latest_stats_season,
+            latest_draft_year=latest_draft_year,
+        )
+        warnings.append(
+            f"{expected['player_name']} ({expected['position']}, pick {expected['overall_pick']}): {reason}"
+        )
+    return warnings
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Summarize context-flag fantasy outcome cohorts")
     parser.add_argument("--input", type=Path, default=INPUT_JSON)
     parser.add_argument("--output-json", type=Path, default=OUTPUT_JSON)
     parser.add_argument("--output-csv", type=Path, default=OUTPUT_CSV)
+    parser.add_argument("--source-metadata", type=Path, default=SOURCE_METADATA_JSON)
+    parser.add_argument(
+        "--validate-known-2025-skill-picks",
+        action="store_true",
+        help="Validate expected 2025 top-10 skill picks are represented in cohort-ready outcomes.",
+    )
     return parser.parse_args()
 
 
 def main() -> None:
     args = parse_args()
     rows = json.loads(args.input.read_text(encoding="utf-8"))
+    source_metadata: dict[str, Any] | None = None
+    if args.source_metadata.exists():
+        source_metadata = json.loads(args.source_metadata.read_text(encoding="utf-8"))
 
     normalized_rows = []
     for row in rows:
@@ -167,6 +290,9 @@ def main() -> None:
         )
 
     latest_nfl_season = max((r["nfl_season"] for r in normalized_rows), default=0)
+    metadata_latest_stats_season = to_int((source_metadata or {}).get("latest_stats_season"))
+    if metadata_latest_stats_season > 0:
+        latest_nfl_season = max(latest_nfl_season, metadata_latest_stats_season)
     summaries: list[dict[str, Any]] = []
 
     for cohort_name, rule in COHORTS.items():
@@ -207,6 +333,25 @@ def main() -> None:
     write_csv(args.output_csv, summaries)
 
     print(f"Built {len(summaries)} cohort summaries")
+    if source_metadata:
+        print(
+            "Source metadata: "
+            f"latest_stats_season={source_metadata.get('latest_stats_season')}, "
+            f"latest_draft_year={source_metadata.get('latest_draft_year')}, "
+            f"is_stale_relative_to_expected={source_metadata.get('is_stale_relative_to_expected')}, "
+            f"expected_latest_season={source_metadata.get('expected_latest_season')}"
+        )
+    else:
+        print("Source metadata: unavailable (sidecar file not found)")
+    print(f"Season coverage baseline: latest_nfl_season={latest_nfl_season}")
+    if args.validate_known_2025_skill_picks:
+        missing_players = validate_known_2025_skill_picks(normalized_rows, source_metadata)
+        if missing_players:
+            print("!!! VALIDATION WARNING: missing expected 2025 skill picks:")
+            for item in missing_players:
+                print(f"  - {item}")
+        else:
+            print("Known 2025 skill-pick validation: all expected players found.")
     print(f"JSON -> {args.output_json}")
     print(f"CSV  -> {args.output_csv}")
 

--- a/tests/test_build_nfl_fantasy_outcomes.py
+++ b/tests/test_build_nfl_fantasy_outcomes.py
@@ -6,8 +6,12 @@ import unittest
 
 from scripts.build_nfl_fantasy_outcomes import (
     build_player_outcome_rows,
+    build_source_metadata,
     career_year_for_season,
     compute_ppr,
+    is_stale_source,
+    latest_draft_year,
+    latest_stats_season,
 )
 
 
@@ -109,6 +113,34 @@ class BuilderJoinTests(unittest.TestCase):
         self.assertEqual(rows[0]["ppr_points"], 27.0)
         self.assertEqual(rows[0]["ppr_per_game"], 13.5)
         self.assertIn("source_mode=weekly_aggregated", rows[0]["source_notes"])
+
+
+class SourceFreshnessTests(unittest.TestCase):
+    def test_latest_season_detectors(self) -> None:
+        stats_rows = [{"season": "2023"}, {"season": "2025"}, {"season": "2024"}]
+        draft_rows = [{"season": "2022"}, {"draft_year": "2024"}, {"season": "2023"}]
+        self.assertEqual(latest_stats_season(stats_rows), 2025)
+        self.assertEqual(latest_draft_year(draft_rows), 2024)
+
+    def test_staleness_check(self) -> None:
+        self.assertFalse(is_stale_source(2025, None))
+        self.assertFalse(is_stale_source(2025, 2025))
+        self.assertTrue(is_stale_source(2024, 2025))
+
+    def test_source_metadata_marks_stale(self) -> None:
+        metadata = build_source_metadata(
+            stats_rows=[{"season": "2024"}],
+            draft_rows=[{"season": "2023"}],
+            source_mode="seasonal_source",
+            expected_latest_season=2025,
+            source_notes="fixture",
+        )
+        self.assertEqual(metadata["player_stats_row_count"], 1)
+        self.assertEqual(metadata["draft_picks_row_count"], 1)
+        self.assertEqual(metadata["latest_stats_season"], 2024)
+        self.assertEqual(metadata["latest_draft_year"], 2023)
+        self.assertEqual(metadata["source_mode"], "seasonal_source")
+        self.assertTrue(metadata["is_stale_relative_to_expected"])
 
 
 if __name__ == "__main__":

--- a/tests/test_summarize_context_flag_outcomes.py
+++ b/tests/test_summarize_context_flag_outcomes.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from scripts.summarize_context_flag_outcomes import (
     detect_missing_player_reason,
     extract_cache_paths_from_source_notes,
+    name_matches_expected,
     validate_known_2025_skill_picks,
 )
 
@@ -22,11 +23,29 @@ class SourceNoteParsingTests(unittest.TestCase):
 
 
 class KnownPickValidationTests(unittest.TestCase):
+    def test_name_matching_supports_abbreviated_forms(self) -> None:
+        self.assertTrue(name_matches_expected("T.Hunter", "Travis Hunter"))
+        self.assertTrue(name_matches_expected("T Hunter", "Travis Hunter"))
+        self.assertTrue(name_matches_expected("Tetairoa McMillan", "T.McMillan"))
+        self.assertFalse(name_matches_expected("T.Burden", "Travis Hunter"))
+
     def test_validation_succeeds_when_expected_players_exist(self) -> None:
         rows = [
             {"player_name": "Travis Hunter", "position": "WR", "draft_year": 2025, "overall_pick": 2},
             {"player_name": "Tetairoa McMillan", "position": "WR", "draft_year": 2025, "overall_pick": 8},
             {"player_name": "Colston Loveland", "position": "TE", "draft_year": 2025, "overall_pick": 10},
+        ]
+        warnings = validate_known_2025_skill_picks(
+            normalized_rows=rows,
+            source_metadata={"latest_stats_season": 2025, "latest_draft_year": 2025},
+        )
+        self.assertEqual(warnings, [])
+
+    def test_validation_accepts_abbreviated_player_names(self) -> None:
+        rows = [
+            {"player_name": "T.Hunter", "position": "WR", "draft_year": 2025, "overall_pick": 2},
+            {"player_name": "T McMillan", "position": "WR", "draft_year": 2025, "overall_pick": 8},
+            {"player_name": "C.Loveland", "position": "TE", "draft_year": 2025, "overall_pick": 10},
         ]
         warnings = validate_known_2025_skill_picks(
             normalized_rows=rows,

--- a/tests/test_summarize_context_flag_outcomes.py
+++ b/tests/test_summarize_context_flag_outcomes.py
@@ -1,0 +1,81 @@
+"""Tests for context flag outcome summarizer validations."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.summarize_context_flag_outcomes import (
+    detect_missing_player_reason,
+    extract_cache_paths_from_source_notes,
+    validate_known_2025_skill_picks,
+)
+
+
+class SourceNoteParsingTests(unittest.TestCase):
+    def test_extract_cache_paths(self) -> None:
+        notes = "player_stats=cache:data/external/nflverse/player_stats.csv; draft_picks=download:data/external/nflverse/draft_picks.csv"
+        stats_path, draft_path = extract_cache_paths_from_source_notes(notes)
+        self.assertEqual(stats_path, Path("data/external/nflverse/player_stats.csv"))
+        self.assertEqual(draft_path, Path("data/external/nflverse/draft_picks.csv"))
+
+
+class KnownPickValidationTests(unittest.TestCase):
+    def test_validation_succeeds_when_expected_players_exist(self) -> None:
+        rows = [
+            {"player_name": "Travis Hunter", "position": "WR", "draft_year": 2025, "overall_pick": 2},
+            {"player_name": "Tetairoa McMillan", "position": "WR", "draft_year": 2025, "overall_pick": 8},
+            {"player_name": "Colston Loveland", "position": "TE", "draft_year": 2025, "overall_pick": 10},
+        ]
+        warnings = validate_known_2025_skill_picks(
+            normalized_rows=rows,
+            source_metadata={"latest_stats_season": 2025, "latest_draft_year": 2025},
+        )
+        self.assertEqual(warnings, [])
+
+    def test_reason_prefers_missing_draft_data_signal(self) -> None:
+        reason = detect_missing_player_reason(
+            expected={"player_name": "Travis Hunter", "position": "WR", "draft_year": 2025, "overall_pick": 2},
+            outcome_rows=[],
+            draft_source_rows=[],
+            stats_source_rows=[],
+            latest_stats_season=2024,
+            latest_draft_year=2024,
+        )
+        self.assertEqual(reason, "missing 2025 draft data")
+
+    def test_reason_detects_id_join_mismatch(self) -> None:
+        reason = detect_missing_player_reason(
+            expected={"player_name": "Travis Hunter", "position": "WR", "draft_year": 2025, "overall_pick": 2},
+            outcome_rows=[],
+            draft_source_rows=[{"player_name": "Travis Hunter", "season": "2025", "position": "WR"}],
+            stats_source_rows=[{"player_name": "Travis Hunter", "season": "2025", "position": "WR"}],
+            latest_stats_season=2025,
+            latest_draft_year=2025,
+        )
+        self.assertEqual(reason, "ID join mismatch")
+
+    def test_validation_uses_source_note_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            stats_path = Path(tmpdir) / "stats.csv"
+            draft_path = Path(tmpdir) / "draft.csv"
+            stats_path.write_text(
+                "player_name,season,position\nTravis Hunter,2025,WR\nTetairoa McMillan,2025,WR\n",
+                encoding="utf-8",
+            )
+            draft_path.write_text(
+                "player_name,season,position,pick\nTravis Hunter,2025,WR,2\nTetairoa McMillan,2025,WR,8\n",
+                encoding="utf-8",
+            )
+            metadata = {
+                "latest_stats_season": 2025,
+                "latest_draft_year": 2025,
+                "source_notes": f"player_stats=cache:{stats_path}; draft_picks=cache:{draft_path}",
+            }
+            warnings = validate_known_2025_skill_picks(normalized_rows=[], source_metadata=metadata)
+            self.assertTrue(any("Colston Loveland" in warning for warning in warnings))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation

- Provide deterministic source-freshness diagnostics and a machine-readable sidecar to record row counts, latest seasons, and detected source mode so cohort summaries can be interpreted with coverage context. 
- Allow pipelines to warn or fail early when input source snapshots lag an expected season and add a light validation to detect missing known 2025 top-10 skill picks. 

### Description

- Added source metadata generation and CLI options in `scripts/build_nfl_fantasy_outcomes.py` including `--expected-latest-season`, `--fail-on-stale-source`, and output sidecar `exports/promoted/nfl-fantasy-outcomes/source_metadata_v1.json`, plus functions `latest_stats_season`, `latest_draft_year`, `is_stale_source`, and `build_source_metadata`. 
- Emitted human-readable diagnostics and optional fast-fail on stale source when `--fail-on-stale-source` is used. 
- Extended `scripts/summarize_context_flag_outcomes.py` to read the sidecar, adjust season coverage baseline, and add optional `--validate-known-2025-skill-picks` validation with helpers `extract_cache_paths_from_source_notes`, `detect_missing_player_reason`, `normalize_name`, and `validate_known_2025_skill_picks` to surface likely reasons when expected 2025 picks are missing. 
- Updated documentation `docs/nfl-fantasy-outcome-calibration.md` to describe the sidecar, freshness checks, example CLI usage, and the validation set, and updated field lists and runbook. 

### Testing

- Ran unit tests in `tests/test_build_nfl_fantasy_outcomes.py` which were updated to exercise `latest_stats_season`, `latest_draft_year`, `is_stale_source`, and `build_source_metadata`, and all assertions passed. 
- Added and ran `tests/test_summarize_context_flag_outcomes.py` covering source-note parsing, missing-player reason detection, and validation flow, and all assertions passed. 
- No integration/network tests were run; the changes were exercised via the new unit tests that simulate source rows and temporary files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebdc29880083328c7586d3d90e4bac)