### PR TITLE
Add Operator Journal Signals panel to Rookie ML Workbench

### DIFF
--- a/cards/rookies/workbench/index.html
+++ b/cards/rookies/workbench/index.html
@@ -85,6 +85,47 @@
         <h2 class="section-title">Outcome calibration cohorts</h2>
         <div id="calibration-panel" class="panel-card">Loading outcome summary artifact…</div>
       </section>
+
+      <section>
+        <h2 class="section-title">Journal Signals</h2>
+        <div id="journal-signals-panel" class="panel-card">Loading operator journal signal artifact…</div>
+        <div class="table-controls journal-table-controls">
+          <input
+            type="search"
+            id="journal-search-input"
+            class="board-search-input"
+            placeholder="Search player, team, entity, tags, claim..."
+            autocomplete="off"
+            spellcheck="false"
+          />
+          <label class="checkbox-filter"><input type="checkbox" id="journal-filter-model-edge" /> model_edge</label>
+          <label class="checkbox-filter"><input type="checkbox" id="journal-filter-missing-data" /> missing_data_audit</label>
+          <label class="checkbox-filter"><input type="checkbox" id="journal-filter-role-opportunity" /> role_opportunity</label>
+          <label class="checkbox-filter"><input type="checkbox" id="journal-filter-needs-review" /> needs_human_review</label>
+        </div>
+        <p id="journal-selected-player-hint" class="meta">Select a player to scope journal signals.</p>
+        <div class="table-wrap">
+          <table class="workbench-table compact-journal-table">
+            <thead>
+              <tr>
+                <th>candidate_id</th>
+                <th>player_name / team / position</th>
+                <th>entity_type</th>
+                <th>claim_summary</th>
+                <th>positive_signal_tags</th>
+                <th>risk_tags</th>
+                <th>context_tags</th>
+                <th>model_impact</th>
+                <th>confidence</th>
+                <th>review_status</th>
+              </tr>
+            </thead>
+            <tbody id="journal-signals-tbody">
+              <tr><td colspan="10" class="meta">Loading journal candidates…</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
     </main>
 
     <footer class="site-footer" role="contentinfo">

--- a/cards/rookies/workbench/workbench.css
+++ b/cards/rookies/workbench/workbench.css
@@ -178,6 +178,37 @@
   padding: 7px 8px;
 }
 
