### PR TITLE
Fix multiseason stats_player fallback control flow

### DIFF
--- a/scripts/build_nfl_fantasy_outcomes.py
+++ b/scripts/build_nfl_fantasy_outcomes.py
@@ -417,9 +417,17 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def main() -> None:
-    args = parse_args()
-
+def resolve_stats_rows(args: argparse.Namespace) -> tuple[
+    list[dict[str, str]],
+    str,
+    str | None,
+    list[str] | None,
+    list[int] | None,
+    list[int] | None,
+    list[Path],
+    str,
+    str,
+]:
     resolved_stats_url = args.stats_source_url
     resolved_stats_urls: list[str] | None = None
     stats_seasons_loaded: list[int] | None = None
@@ -427,6 +435,10 @@ def main() -> None:
     seasonal_cache_paths: list[Path] = []
     stats_resolution_note = "manual_stats_source_url"
     resolved_stats_source = args.stats_source
+    stats_mode = "cache_or_download"
+    stats_rows: list[dict[str, str]] = []
+    stats_rows_loaded_from_multiseason = False
+
     if not resolved_stats_url and args.stats_source == "stats_player":
         try:
             asset_names = fetch_release_asset_names(NFLVERSE_STATS_PLAYER_RELEASE_API)
@@ -462,30 +474,42 @@ def main() -> None:
                     asset_url = f"{NFLVERSE_STATS_PLAYER_BASE_URL}{asset_name}"
                     cache_path = CACHE_DIR / f"stats_player_reg_{season}.csv"
                     rows, _ = load_source_rows(asset_url, cache_path, refresh=args.refresh)
-                    stats_rows.extend(rows)
-                    resolved_stats_urls.append(asset_url)
-                    seasonal_cache_paths.append(cache_path)
-                    stats_seasons_loaded.append(season)
+                    if rows:
+                        stats_rows.extend(rows)
+                        resolved_stats_urls.append(asset_url)
+                        seasonal_cache_paths.append(cache_path)
+                        stats_seasons_loaded.append(season)
                 stats_mode = "download" if args.refresh else "cache_or_download"
-                stats_resolution_note = (
-                    f"stats_player_seasonal_assets_loaded={len(stats_seasons_loaded)};"
-                    f" requested_range={season_start}-{season_end}; latest_discovered={latest_discovered}"
-                )
-    if not resolved_stats_url and resolved_stats_source == "legacy_player_stats":
-        resolved_stats_url = NFLVERSE_LEGACY_PLAYER_STATS_URL
-        stats_resolution_note = "legacy_player_stats_default_url"
-    if not resolved_stats_url and resolved_stats_source == "stats_player":
-        if args.stats_source == "legacy_player_stats":
+                if stats_rows:
+                    stats_rows_loaded_from_multiseason = True
+                    resolved_stats_source = "stats_player"
+                    stats_resolution_note = (
+                        f"stats_player_seasonal_assets_loaded={len(stats_seasons_loaded)};"
+                        f" requested_range={season_start}-{season_end}; latest_discovered={latest_discovered}"
+                    )
+                else:
+                    stats_resolution_note = (
+                        f"stats_player_seasonal_assets_loaded=0;requested_range={season_start}-{season_end};"
+                        f" latest_discovered={latest_discovered};fallback=legacy_player_stats"
+                    )
+                    if not args.stats_source_url:
+                        resolved_stats_source = "legacy_player_stats"
+                        resolved_stats_url = NFLVERSE_LEGACY_PLAYER_STATS_URL
+
+    if not stats_rows_loaded_from_multiseason:
+        if not resolved_stats_url and resolved_stats_source == "legacy_player_stats":
             resolved_stats_url = NFLVERSE_LEGACY_PLAYER_STATS_URL
             stats_resolution_note = "legacy_player_stats_default_url"
-        else:
-            resolved_stats_url = NFLVERSE_LEGACY_PLAYER_STATS_URL
-            resolved_stats_source = "legacy_player_stats"
-            stats_resolution_note = "stats_player_unresolved; fallback=legacy_player_stats"
+        if not resolved_stats_url and resolved_stats_source == "stats_player":
+            if args.stats_source == "legacy_player_stats":
+                resolved_stats_url = NFLVERSE_LEGACY_PLAYER_STATS_URL
+                stats_resolution_note = "legacy_player_stats_default_url"
+            else:
+                resolved_stats_url = NFLVERSE_LEGACY_PLAYER_STATS_URL
+                resolved_stats_source = "legacy_player_stats"
+                stats_resolution_note = "stats_player_unresolved; fallback=legacy_player_stats"
 
