### PR TITLE
Add five operator-journal candidates for model-edge, landing-spot, and audit watches

### DIFF
--- a/data/operator-journal/processed/2026_operator_signal_candidates.json
+++ b/data/operator-journal/processed/2026_operator_signal_candidates.json
@@ -195,5 +195,196 @@
     "needs_verification": true,
     "source_type": "operator_journal",
     "review_status": "needs_human_review"
+  },
+  {
+    "candidate_id": "cand_oj_2026_006_nick_singleton_titans_landing_spot_missing_data_audit",
+    "source_entry_id": "oj_2026_006_nick_singleton_titans",
+    "entity_type": "player",
+    "player_name": "Nick Singleton",
+    "team": "Titans",
+    "position": "RB",
+    "related_entities": [],
+    "claim_summary": "Negative pre-draft model-edge context with landing-spot opportunity and missing-data audit note for profile completeness review.",
+    "positive_signal_tags": [
+      "athletic_rb_profile",
+      "early_age_production_signal",
+      "receiving_efficiency_signal",
+      "titans_backfield_opportunity",
+      "pollard_contract_year",
+      "spears_workload_size_question"
+    ],
+    "risk_tags": [
+      "mid_late_round_capital_risk",
+      "longshot_backfield_takeover",
+      "predraft_model_negative_edge",
+      "incomplete_profile_data_risk",
+      "role_projection_uncertainty"
+    ],
+    "context_tags": [
+      "model_edge_minus_10",
+      "missing_data_audit",
+      "post_draft_landing_spot_watch"
+    ],
+    "model_impact": "review_profile_data_completeness_before_final_take",
+    "downstream_repos": [
+      "TIBER-Rookies",
+      "Role-and-Opportunity"
+    ],
+    "confidence": "medium",
+    "needs_verification": true,
+    "source_type": "operator_journal",
+    "review_status": "needs_human_review"
+  },
+  {
+    "candidate_id": "cand_oj_2026_007_emmett_johnson_chiefs_passing_down_role_watch",
+    "source_entry_id": "oj_2026_007_emmett_johnson_chiefs",
+    "entity_type": "player",
+    "player_name": "Emmett Johnson",
+    "team": "Chiefs",
+    "position": "RB",
+    "related_entities": [],
+    "claim_summary": "Late-round role-path watch focused on passing-down deployment and injury-contingent upside in a high-powered offense.",
+    "positive_signal_tags": [
+      "high_powered_offense",
+      "passing_down_role_path",
+      "injury_contingent_upside",
+      "late_round_role_watch"
+    ],
+    "risk_tags": [
+      "round5_insulation_risk",
+      "low_predraft_alpha",
+      "limited_model_evidence",
+      "role_projection_uncertainty",
+      "depth_chart_dependency"
+    ],
+    "context_tags": [
+      "predraft_alpha_36_4",
+      "chiefs_passing_down_watch",
+      "post_draft_watchlist"
+    ],
+    "model_impact": "track_as_late_round_role_path_candidate",
+    "downstream_repos": [
+      "TIBER-Rookies",
+      "Role-and-Opportunity"
+    ],
+    "confidence": "low_medium",
+    "needs_verification": true,
+    "source_type": "operator_journal",
+    "review_status": "needs_human_review"
+  },
+  {
+    "candidate_id": "cand_oj_2026_008_skyler_bell_bills_model_edge_model_edge_landing_spot_validation",
+    "source_entry_id": "oj_2026_008_skyler_bell_bills_model_edge",
+    "entity_type": "player",
+    "player_name": "Skyler Bell",
+    "team": "Bills",
+    "position": "WR",
+    "related_entities": [],
+    "claim_summary": "Positive model-edge note with favorable NFL landing spot and role opportunity, tracked as validation-watch only.",
+    "positive_signal_tags": [
+      "model_edge_confirmed_by_landing_spot",
+      "wr2_wr3_path",
+      "available_target_opportunity",
+      "strong_landing_spot",
+      "post_draft_role_opportunity"
+    ],
+    "risk_tags": [
+      "late_selection_urgency_concern",
+      "low_draft_capital_insulation",
+      "role_competition_risk",
+      "model_edge_validation_needed"
+    ],
+    "context_tags": [
+      "predraft_alpha_62_3",
+      "tiber_edge_plus_18",
+      "bills_wr_room_watch",
+      "post_draft_watchlist"
+    ],
+    "model_impact": "track_as_model_edge_role_opportunity_candidate",
+    "downstream_repos": [
+      "TIBER-Rookies",
+      "Role-and-Opportunity"
+    ],
+    "confidence": "medium",
+    "needs_verification": true,
+    "source_type": "operator_journal",
+    "review_status": "needs_human_review"
+  },
+  {
+    "candidate_id": "cand_oj_2026_009_germie_bernard_mccarthy_slot_slot_role_context",
+    "source_entry_id": "oj_2026_009_germie_bernard_mccarthy_slot",
+    "entity_type": "player",
+    "player_name": "Germie Bernard",
+    "team": "Steelers",
+    "position": "WR",
+    "related_entities": [],
+    "claim_summary": "Early Round 2 trade-up with positive model-edge and slot-role coaching-context note for role-opportunity review.",
+    "positive_signal_tags": [
+      "early_round2_trade_up",
+      "slot_role_coaching_signal",
+      "mccarthy_slot_wr_history",
+      "model_edge_positive",
+      "role_archetype_fit_watch"
+    ],
+    "risk_tags": [
+      "coach_context_transfer_risk",
+      "steelers_wr_room_watch",
+      "qb_room_uncertainty",
+      "year1_volume_uncertainty"
+    ],
+    "context_tags": [
+      "predraft_alpha_55_5",
+      "tiber_edge_plus_6_5",
+      "mccarthy_slot_fpg_signal",
+      "post_draft_role_watch"
+    ],
+    "model_impact": "review_slot_role_context_in_role_opportunity_layer",
+    "downstream_repos": [
+      "TIBER-Rookies",
+      "Role-and-Opportunity",
+      "TIBER-Teamstate"
+    ],
+    "confidence": "medium",
+    "needs_verification": true,
+    "source_type": "operator_journal",
+    "review_status": "needs_human_review"
+  },
+  {
+    "candidate_id": "cand_oj_2026_010_malachi_fields_giants_landing_spot_over_profile",
+    "source_entry_id": "oj_2026_010_malachi_fields_giants",
+    "entity_type": "player",
+    "player_name": "Malachi Fields",
+    "team": "Giants",
+    "position": "WR",
+    "related_entities": [],
+    "claim_summary": "Landing-spot opportunity note despite weaker profile and negative model-edge; tracked as landing-spot-over-profile watch candidate.",
+    "positive_signal_tags": [
+      "year1_route_path",
+      "full_time_route_runner_opportunity",
+      "improved_offense_watch",
+      "landing_spot_opportunity"
+    ],
+    "risk_tags": [
+      "low_predraft_alpha",
+      "negative_model_edge",
+      "college_efficiency_concern",
+      "man_coverage_struggle",
+      "role_competition_risk"
+    ],
+    "context_tags": [
+      "predraft_alpha_39_5",
+      "pick_74_context",
+      "giants_wr_room_watch",
+      "post_draft_landing_spot_watch"
+    ],
+    "model_impact": "track_as_landing_spot_opportunity_over_profile_candidate",
+    "downstream_repos": [
+      "TIBER-Rookies",
+      "Role-and-Opportunity"
+    ],
+    "confidence": "medium",
+    "needs_verification": true,
+    "source_type": "operator_journal",
+    "review_status": "needs_human_review"
   }
 ]