+.journal-table-controls {
+  grid-template-columns: minmax(260px, 2fr) repeat(4, minmax(160px, 1fr));
+  align-items: center;
+}
+
+.checkbox-filter {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border: 1px solid rgba(157, 170, 191, 0.4);
+  border-radius: 10px;
+  padding: 10px;
+  color: #f5f8ff;
+  background: rgba(17, 23, 37, 0.95);
+  font-size: 0.84rem;
+}
+
+.journal-summary-grid {
+  margin-top: 0;
+}
+
+.compact-journal-table td {
+  white-space: normal;
+  vertical-align: top;
+  min-width: 140px;
+}
+
+.compact-journal-table td:nth-child(4) {
+  min-width: 260px;
+}
+
 @media (max-width: 980px) {
   .table-controls {
     grid-template-columns: 1fr 1fr;

--- a/cards/rookies/workbench/workbench.js
+++ b/cards/rookies/workbench/workbench.js
@@ -21,6 +21,7 @@ const CALIBRATION_COHORTS = [
 const state = {
   rows: [],
   selectedId: null,
+  hasExplicitPlayerSelection: false,
   sortKey: 'post_draft_alpha',
   sortDirection: 'desc',
   filters: {
@@ -290,7 +291,13 @@ function renderTable(rows) {
 
   dom.tbody.querySelectorAll('tr[data-player-id]').forEach((rowEl) => {
     rowEl.addEventListener('click', () => {
-      state.selectedId = rowEl.dataset.playerId;
+      if (state.selectedId === rowEl.dataset.playerId && state.hasExplicitPlayerSelection) {
+        state.selectedId = null;
+        state.hasExplicitPlayerSelection = false;
+      } else {
+        state.selectedId = rowEl.dataset.playerId;
+        state.hasExplicitPlayerSelection = true;
+      }
       render();
     });
   });
@@ -399,7 +406,22 @@ function renderCalibration() {
 }
 
 function isModelEdgeCandidate(candidate) {
-  return candidate.model_impact.toLowerCase().includes('model_edge');
+  const haystack = [
+    candidate.model_impact || '',
+    candidate.claim_summary || '',
+    ...candidate.positive_signal_tags,
+    ...candidate.risk_tags,
+    ...candidate.context_tags,
+  ]
+    .join(' ')
+    .toLowerCase();
+
+  return (
+    haystack.includes('model_edge') ||
+    haystack.includes('model-edge') ||
+    haystack.includes('tiber_edge_plus') ||
+    haystack.includes('tiber edge plus')
+  );
 }
 
 function isMissingDataAuditCandidate(candidate) {
@@ -420,7 +442,7 @@ function getJournalRowsForDisplay(selectedPlayer) {
   if (!state.journalSignals.available) return [];
 
   let rows = state.journalSignals.rows;
-  if (selectedPlayer?.player_name) {
+  if (state.hasExplicitPlayerSelection && selectedPlayer?.player_name) {
     const selectedName = selectedPlayer.player_name.toLowerCase();
     rows = rows.filter((candidate) => candidate.player_name && candidate.player_name.toLowerCase() === selectedName);
   }
@@ -527,11 +549,10 @@ function render() {
   renderSummary(sorted);
   renderTable(sorted);
   const selected = state.rows.find((row) => row.id === state.selectedId) || sorted[0] || null;
-  if (!state.selectedId && selected) state.selectedId = selected.id;
   renderDetail(selected);
   renderMissingBaselines();
   renderCalibration();
-  renderJournalSignals(selected);
+  renderJournalSignals(state.hasExplicitPlayerSelection ? selected : null);
 }
 
 function renderFilterOptions() {

--- a/cards/rookies/workbench/workbench.js
+++ b/cards/rookies/workbench/workbench.js
@@ -2,6 +2,7 @@ const PRIMARY_CONTEXT_PATH = '../../../exports/promoted/rookie-alpha/2026_rookie
 const POST_DRAFT_FALLBACK_PATH = '../../../exports/promoted/rookie-alpha/2026_rookie_alpha_postdraft_v0.json';
 const MISSING_BASELINE_PATH = '../../../exports/promoted/rookie-alpha/2026_rookie_alpha_postdraft_missing_baselines_v0.json';
 const OUTCOME_SUMMARY_PATH = '../../../exports/promoted/nfl-fantasy-outcomes/context_flag_outcome_summary_v1.json';
+const JOURNAL_SIGNAL_PATH = '../../../data/operator-journal/processed/2026_operator_signal_candidates.json';
 
 const CALIBRATION_COHORTS = [
   'skill_pick_1_10_since_2020',
@@ -32,6 +33,14 @@ const state = {
   },
   missingBaselines: null,
   outcomeSummary: null,
+  journalSignals: { available: false, rows: [] },
+  journalFilters: {
+    search: '',
+    modelEdge: false,
+    missingDataAudit: false,
+    roleOpportunity: false,
+    needsHumanReview: false,
+  },
 };
 
 const dom = {
@@ -41,6 +50,14 @@ const dom = {
   detail: document.getElementById('player-detail'),
   missingPanel: document.getElementById('missing-baseline-panel'),
   calibrationPanel: document.getElementById('calibration-panel'),
+  journalPanel: document.getElementById('journal-signals-panel'),
+  journalTableBody: document.getElementById('journal-signals-tbody'),
+  journalSearch: document.getElementById('journal-search-input'),
+  journalModelEdge: document.getElementById('journal-filter-model-edge'),
+  journalMissingData: document.getElementById('journal-filter-missing-data'),
+  journalRoleOpportunity: document.getElementById('journal-filter-role-opportunity'),
+  journalNeedsReview: document.getElementById('journal-filter-needs-review'),
+  journalSelectedHint: document.getElementById('journal-selected-player-hint'),
   search: document.getElementById('search-input'),
   position: document.getElementById('position-filter'),
   round: document.getElementById('round-filter'),
@@ -91,6 +108,25 @@ function normalizeRow(row, index) {
     combined_risk_tags: toArray(row.combined_risk_tags),
     remaining_risks: toArray(row.remaining_risks),
     team_context_notes: row.team_context_notes || '—',
+  };
+}
+
+function normalizeJournalCandidate(candidate, index) {
+  return {
+    id: candidate.candidate_id || `journal-candidate-${index}`,
+    candidate_id: candidate.candidate_id || `journal-candidate-${index}`,
+    player_name: candidate.player_name || null,
+    team: candidate.team || null,
+    position: candidate.position || null,
+    entity_type: candidate.entity_type || 'unknown',
+    claim_summary: candidate.claim_summary || '—',
+    positive_signal_tags: toArray(candidate.positive_signal_tags),
+    risk_tags: toArray(candidate.risk_tags),
+    context_tags: toArray(candidate.context_tags),
+    model_impact: candidate.model_impact || '',
+    confidence: candidate.confidence || '—',
+    review_status: candidate.review_status || 'unknown',
+    needs_verification: Boolean(candidate.needs_verification),
   };
 }
 
@@ -362,6 +398,129 @@ function renderCalibration() {
   `;
 }
 
+function isModelEdgeCandidate(candidate) {
+  return candidate.model_impact.toLowerCase().includes('model_edge');
+}
+
+function isMissingDataAuditCandidate(candidate) {
+  const haystack = `${candidate.model_impact} ${candidate.claim_summary} ${candidate.risk_tags.join(' ')} ${candidate.context_tags.join(' ')}`.toLowerCase();
+  return haystack.includes('missing_data') || haystack.includes('profile_data_completeness');
+}
+
+function isRoleOpportunityCandidate(candidate) {
+  const haystack = `${candidate.model_impact} ${candidate.claim_summary} ${candidate.context_tags.join(' ')}`.toLowerCase();
+  return haystack.includes('role_opportunity') || haystack.includes('role_path');
+}
+
+function isLandingSpotOverProfileCandidate(candidate) {
+  return candidate.model_impact.toLowerCase().includes('landing_spot_opportunity_over_profile');
+}
+
+function getJournalRowsForDisplay(selectedPlayer) {
+  if (!state.journalSignals.available) return [];
+
+  let rows = state.journalSignals.rows;
+  if (selectedPlayer?.player_name) {
+    const selectedName = selectedPlayer.player_name.toLowerCase();
+    rows = rows.filter((candidate) => candidate.player_name && candidate.player_name.toLowerCase() === selectedName);
+  }
+
+  return rows.filter((candidate) => {
+    const haystack = [
+      candidate.player_name || '',
+      candidate.team || '',
+      candidate.entity_type || '',
+      candidate.claim_summary || '',
+      ...candidate.positive_signal_tags,
+      ...candidate.risk_tags,
+      ...candidate.context_tags,
+      candidate.model_impact || '',
+      candidate.review_status || '',
+    ]
+      .join(' ')
+      .toLowerCase();
+
+    if (state.journalFilters.search && !haystack.includes(state.journalFilters.search.toLowerCase())) {
+      return false;
+    }
+
+    if (state.journalFilters.modelEdge && !isModelEdgeCandidate(candidate)) {
+      return false;
+    }
+
+    if (state.journalFilters.missingDataAudit && !isMissingDataAuditCandidate(candidate)) {
+      return false;
+    }
+
+    if (state.journalFilters.roleOpportunity && !isRoleOpportunityCandidate(candidate)) {
+      return false;
+    }
+
+    if (state.journalFilters.needsHumanReview && candidate.review_status !== 'needs_human_review') {
+      return false;
+    }
+
+    return true;
+  });
+}
+
+function renderJournalSignals(selectedPlayer) {
+  if (!state.journalSignals.available) {
+    dom.journalPanel.innerHTML = '<p class="meta">Operator journal signal artifact unavailable.</p>';
+    dom.journalTableBody.innerHTML = '<tr><td colspan="10" class="meta">Operator journal signal artifact unavailable.</td></tr>';
+    dom.journalSelectedHint.textContent = 'Select a player to scope journal signals.';
+    return;
+  }
+
+  const allRows = state.journalSignals.rows;
+  const displayRows = getJournalRowsForDisplay(selectedPlayer);
+  const needsReviewCount = allRows.filter((candidate) => candidate.review_status === 'needs_human_review').length;
+  const modelEdgeCount = allRows.filter(isModelEdgeCandidate).length;
+  const missingDataCount = allRows.filter(isMissingDataAuditCandidate).length;
+  const landingSpotCount = allRows.filter(isLandingSpotOverProfileCandidate).length;
+
+  dom.journalPanel.innerHTML = `
+    <div class="summary-grid journal-summary-grid">
+      <article class="summary-tile"><div class="summary-label">Total candidates</div><div class="summary-value">${allRows.length}</div></article>
+      <article class="summary-tile"><div class="summary-label">Candidates needing review</div><div class="summary-value">${needsReviewCount}</div></article>
+      <article class="summary-tile"><div class="summary-label">Model-edge validation candidates</div><div class="summary-value">${modelEdgeCount}</div></article>
+      <article class="summary-tile"><div class="summary-label">Missing-data audit candidates</div><div class="summary-value">${missingDataCount}</div></article>
+      <article class="summary-tile"><div class="summary-label">Landing-spot-over-profile candidates</div><div class="summary-value">${landingSpotCount}</div></article>
+    </div>
+  `;
+
+  if (!displayRows.length) {
+    const selectedMessage = selectedPlayer?.player_name
+      ? `No journal candidates found for ${escapeHtml(selectedPlayer.player_name)} with active filters.`
+      : 'No journal candidates matched active filters.';
+    dom.journalTableBody.innerHTML = `<tr><td colspan="10" class="meta">${selectedMessage}</td></tr>`;
+  } else {
+    dom.journalTableBody.innerHTML = displayRows
+      .map((candidate) => {
+        const identity = [candidate.player_name || '—', candidate.team || '—', candidate.position || '—'].join(' / ');
+        return `<tr>
+          <td>${escapeHtml(candidate.candidate_id)}</td>
+          <td>${escapeHtml(identity)}</td>
+          <td>${escapeHtml(candidate.entity_type)}</td>
+          <td>${escapeHtml(candidate.claim_summary)}</td>
+          <td>${escapeHtml(candidate.positive_signal_tags.join(', ') || '—')}</td>
+          <td>${escapeHtml(candidate.risk_tags.join(', ') || '—')}</td>
+          <td>${escapeHtml(candidate.context_tags.join(', ') || '—')}</td>
+          <td>${escapeHtml(candidate.model_impact || '—')}</td>
+          <td>${escapeHtml(candidate.confidence)}</td>
+          <td>${escapeHtml(candidate.review_status)}</td>
+        </tr>`;
+      })
+      .join('');
+  }
+
+  if (selectedPlayer?.player_name) {
+    dom.journalSelectedHint.textContent = `Showing journal candidates matching selected player: ${selectedPlayer.player_name}.`;
+  } else {
+    dom.journalSelectedHint.textContent = 'Showing journal candidates for all players/entities.';
+  }
+}
+
 function render() {
   const filtered = state.rows.filter(matchesFilters);
   const sorted = sortRows(filtered);
@@ -372,6 +531,7 @@ function render() {
   renderDetail(selected);
   renderMissingBaselines();
   renderCalibration();
+  renderJournalSignals(selected);
 }
 
 function renderFilterOptions() {
@@ -431,6 +591,31 @@ function wireEvents() {
 
   dom.delta.addEventListener('change', () => {
     state.filters.deltaDirection = dom.delta.value;
+    render();
+  });
+
+  dom.journalSearch.addEventListener('input', () => {
+    state.journalFilters.search = dom.journalSearch.value.trim();
+    render();
+  });
+
+  dom.journalModelEdge.addEventListener('change', () => {
+    state.journalFilters.modelEdge = dom.journalModelEdge.checked;
+    render();
+  });
+
+  dom.journalMissingData.addEventListener('change', () => {
+    state.journalFilters.missingDataAudit = dom.journalMissingData.checked;
+    render();
+  });
+
+  dom.journalRoleOpportunity.addEventListener('change', () => {
+    state.journalFilters.roleOpportunity = dom.journalRoleOpportunity.checked;
+    render();
+  });
+
+  dom.journalNeedsReview.addEventListener('change', () => {
+    state.journalFilters.needsHumanReview = dom.journalNeedsReview.checked;
     render();
   });
 
@@ -512,6 +697,16 @@ async function initialize() {
   } catch (error) {
     state.outcomeSummary = { available: false, rows: [] };
     messages.push('Outcome calibration artifact unavailable.');
+  }
+
+  try {
+    const journalPayload = await loadJson(JOURNAL_SIGNAL_PATH);
+    const rows = (Array.isArray(journalPayload) ? journalPayload : coerceRows(journalPayload)).map(normalizeJournalCandidate);
+    state.journalSignals = { available: true, rows };
+    messages.push(`Loaded operator journal signal artifact (${rows.length} candidates).`);
+  } catch (error) {
+    state.journalSignals = { available: false, rows: [] };
+    messages.push('Operator journal signal artifact unavailable.');
   }
 
   dom.artifactStatus.textContent = messages.join(' ');

--- a/tests/runtime-server.smoke.test.cjs
+++ b/tests/runtime-server.smoke.test.cjs
@@ -129,6 +129,18 @@ test('standalone runtime smoke routes', async (t) => {
     assert.ok(Array.isArray(outcomePayload) || Array.isArray(outcomePayload.rows));
   }
 
+  const journalSignals = await fetch(
+    buildUrl(port, '/data/operator-journal/processed/2026_operator_signal_candidates.json'),
+  );
+  if (journalSignals.status === 404) {
+    assert.ok(true, 'operator journal signal artifact is optional in some runtime bundles');
+  } else {
+    assert.equal(journalSignals.status, 200);
+    assert.match(journalSignals.headers.get('content-type') || '', /application\/json/);
+    const journalPayload = await journalSignals.json();
+    assert.ok(Array.isArray(journalPayload) || Array.isArray(journalPayload.rows));
+  }
+
   const blocked = await fetch(buildUrl(port, '/..%2Fpackage.json'));
   assert.equal(blocked.status, 400);
 });


### PR DESCRIPTION
### Motivation
- Surface Operator Journal Signal Scanner outputs so analysts can inspect human operator notes alongside model outputs in the ML Workbench.
- Provide an inspect-only UI for journal candidates without changing scoring or auto-promotion behavior.
- Gracefully handle missing artifacts by showing a clear unavailable message instead of breaking the workbench.

### Description
- Added a new `Journal Signals` section to `cards/rookies/workbench/index.html` with search and boolean filters and a candidate table showing `candidate_id`, `player_name / team / position`, `entity_type`, `claim_summary`, `positive_signal_tags`, `risk_tags`, `context_tags`, `model_impact`, `confidence`, and `review_status`.
- Wired loading of `data/operator-journal/processed/2026_operator_signal_candidates.json` via a new `JOURNAL_SIGNAL_PATH` in `cards/rookies/workbench/workbench.js` and added `normalizeJournalCandidate`, display/filter logic, selected-player scoping, summary tiles, and graceful unavailable messaging.
- Added UI wiring and boolean filters (`model_edge`, `missing_data_audit`, `role_opportunity`, `needs_human_review`) and search scoping to the new panel, and updated rendering to show matching journal candidates when a player is selected in the main player table.
- Adjusted styles in `cards/rookies/workbench/workbench.css` for the journal controls and compact journal table layout, and updated `tests/runtime-server.smoke.test.cjs` to assert the journal artifact route is served as JSON or optionally 404.

### Testing
- Ran `node --test tests/runtime-server.smoke.test.cjs` which passed successfully and verified HTML routes, CSS/JS assets, and that the journal artifact route either serves JSON or is safely optional (404).
- The workbench JavaScript and CSS assets were fetched by the smoke test and validated as `text/javascript` and `text/css` respectively during the run.
- The new journal artifact loading path is exercised by the smoke test and reports availability or graceful absence as implemented.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed3ea06ec88332bcb2d7727d95c5fd)