-    stats_cache = args.stats_cache or (STATS_PLAYER_CACHE if resolved_stats_source == "stats_player" else LEGACY_STATS_CACHE)
-
-    if resolved_stats_source != "stats_player" or resolved_stats_url is not None and resolved_stats_urls is None:
+        stats_cache = args.stats_cache or (STATS_PLAYER_CACHE if resolved_stats_source == "stats_player" else LEGACY_STATS_CACHE)
         try:
             stats_rows, stats_mode = load_source_rows(resolved_stats_url, stats_cache, refresh=args.refresh)
         except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError) as exc:
@@ -499,12 +523,42 @@ def main() -> None:
             else:
                 raise
 
+    return (
+        stats_rows,
+        stats_mode,
+        resolved_stats_source,
+        resolved_stats_url,
+        resolved_stats_urls,
+        stats_seasons_loaded,
+        missing_stats_seasons,
+        seasonal_cache_paths,
+        stats_resolution_note,
+    )
+
+
+def main() -> None:
+    args = parse_args()
+    (
+        stats_rows,
+        stats_mode,
+        resolved_stats_source,
+        resolved_stats_url,
+        resolved_stats_urls,
+        stats_seasons_loaded,
+        missing_stats_seasons,
+        seasonal_cache_paths,
+        stats_resolution_note,
+    ) = resolve_stats_rows(args)
+
     draft_rows, draft_mode = load_source_rows(NFLVERSE_DRAFT_PICKS_URL, args.draft_cache, refresh=args.refresh)
 
+    resolved_stats_cache = args.stats_cache or (
+        STATS_PLAYER_CACHE if resolved_stats_source == "stats_player" else LEGACY_STATS_CACHE
+    )
     player_stats_source_note = (
         ",".join(str(path) for path in seasonal_cache_paths)
         if seasonal_cache_paths
-        else str(stats_cache)
+        else str(resolved_stats_cache)
     )
     notes = f"stats_source={resolved_stats_source}; stats_resolution={stats_resolution_note}; player_stats={stats_mode}:{player_stats_source_note}; draft_picks={draft_mode}:{args.draft_cache}"
     source_mode = detect_source_mode(stats_rows)