--- a/data/operator-journal/raw/2026_rookie_journal_entries.json
+++ b/data/operator-journal/raw/2026_rookie_journal_entries.json
@@ -43,5 +43,50 @@
     "source_type": "operator_journal",
     "operator": "local",
     "review_status": "raw"
+  },
+  {
+    "entry_id": "oj_2026_006_nick_singleton_titans",
+    "entry_date": "2026-04-25",
+    "entry_title": "Nick Singleton Titans landing spot and missing-data audit",
+    "entry_text": "Singleton fell further than expected at the draft and had a -10 vs consensus edge on the model pre-draft grade. He fell to Tennessee in a good landing spot. Tony Pollard is aging, could be cut, and is on the last year of his contract. Tyjae Spears is undersized and has not crossed 100 carries in any of his 3 seasons. Singleton is still more of a longshot to ever lead the backfield with this capital, but he is a hyper-athletic RB who had elite production/efficiency as an 18-year-old at Penn State and was an efficient receiver throughout. Nick Singleton also appears to have had insufficient data inside his rookie profile, so the pre-draft grade may not accurately reflect what could have been graded.",
+    "source_type": "operator_journal",
+    "operator": "local",
+    "review_status": "raw"
+  },
+  {
+    "entry_id": "oj_2026_007_emmett_johnson_chiefs",
+    "entry_date": "2026-04-25",
+    "entry_title": "Emmett Johnson Chiefs passing-down opportunity watch",
+    "entry_text": "The mid-round 5 draft capital is not great and is probably telling, but Emmett Johnson may only need to fend off Emari Demercado for some sort of passing-down role in the Chiefs high-powered offense. In the case of a KW3 injury, he could step into somewhat of a lead role as well. The model graded Emmett Johnson as a 36.4 pre-draft grade, with limited supporting evidence.",
+    "source_type": "operator_journal",
+    "operator": "local",
+    "review_status": "raw"
+  },
+  {
+    "entry_id": "oj_2026_008_skyler_bell_bills_model_edge",
+    "entry_date": "2026-04-25",
+    "entry_title": "Skyler Bell Bills landing spot and model edge",
+    "entry_text": "Skyler Bell has a pretty undeniably great landing spot, with a legitimate opportunity to step in as WR2/3 alongside DJ Moore and Khalil Shakir. The lack of urgency to select him is definitely a concern. The model had Bell with a pre-draft grade of 62.3 and a +18 model edge.",
+    "source_type": "operator_journal",
+    "operator": "local",
+    "review_status": "raw"
+  },
+  {
+    "entry_id": "oj_2026_009_germie_bernard_mccarthy_slot",
+    "entry_date": "2026-04-25",
+    "entry_title": "Germie Bernard Mike McCarthy slot WR context",
+    "entry_text": "Mike McCarthy's primary slot WR has finished top-10 in fantasy points per game in 7 of his last 13 full seasons as an NFL head coach. Germie Bernard was drafted in an early Round 2 trade-up by the Steelers. The model gave Bernard a pre-draft grade of 55.5 and model edge of +6.5.",
+    "source_type": "operator_journal",
+    "operator": "local",
+    "review_status": "raw"
+  },
+  {
+    "entry_id": "oj_2026_010_malachi_fields_giants",
+    "entry_date": "2026-04-25",
+    "entry_title": "Malachi Fields Giants landing spot versus profile concern",
+    "entry_text": "The Giants selected Malachi Fields at pick 74. Fields was not very efficient or a big producer in college and struggles against man coverage despite profiling as an X receiver. But this is a nice landing spot for Fields, who should have a chance to be a full-time route runner in Year 1 in what is likely an improved offense. He just has to beat out Mooney. Fields had a pre-draft grade of 39.5 and was negative against consensus.",
+    "source_type": "operator_journal",
+    "operator": "local",
+    "review_status": "raw"
   }
 ]

