### PR TITLE
Add 2026 Day 2 draft signal profile translator artifacts

### DIFF
--- a/data/processed/2026_day2_draft_signal_profiles.json
+++ b/data/processed/2026_day2_draft_signal_profiles.json
@@ -1,0 +1,107 @@
+[
+  {
+    "player_id": "wr-dezhaun-stribling",
+    "player_name": "De'Zhaun Stribling",
+    "position": "WR",
+    "round": 2,
+    "pick": 33,
+    "team": "49ers",
+    "pre_draft_tiber_stance": "Vertical WR profile with athletic upside and developmental route-translation variance entering the draft.",
+    "day2_signal_summary": "Early Day 2 capital (pick 33) is near-Round-1 market validation for a WR archetype with role upside, while still carrying weaker insulation than true Round 1 investment.",
+    "talent_confirmation_signal": "strong",
+    "opportunity_insulation_signal": "moderate",
+    "short_term_fantasy_runway": "strong",
+    "primary_risks": [
+      "Target competition and role clarity in the 49ers pass-catching room can cap early volume certainty.",
+      "Day 2 WR capital provides meaningful opportunity signal but less long-horizon patience than Round 1 capital."
+    ],
+    "translator_tags": [
+      "early_day2_capital",
+      "near_round1_skill_capital",
+      "shanahan_role_translation_watch",
+      "athletic_profile_boost",
+      "target_room_competition_watch"
+    ],
+    "post_draft_handling": "Translate as a meaningful market-confidence upgrade with actionable Year 1 role potential, but avoid assigning Round 1-level insulation assumptions.",
+    "notes": "Operator-seeded Day 2 profile pending canonical draft_results reconciliation.",
+    "source_status": "operator_seeded"
+  },
+  {
+    "player_id": "wr-denzel-boston",
+    "player_name": "Denzel Boston",
+    "position": "WR",
+    "round": 2,
+    "pick": null,
+    "team": "Browns",
+    "pre_draft_tiber_stance": "Contested-catch and production-backed WR with mixed separator/translation opinions pre-draft.",
+    "day2_signal_summary": "Round 2 WR capital confirms meaningful organizational intent and role opportunity, but without the same contract/runway insulation as Round 1.",
+    "talent_confirmation_signal": "moderate",
+    "opportunity_insulation_signal": "moderate",
+    "short_term_fantasy_runway": "strong",
+    "primary_risks": [
+      "Exact pick slot is not yet locked in this operator-seeded artifact.",
+      "Browns target competition and deployment context can materially shift early fantasy runway."
+    ],
+    "translator_tags": [
+      "round2_wr_capital",
+      "browns_double_wr_investment",
+      "kcc_target_competition_signal",
+      "role_path_review"
+    ],
+    "post_draft_handling": "Treat as a positive role-opportunity translator signal and monitor role pathway, while keeping insulation assumptions clearly below Round 1 certainty.",
+    "notes": "Operator-seeded Day 2 profile; pick remains null until canonical reconciliation.",
+    "source_status": "operator_seeded"
+  },
+  {
+    "player_id": "qb-carson-beck",
+    "player_name": "Carson Beck",
+    "position": "QB",
+    "round": 3,
+    "pick": 65,
+    "team": "Cardinals",
+    "pre_draft_tiber_stance": "Developmental pocket QB profile with outcome sensitivity to timeline and organizational context.",
+    "day2_signal_summary": "Round 3 QB capital provides real development commitment signal and roster-path relevance, but materially less long-term insulation than Round 1 or Round 2 quarterback investment.",
+    "talent_confirmation_signal": "mixed",
+    "opportunity_insulation_signal": "limited",
+    "short_term_fantasy_runway": "delayed",
+    "primary_risks": [
+      "Day 3-adjacent QB capital band can produce fragile organizational patience.",
+      "Starting timeline and QB-room hierarchy are still context-dependent."
+    ],
+    "translator_tags": [
+      "round3_qb_capital",
+      "developmental_qb_capital",
+      "delayed_start_path",
+      "qb_room_context_required"
+    ],
+    "post_draft_handling": "Apply developmental-quarterback translation with delayed near-term runway and limited insulation assumptions pending clearer room dynamics.",
+    "notes": "Operator-seeded Day 2 profile pending canonical draft_results reconciliation.",
+    "source_status": "operator_seeded"
+  },
+  {
+    "player_id": "qb-drew-allar",
+    "player_name": "Drew Allar",
+    "position": "QB",
+    "round": 3,
+    "pick": 76,
+    "team": "Steelers",
+    "pre_draft_tiber_stance": "Traits-forward developmental QB profile with uneven short-term readiness projection.",
+    "day2_signal_summary": "Round 3 selection signals actionable organizational interest and a plausible developmental path, while still offering limited insulation relative to earlier capital tiers.",
+    "talent_confirmation_signal": "mixed",
+    "opportunity_insulation_signal": "limited",
+    "short_term_fantasy_runway": "delayed",
+    "primary_risks": [
+      "Delayed start trajectory may suppress early fantasy utility.",
+      "Steelers QB-room structure could constrain immediate role access."
+    ],
+    "translator_tags": [
+      "round3_qb_capital",
+      "developmental_qb_capital",
+      "steelers_qb_room_watch",
+      "delayed_start_path"
+    ],
+    "post_draft_handling": "Treat as a developmental Day 2 QB signal with constrained insulation; preserve upside path notes without upgrading to Round 1-style certainty.",
+    "notes": "Operator-seeded Day 2 profile pending canonical draft_results reconciliation.",
+    "source_status": "operator_seeded"
+  }
+]