--- a/tests/test_build_nfl_fantasy_outcomes.py
+++ b/tests/test_build_nfl_fantasy_outcomes.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import unittest
+from argparse import Namespace
+from unittest.mock import patch
 
 from scripts.build_nfl_fantasy_outcomes import (
     build_player_outcome_rows,
@@ -13,6 +15,7 @@ from scripts.build_nfl_fantasy_outcomes import (
     is_stale_source,
     latest_draft_year,
     latest_stats_season,
+    resolve_stats_rows,
 )
 
 
@@ -183,6 +186,81 @@ class StatsSourceSelectionTests(unittest.TestCase):
         self.assertEqual(metadata["stats_seasons_loaded"], [2022, 2024])
         self.assertEqual(metadata["missing_stats_seasons"], [2023, 2025])
         self.assertIn("stats_urls", metadata)
+
+    def test_multiseason_rows_do_not_fallback_when_resolved_stats_url_none(self) -> None:
+        args = Namespace(
+            stats_source_url=None,
+            stats_source="stats_player",
+            stats_season_start=2022,
+            stats_season_end=None,
+            expected_latest_season=2025,
+            refresh=False,
+            stats_cache=None,
+        )
+        with (
+            patch(
+                "scripts.build_nfl_fantasy_outcomes.fetch_release_asset_names",
+                return_value=[
+                    "stats_player_reg_2022.csv.gz",
+                    "stats_player_reg_2023.csv.gz",
+                    "stats_player_reg_2024.csv.gz",
+                    "stats_player_reg_2025.csv.gz",
+                ],
+            ),
+            patch(
+                "scripts.build_nfl_fantasy_outcomes.load_source_rows",
+                side_effect=[
+                    ([{"season": "2022"}], "cache"),
+                    ([{"season": "2023"}], "cache"),
+                    ([{"season": "2024"}], "cache"),
+                    ([{"season": "2025"}], "cache"),
+                ],
+            ) as mock_load,
+        ):
+            (
+                stats_rows,
+                _stats_mode,
+                resolved_stats_source,
+                resolved_stats_url,
+                resolved_stats_urls,
+                stats_seasons_loaded,
+                missing_stats_seasons,
+                _seasonal_cache_paths,
+                _stats_resolution_note,
+            ) = resolve_stats_rows(args)
+
+        self.assertEqual(resolved_stats_source, "stats_player")
+        self.assertIsNone(resolved_stats_url)
+        self.assertEqual(stats_seasons_loaded, [2022, 2023, 2024, 2025])
+        self.assertEqual(missing_stats_seasons, [])
+        self.assertEqual([row["season"] for row in stats_rows], ["2022", "2023", "2024", "2025"])
+        self.assertEqual(len(resolved_stats_urls or []), 4)
+        self.assertEqual(mock_load.call_count, 4)
+
+    def test_multiseason_metadata_consistency_and_not_stale(self) -> None:
+        stats_rows = [{"season": str(season)} for season in [2022, 2023, 2024, 2025]]
+        metadata = build_source_metadata(
+            stats_rows=stats_rows,
+            draft_rows=[{"season": "2025"}],
+            source_mode="seasonal_source",
+            expected_latest_season=2025,
+            source_notes="fixture",
+            stats_source="stats_player",
+            stats_urls=[
+                "https://example.com/stats_player_reg_2022.csv.gz",
+                "https://example.com/stats_player_reg_2023.csv.gz",
+                "https://example.com/stats_player_reg_2024.csv.gz",
+                "https://example.com/stats_player_reg_2025.csv.gz",
+            ],
+            stats_seasons_loaded=[2022, 2023, 2024, 2025],
+            missing_stats_seasons=[],
+        )
+        self.assertEqual(metadata["stats_source"], "stats_player")
+        self.assertEqual(metadata["earliest_stats_season"], 2022)
+        self.assertEqual(metadata["latest_stats_season"], 2025)
+        self.assertEqual(metadata["stats_seasons_loaded"], [2022, 2023, 2024, 2025])
+        self.assertEqual(metadata["missing_stats_seasons"], [])
+        self.assertFalse(metadata["is_stale_relative_to_expected"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- The script could discover and load multiple seasonal `stats_player` assets but still fall back to legacy `player_stats` because `resolved_stats_url` remained `None`, causing loaded rows to be overwritten and metadata to be inconsistent. 
- The change ensures that successful multi-season loads are treated as authoritative and that legacy fallback only happens on true failure cases.

### Description
- Extracted the stats discovery/loading control flow into a new helper `resolve_stats_rows(args)` and introduced the boolean sentinel `stats_rows_loaded_from_multiseason` to mark successful multi-season loads. 
- When seasonal `stats_player` rows are loaded, the code now preserves `resolved_stats_source = "stats_player"`, retains `stats_urls`/`stats_seasons_loaded`/`missing_stats_seasons`, and avoids reloading legacy `player_stats`. 
- Legacy fallback is now constrained to discovery failures, no seasonal assets, or zero rows loaded for the requested range (and still respects an explicitly pinned `--stats-source-url`). 
- Fixed the player-stats cache note logic so the metadata `player_stats` cache path reflects the resolved source context.
- Modified `main()` to use `resolve_stats_rows()` and updated `build_source_metadata()` wiring so multi-season metadata remains consistent.

### Testing
- Added unit tests in `tests/test_build_nfl_fantasy_outcomes.py` that simulate successful seasonal `stats_player` loading with `resolved_stats_url is None` and verify no legacy fallback and correct season/url tracking. 
- Added a regression test validating metadata consistency and non-staleness for multi-season `stats_player` (2022–2025 loaded with expected latest 2025). 
- Ran the test suite with `python -m unittest tests/test_build_nfl_fantasy_outcomes.py` and all tests passed (12 tests, OK).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebfa17e04c8332965e6d880958b032)