--- a/docs/operator-journal-signal-scanner.md
+++ b/docs/operator-journal-signal-scanner.md
@@ -50,7 +50,10 @@ Candidate tags are created for analyst review before any downstream use:
 - `TIBER-Rookies`
 - `TIBER-Data`
 
-Model-edge notes (for example, Tanner Koziol `+18`) are treated as validation-watch candidates only, and never as automatic grade or score bumps.
+Model-edge notes can be positive or negative and are always treated as candidate-tag context, not score changes.
+- Positive model edge plus NFL/landing-spot confirmation is a validation-watch candidate.
+- Negative model edge plus better landing spot is tracked as a "landing spot over profile" candidate.
+- Missing-data observations become audit candidates and profile-completeness review tasks, not retroactive score edits.
 
 Only reviewed/promoted items should be consumed by Teamstate, Role-Opportunity, post-draft alpha, or any TIBER-Data downstream workflows. The scanner's goal is to turn hobby notes into a repeatable information layer without bypassing model governance.
 

--- a/scripts/build_operator_signal_candidates.py
+++ b/scripts/build_operator_signal_candidates.py
@@ -185,6 +185,191 @@ def build_candidates_for_entry(entry: dict[str, Any]) -> list[dict[str, Any]]:
         )
         return [candidate]
 