--- a/docs/day2-draft-signal-profiles-2026.md
+++ b/docs/day2-draft-signal-profiles-2026.md
@@ -1,0 +1,52 @@
+# 2026 Day 2 Draft Signal Profiles
+
+## Purpose
+
+This artifact captures a lightweight, human-readable **post-draft translator layer** for 2026 rookie skill players and quarterbacks selected in **Rounds 2-3**.
+
+It complements the Round 1 signal profiles and is intentionally separated from Rookie Alpha score generation.
+
+- It records Day 2 interpretation in a structured, auditable format.
+- It does **not** alter Rookie Alpha scoring inputs or outputs.
+- It allows early post-draft handling to be preserved while canonical draft artifacts are reconciled.
+
+## Day 2 vs Round 1 Capital
+
+Round 1 and Day 2 capital should not be treated as equivalent signals.
+
+- **Round 1 capital** often conveys stronger organizational insulation, longer runway patience, and higher tolerance for early developmental variance.
+- **Day 2 capital** still matters meaningfully, but usually carries weaker insulation and a wider range of role outcomes.
+
+For translator logic, Day 2 should be interpreted as material opportunity and intent signal, but below Round 1 certainty.
+
+## Why Day 2 Profiles Are Translator Notes (Not Scoring Changes)
+
+These profiles are intentionally a translator artifact.
+
+- Pre-draft model stance remains unchanged.
+- Rookie Alpha scoring remains unchanged.
+- Promoted alpha artifacts are not regenerated.
+
+The goal is clarity and traceability: document how draft capital should adjust interpretation **without rewriting model math**.
+
+## Outcome Calibration Connection
+
+Day 2 profile tags and signal labels are designed for later calibration loops.
+
+Future analysis can compare declared Day 2 expectations (talent confirmation, opportunity insulation, and runway) against realized outcomes to tune translator priors over time.
+
+This keeps post-draft interpretation explicit while preserving pre-draft model integrity.
+
+## Opportunity Insulation Doctrine for Day 2
+
+Day 2 picks can indicate meaningful role path and organizational interest, but they should generally receive less opportunity insulation than comparable Round 1 selections.
+
+Practically:
+
+- treat Day 2 as a positive role-opportunity signal,
+- avoid assigning automatic long-horizon insulation,
+- require follow-up context (depth chart, coaching usage, QB room stability) to escalate confidence.
+
+## Source Status
+
+All current entries in `data/processed/2026_day2_draft_signal_profiles.json` are marked `operator_seeded` until canonical `draft_results` reconciliation is complete.