+    if "nick_singleton_titans" in entry_id:
+        candidate = _base_candidate(entry, "landing_spot_missing_data_audit", "player")
+        candidate.update(
+            {
+                "player_name": "Nick Singleton",
+                "team": "Titans",
+                "position": "RB",
+                "claim_summary": (
+                    "Negative pre-draft model-edge context with landing-spot opportunity and missing-data "
+                    "audit note for profile completeness review."
+                ),
+                "positive_signal_tags": [
+                    "athletic_rb_profile",
+                    "early_age_production_signal",
+                    "receiving_efficiency_signal",
+                    "titans_backfield_opportunity",
+                    "pollard_contract_year",
+                    "spears_workload_size_question",
+                ],
+                "risk_tags": [
+                    "mid_late_round_capital_risk",
+                    "longshot_backfield_takeover",
+                    "predraft_model_negative_edge",
+                    "incomplete_profile_data_risk",
+                    "role_projection_uncertainty",
+                ],
+                "context_tags": [
+                    "model_edge_minus_10",
+                    "missing_data_audit",
+                    "post_draft_landing_spot_watch",
+                ],
+                "model_impact": "review_profile_data_completeness_before_final_take",
+                "downstream_repos": ["TIBER-Rookies", "Role-and-Opportunity"],
+                "confidence": "medium",
+            }
+        )
+        return [candidate]
+
+    if "emmett_johnson_chiefs" in entry_id:
+        candidate = _base_candidate(entry, "passing_down_role_watch", "player")
+        candidate.update(
+            {
+                "player_name": "Emmett Johnson",
+                "team": "Chiefs",
+                "position": "RB",
+                "claim_summary": (
+                    "Late-round role-path watch focused on passing-down deployment and injury-contingent "
+                    "upside in a high-powered offense."
+                ),
+                "positive_signal_tags": [
+                    "high_powered_offense",
+                    "passing_down_role_path",
+                    "injury_contingent_upside",
+                    "late_round_role_watch",
+                ],
+                "risk_tags": [
+                    "round5_insulation_risk",
+                    "low_predraft_alpha",
+                    "limited_model_evidence",
+                    "role_projection_uncertainty",
+                    "depth_chart_dependency",
+                ],
+                "context_tags": [
+                    "predraft_alpha_36_4",
+                    "chiefs_passing_down_watch",
+                    "post_draft_watchlist",
+                ],
+                "model_impact": "track_as_late_round_role_path_candidate",
+                "downstream_repos": ["TIBER-Rookies", "Role-and-Opportunity"],
+                "confidence": "low_medium",
+            }
+        )
+        return [candidate]
+
+    if "skyler_bell_bills_model_edge" in entry_id:
+        candidate = _base_candidate(entry, "model_edge_landing_spot_validation", "player")
+        candidate.update(
+            {
+                "player_name": "Skyler Bell",
+                "team": "Bills",
+                "position": "WR",
+                "claim_summary": (
+                    "Positive model-edge note with favorable NFL landing spot and role opportunity, tracked "
+                    "as validation-watch only."
+                ),
+                "positive_signal_tags": [
+                    "model_edge_confirmed_by_landing_spot",
+                    "wr2_wr3_path",
+                    "available_target_opportunity",
+                    "strong_landing_spot",
+                    "post_draft_role_opportunity",
+                ],
+                "risk_tags": [
+                    "late_selection_urgency_concern",
+                    "low_draft_capital_insulation",
+                    "role_competition_risk",
+                    "model_edge_validation_needed",
+                ],
+                "context_tags": [
+                    "predraft_alpha_62_3",
+                    "tiber_edge_plus_18",
+                    "bills_wr_room_watch",
+                    "post_draft_watchlist",
+                ],
+                "model_impact": "track_as_model_edge_role_opportunity_candidate",
+                "downstream_repos": ["TIBER-Rookies", "Role-and-Opportunity"],
+                "confidence": "medium",
+            }
+        )
+        return [candidate]
+
+    if "germie_bernard_mccarthy_slot" in entry_id:
+        candidate = _base_candidate(entry, "slot_role_context", "player")
+        candidate.update(
+            {
+                "player_name": "Germie Bernard",
+                "team": "Steelers",
+                "position": "WR",
+                "claim_summary": (
+                    "Early Round 2 trade-up with positive model-edge and slot-role coaching-context note for "
+                    "role-opportunity review."
+                ),
+                "positive_signal_tags": [
+                    "early_round2_trade_up",
+                    "slot_role_coaching_signal",
+                    "mccarthy_slot_wr_history",
+                    "model_edge_positive",
+                    "role_archetype_fit_watch",
+                ],
+                "risk_tags": [
+                    "coach_context_transfer_risk",
+                    "steelers_wr_room_watch",
+                    "qb_room_uncertainty",
+                    "year1_volume_uncertainty",
+                ],
+                "context_tags": [
+                    "predraft_alpha_55_5",
+                    "tiber_edge_plus_6_5",
+                    "mccarthy_slot_fpg_signal",
+                    "post_draft_role_watch",
+                ],
+                "model_impact": "review_slot_role_context_in_role_opportunity_layer",
+                "downstream_repos": ["TIBER-Rookies", "Role-and-Opportunity", "TIBER-Teamstate"],
+                "confidence": "medium",
+            }
+        )
+        return [candidate]
+
+    if "malachi_fields_giants" in entry_id:
+        candidate = _base_candidate(entry, "landing_spot_over_profile", "player")
+        candidate.update(
+            {
+                "player_name": "Malachi Fields",
+                "team": "Giants",
+                "position": "WR",
+                "claim_summary": (
+                    "Landing-spot opportunity note despite weaker profile and negative model-edge; tracked "
+                    "as landing-spot-over-profile watch candidate."
+                ),
+                "positive_signal_tags": [
+                    "year1_route_path",
+                    "full_time_route_runner_opportunity",
+                    "improved_offense_watch",
+                    "landing_spot_opportunity",
+                ],
+                "risk_tags": [
+                    "low_predraft_alpha",
+                    "negative_model_edge",
+                    "college_efficiency_concern",
+                    "man_coverage_struggle",
+                    "role_competition_risk",
+                ],
+                "context_tags": [
+                    "predraft_alpha_39_5",
+                    "pick_74_context",
+                    "giants_wr_room_watch",
+                    "post_draft_landing_spot_watch",
+                ],
+                "model_impact": "track_as_landing_spot_opportunity_over_profile_candidate",
+                "downstream_repos": ["TIBER-Rookies", "Role-and-Opportunity"],
+                "confidence": "medium",
+            }
+        )
+        return [candidate]
+
     return []
 
 

--- a/tests/test_build_operator_signal_candidates.py
+++ b/tests/test_build_operator_signal_candidates.py
@@ -46,6 +46,31 @@ class BuildOperatorSignalCandidatesTests(unittest.TestCase):
         self.assertIn("tiber_edge_plus_18", tanner["context_tags"])
         self.assertIn("model_edge_confirmed_by_draft_capital", tanner["positive_signal_tags"])
 
+    def test_nick_singleton_includes_missing_data_audit_tags(self) -> None:
+        nick = next(c for c in self.candidates if c["player_name"] == "Nick Singleton")
+        self.assertIn("missing_data_audit", nick["context_tags"])
+        self.assertIn("incomplete_profile_data_risk", nick["risk_tags"])
+
+    def test_emmett_johnson_includes_predraft_alpha_and_passing_down_role(self) -> None:
+        emmett = next(c for c in self.candidates if c["player_name"] == "Emmett Johnson")
+        self.assertIn("predraft_alpha_36_4", emmett["context_tags"])
+        self.assertIn("passing_down_role_path", emmett["positive_signal_tags"])
+
+    def test_skyler_bell_includes_model_edge_and_urgency_risk(self) -> None:
+        skyler = next(c for c in self.candidates if c["player_name"] == "Skyler Bell")
+        self.assertIn("tiber_edge_plus_18", skyler["context_tags"])
+        self.assertIn("late_selection_urgency_concern", skyler["risk_tags"])
+
+    def test_germie_bernard_includes_slot_context_and_trade_up(self) -> None:
+        germie = next(c for c in self.candidates if c["player_name"] == "Germie Bernard")
+        self.assertIn("mccarthy_slot_fpg_signal", germie["context_tags"])
+        self.assertIn("early_round2_trade_up", germie["positive_signal_tags"])
+
+    def test_malachi_fields_includes_profile_risk_and_year1_route_path(self) -> None:
+        fields = next(c for c in self.candidates if c["player_name"] == "Malachi Fields")
+        self.assertIn("man_coverage_struggle", fields["risk_tags"])
+        self.assertIn("year1_route_path", fields["positive_signal_tags"])
+
     def test_all_candidates_are_operator_journal_source(self) -> None:
         for candidate in self.candidates:
             self.assertEqual(candidate["source_type"], "operator_journal")