--- a/scripts/validate_day2_draft_signal_profiles.py
+++ b/scripts/validate_day2_draft_signal_profiles.py
@@ -1,0 +1,89 @@
+import json
+from pathlib import Path
+
+REQUIRED_FIELDS = {
+    "player_id",
+    "player_name",
+    "position",
+    "round",
+    "pick",
+    "team",
+    "pre_draft_tiber_stance",
+    "day2_signal_summary",
+    "talent_confirmation_signal",
+    "opportunity_insulation_signal",
+    "short_term_fantasy_runway",
+    "primary_risks",
+    "translator_tags",
+    "post_draft_handling",
+    "notes",
+    "source_status",
+}
+
+TALENT_SIGNALS = {"strong", "moderate", "mixed", "uncertain"}
+OPPORTUNITY_SIGNALS = {"strong", "moderate", "limited", "uncertain"}
+RUNWAY_SIGNALS = {"immediate", "strong", "delayed", "blocked", "uncertain"}
+VALID_ROUNDS = {2, 3}
+
+
+def validate_profiles(path: Path) -> list[str]:
+    errors: list[str] = []
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return [f"Invalid JSON: {exc}"]
+
+    if not isinstance(payload, list):
+        return ["Profile file must be a JSON array."]
+
+    for idx, profile in enumerate(payload):
+        context = f"profiles[{idx}]"
+        if not isinstance(profile, dict):
+            errors.append(f"{context}: entry must be an object")
+            continue
+
+        missing = REQUIRED_FIELDS - set(profile.keys())
+        if missing:
+            errors.append(f"{context}: missing required fields: {sorted(missing)}")
+
+        round_value = profile.get("round")
+        if round_value not in VALID_ROUNDS:
+            errors.append(f"{context}: round must be 2 or 3")
+
+        pick_value = profile.get("pick")
+        if pick_value is not None and not isinstance(pick_value, int):
+            errors.append(f"{context}: pick must be an integer or null")
+
+        talent = profile.get("talent_confirmation_signal")
+        if talent not in TALENT_SIGNALS:
+            errors.append(f"{context}: invalid talent_confirmation_signal '{talent}'")
+
+        opportunity = profile.get("opportunity_insulation_signal")
+        if opportunity not in OPPORTUNITY_SIGNALS:
+            errors.append(f"{context}: invalid opportunity_insulation_signal '{opportunity}'")
+
+        runway = profile.get("short_term_fantasy_runway")
+        if runway not in RUNWAY_SIGNALS:
+            errors.append(f"{context}: invalid short_term_fantasy_runway '{runway}'")
+
+        for list_field in ("primary_risks", "translator_tags"):
+            value = profile.get(list_field)
+            if not isinstance(value, list):
+                errors.append(f"{context}: {list_field} must be a list")
+
+        if profile.get("source_status") != "operator_seeded":
+            errors.append(f"{context}: source_status must be 'operator_seeded'")
+
+    return errors
+
+
+if __name__ == "__main__":
+    profile_path = Path("data/processed/2026_day2_draft_signal_profiles.json")
+    validation_errors = validate_profiles(profile_path)
+    if validation_errors:
+        print("Day 2 draft signal profile validation failed:")
+        for err in validation_errors:
+            print(f"- {err}")
+        raise SystemExit(1)
+
+    print(f"Validated {profile_path}")

--- a/tests/test_day2_draft_signal_profiles.py
+++ b/tests/test_day2_draft_signal_profiles.py
@@ -1,0 +1,15 @@
+import unittest
+from pathlib import Path
+
+from scripts.validate_day2_draft_signal_profiles import validate_profiles
+
+
+class Day2DraftSignalProfilesTests(unittest.TestCase):
+    def test_profiles_validate(self) -> None:
+        profile_path = Path("data/processed/2026_day2_draft_signal_profiles.json")
+        errors = validate_profiles(profile_path)
+        self.assertEqual(errors, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Provide a lightweight Day 2 (Rounds 2–3) post-draft translator artifact to complement existing Round 1 signal profiles for 2026 rookies.
- Capture operator-seeded signals for select WRs and QBs without altering pre-draft model grades or Rookie Alpha scoring.
- Preserve traceability by marking entries `operator_seeded` until canonical `draft_results` reconciliation occurs.

### Description
- Add `data/processed/2026_day2_draft_signal_profiles.json` containing operator-seeded Day 2 profiles for De'Zhaun Stribling, Denzel Boston, Carson Beck, and Drew Allar with the required JSON schema fields. 
- Add `scripts/validate_day2_draft_signal_profiles.py` implementing schema validation (required fields, allowed enums for signals, `round` constraint to 2/3, `pick` type check, and `source_status == "operator_seeded"`).
- Add `tests/test_day2_draft_signal_profiles.py` which invokes the validator to enforce CI-level checks on the artifact. 
- Add `docs/day2-draft-signal-profiles-2026.md` documenting Day 2 doctrine, separation from scoring, calibration intent, and handling guidance.

### Testing
- Ran `python scripts/validate_day2_draft_signal_profiles.py` and it validated `data/processed/2026_day2_draft_signal_profiles.json` successfully. 
- Ran `python -m unittest tests/test_day2_draft_signal_profiles.py` and the unit test passed (`OK`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eca2973d908332855696218c6d137f)