### PR DESCRIPTION
### Motivation
- Capture five additional operator notes into the scanner to surface model-edge validation, landing-spot-over-profile context, passing-down opportunity watches, missing-data audit flags, and coaching/slot-role context as candidate tags for analyst review.
- Preserve scanner doctrine: these notes must not change Rookie Alpha/post-draft scoring, remain `source_type: operator_journal`, default to `review_status: needs_human_review`, and use stable candidate IDs derived from `source_entry_id`.
- Make mappings deterministic so unmapped entries continue to fail loudly by default unless `--allow-unmapped` is explicitly used.

### Description
- Appended five raw entries (`oj_2026_006` → `oj_2026_010`) to `data/operator-journal/raw/2026_rookie_journal_entries.json` for Nick Singleton, Emmett Johnson, Skyler Bell, Germie Bernard, and Malachi Fields. 
- Added deterministic mapping rules in `scripts/build_operator_signal_candidates.py` that emit player candidates with `candidate_id` format `cand_${source_entry_id}_...` and the requested `positive_signal_tags`, `risk_tags`, `context_tags`, `model_impact`, `downstream_repos`, `confidence`, and `needs_verification` fields. 
- Regenerated processed output at `data/operator-journal/processed/2026_operator_signal_candidates.json` so the five new candidates are emitted with stable IDs and expected tag sets. 
- Expanded unit tests in `tests/test_build_operator_signal_candidates.py` to assert the new candidates include the specified tags and contexts, and updated `docs/operator-journal-signal-scanner.md` to clarify model-edge (positive/negative), landing-spot-over-profile, and missing-data audit semantics. 

### Testing
- Built candidates with `python scripts/build_operator_signal_candidates.py` which completed successfully. 
- Ran unit tests with `python -m pytest tests/test_build_operator_signal_candidates.py -q` and received `17 passed` (all tests passed). 
- Verified candidate ID uniqueness and defaults via the added tests, which passed, confirming `source_type` remains `operator_journal` and `review_status` remains `needs_human_review`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed2e9970d08332b9e581a3475ed3ea)