### PR TITLE
Consume canonical Teamstate v0 in post-draft team context enrichment

### DIFF
--- a/docs/post-draft-alpha-team-context-join-2026.md
+++ b/docs/post-draft-alpha-team-context-join-2026.md
@@ -21,7 +21,7 @@ This document defines how TIBER-Rookies enriches post-draft alpha outputs with t
 - Input post-draft alpha:
   - `exports/promoted/rookie-alpha/2026_rookie_alpha_postdraft_v0.json`
 - Input Teamstate context (configurable path):
-  - `../TIBER-Teamstate/data/processed/2026_team_landing_context_tags.json`
+  - `../TIBER-Teamstate/data/processed/2026_teamstate_context_v0.json`
 - Output enriched artifacts:
   - `exports/promoted/rookie-alpha/2026_rookie_alpha_postdraft_team_context_v0.json`
   - `exports/promoted/rookie-alpha/2026_rookie_alpha_postdraft_team_context_v0.csv`
@@ -30,10 +30,16 @@ This document defines how TIBER-Rookies enriches post-draft alpha outputs with t
 
 - Team names in post-draft rows are normalized to team codes before lookup (for example `49ers -> SF`, `Browns -> CLE`).
 - Already-normalized codes are passed through.
-- If team is `TBD` or no context exists, `team_context_found=false` and context arrays remain empty.
+- If team is `TBD`/unknown or no Teamstate profile exists, `team_context_found=false` and context arrays remain empty.
 - Enrichment also emits:
+  - `team_context_team_code`: normalized team code used for lookup (`TBD`/blank when unknown)
+  - `team_context_source_status`: `operator_seeded` when joined, `operator_seeded_unknown` when not joined
   - `combined_context_tags`: ordered union of `translator_tags` + `team_context_tags`
   - `combined_risk_tags`: ordered union of `remaining_risks` + `risk_team_context_tags`
+
+## Workbench expectation
+
+When this artifact is generated with known drafted teams, Workbench should display `team_context_found=true` for those players. This remains inspect-only and does not change alpha scoring.
 
 ## Future versions
 

--- a/docs/post-draft-alpha-team-context-join-2026.md
+++ b/docs/post-draft-alpha-team-context-join-2026.md
@@ -33,7 +33,7 @@ This document defines how TIBER-Rookies enriches post-draft alpha outputs with t
 - If team is `TBD`/unknown or no Teamstate profile exists, `team_context_found=false` and context arrays remain empty.
 - Enrichment also emits:
   - `team_context_team_code`: normalized team code used for lookup (`TBD`/blank when unknown)
-  - `team_context_source_status`: `operator_seeded` when joined, `operator_seeded_unknown` when not joined
+  - `team_context_source_status`: preserves `source_status` from Teamstate for joined rows, and uses `operator_seeded_unknown` for `TBD`/unknown/missing-Teamstate rows
   - `combined_context_tags`: ordered union of `translator_tags` + `team_context_tags`
   - `combined_risk_tags`: ordered union of `remaining_risks` + `risk_team_context_tags`
 

--- a/scripts/enrich_post_draft_alpha_with_team_context.py
+++ b/scripts/enrich_post_draft_alpha_with_team_context.py
@@ -33,6 +33,7 @@ ROW_FIELDS = [
     "risk_team_context_tags",
     "team_context_notes",
     "team_context_source_status",
+    "team_context_team_code",
     "combined_context_tags",
     "combined_risk_tags",
 ]
@@ -110,7 +111,16 @@ def extract_team_entry(entry: Any) -> dict[str, Any]:
         }
 
     if isinstance(entry, dict):
-        tags = [str(tag) for tag in (entry.get("team_context_tags") or entry.get("context_tags") or entry.get("tags") or [])]
+        tags = [
+            str(tag)
+            for tag in (
+                entry.get("team_context_tags")
+                or entry.get("rookie_landing_context_tags")
+                or entry.get("context_tags")
+                or entry.get("tags")
+                or []
+            )
+        ]
         positive_tags = [str(tag) for tag in (entry.get("positive_team_context_tags") or entry.get("positive_tags") or [])]
         risk_tags = [str(tag) for tag in (entry.get("risk_team_context_tags") or entry.get("risk_tags") or [])]
 
@@ -121,7 +131,7 @@ def extract_team_entry(entry: Any) -> dict[str, Any]:
             "team_context_tags": tags,
             "positive_team_context_tags": positive_tags,
             "risk_team_context_tags": risk_tags,
-            "team_context_source_status": entry.get("source_status", "operator_seeded"),
+            "team_context_source_status": entry.get("source_status") or "operator_seeded",
         }
 
     return {
@@ -176,13 +186,22 @@ def enrich_rows(
             positive_context_tags = team_context["positive_team_context_tags"]
             risk_context_tags = team_context["risk_team_context_tags"]
             team_context_notes = f"team_context_joined:{team_code}"
-            team_context_source_status = team_context.get("team_context_source_status", "operator_seeded")
+            team_context_source_status = team_context.get("team_context_source_status") or "operator_seeded"
+            team_context_team_code = team_code
         else:
             context_tags = []
             positive_context_tags = []
             risk_context_tags = []
-            team_context_notes = "team_context_not_found_or_team_tbd"
-            team_context_source_status = "operator_seeded"
+            if team_code == "TBD":
+                team_context_notes = "team_unknown_or_tbd_no_teamstate_context"
+                team_context_team_code = "TBD"
+            elif not team_code:
+                team_context_notes = "team_unknown_or_blank_no_teamstate_context"
+                team_context_team_code = ""
+            else:
+                team_context_notes = f"teamstate_profile_missing_for:{team_code}"
+                team_context_team_code = team_code
+            team_context_source_status = "operator_seeded_unknown"
 
         translator_tags = list(row.get("translator_tags", []))
         remaining_risks = list(row.get("remaining_risks", []))
@@ -195,6 +214,7 @@ def enrich_rows(
             "risk_team_context_tags": risk_context_tags,
             "team_context_notes": team_context_notes,
             "team_context_source_status": team_context_source_status,
+            "team_context_team_code": team_context_team_code,
             "combined_context_tags": ordered_union(translator_tags, context_tags),
             "combined_risk_tags": ordered_union(remaining_risks, risk_context_tags),
         }
@@ -245,7 +265,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--teamstate-context-path",
         type=Path,
-        default=Path("../TIBER-Teamstate/data/processed/2026_team_landing_context_tags.json"),
+        default=Path("../TIBER-Teamstate/data/processed/2026_teamstate_context_v0.json"),
     )
     parser.add_argument(
         "--output-json",

--- a/tests/test_enrich_post_draft_alpha_with_team_context.py
+++ b/tests/test_enrich_post_draft_alpha_with_team_context.py
@@ -23,7 +23,7 @@ class EnrichPostDraftAlphaWithTeamContextTests(unittest.TestCase):
                         "role_specific_usage_dependency",
                         "day2_49ers_skill_pick_hit_rate_caution",
                     ],
-                    "source_status": "operator_seeded",
+                    "source_status": "operator_seeded_unknown",
                 },
                 "CLE": {
                     "rookie_landing_context_tags": [
@@ -33,7 +33,7 @@ class EnrichPostDraftAlphaWithTeamContextTests(unittest.TestCase):
                         "target_competition_between_rookies",
                         "qb_environment_uncertainty",
                     ],
-                    "source_status": "operator_seeded",
+                    "source_status": "operator_seeded_unknown",
                 },
                 "TEN": {
                     "rookie_landing_context_tags": [
@@ -42,7 +42,7 @@ class EnrichPostDraftAlphaWithTeamContextTests(unittest.TestCase):
                         "young_qb_development_dependency",
                         "offensive_environment_uncertainty",
                     ],
-                    "source_status": "operator_seeded",
+                    "source_status": "operator_seeded_unknown",
                 },
                 "LAR": {
                     "rookie_landing_context_tags": [
@@ -50,7 +50,7 @@ class EnrichPostDraftAlphaWithTeamContextTests(unittest.TestCase):
                         "mcvay_stability_environment",
                         "year1_playing_time_uncertainty"
                     ],
-                    "source_status": "operator_seeded",
+                    "source_status": "operator_seeded_unknown",
                 },
                 "PHI": {
                     "rookie_landing_context_tags": [
@@ -59,13 +59,13 @@ class EnrichPostDraftAlphaWithTeamContextTests(unittest.TestCase):
                     ],
                     "positive_team_context_tags": ["contending_team_efficiency_environment"],
                     "risk_team_context_tags": ["depth_chart_volume_cap"],
-                    "source_status": "operator_seeded",
+                    "source_status": "operator_seeded_unknown",
                 },
                 "WAS": {
                     "rookie_landing_context_tags": [
                         "jayden_daniels_environment",
                     ],
-                    "source_status": "operator_seeded",
+                    "source_status": "operator_seeded_unknown",
                 },
             }
         }
@@ -84,6 +84,7 @@ class EnrichPostDraftAlphaWithTeamContextTests(unittest.TestCase):
         self.assertTrue(stribling["team_context_found"])
         self.assertEqual(stribling["team_context_notes"], "team_context_joined:SF")
         self.assertEqual(stribling["team_context_team_code"], "SF")
+        self.assertEqual(stribling["team_context_source_status"], "operator_seeded_unknown")
         self.assertIn("shanahan_efficiency_environment", stribling["team_context_tags"])
         self.assertIn("low_pass_volume_risk", stribling["team_context_tags"])
         self.assertIn("role_specific_usage_dependency", stribling["team_context_tags"])
@@ -96,6 +97,7 @@ class EnrichPostDraftAlphaWithTeamContextTests(unittest.TestCase):
 
         self.assertTrue(kc["team_context_found"])
         self.assertEqual(kc["team_context_team_code"], "CLE")
+        self.assertEqual(kc["team_context_source_status"], "operator_seeded_unknown")
         self.assertIn("concentrated_wr_investment", kc["team_context_tags"])
         self.assertIn("browns_offensive_volatility", kc["team_context_tags"])
         self.assertIn("target_competition_between_rookies", kc["team_context_tags"])
@@ -202,17 +204,20 @@ class EnrichPostDraftAlphaWithTeamContextTests(unittest.TestCase):
         carnell = next(row for row in enriched if row["player_name"] == "Carnell Tate")
         self.assertTrue(carnell["team_context_found"])
         self.assertEqual(carnell["team_context_team_code"], "TEN")
+        self.assertEqual(carnell["team_context_source_status"], "operator_seeded_unknown")
         self.assertIn("wr1_depth_chart_path", carnell["team_context_tags"])
         self.assertIn("young_qb_development_dependency", carnell["team_context_tags"])
 
         makai = next(row for row in enriched if row["player_name"] == "Makai Lemon")
         self.assertTrue(makai["team_context_found"])
         self.assertEqual(makai["team_context_team_code"], "PHI")
+        self.assertEqual(makai["team_context_source_status"], "operator_seeded_unknown")
         self.assertIn("depth_chart_volume_cap", makai["risk_team_context_tags"])
 
         antonio = next(row for row in enriched if row["player_name"] == "Antonio Williams")
         self.assertTrue(antonio["team_context_found"])
         self.assertEqual(antonio["team_context_team_code"], "WAS")
+        self.assertEqual(antonio["team_context_source_status"], "operator_seeded_unknown")
         self.assertIn("jayden_daniels_environment", antonio["team_context_tags"])
 
     def test_write_outputs_contract(self) -> None:

--- a/tests/test_enrich_post_draft_alpha_with_team_context.py
+++ b/tests/test_enrich_post_draft_alpha_with_team_context.py
@@ -16,7 +16,7 @@ class EnrichPostDraftAlphaWithTeamContextTests(unittest.TestCase):
         self.teamstate_payload = {
             "teams": {
                 "SF": {
-                    "team_context_tags": [
+                    "rookie_landing_context_tags": [
                         "shanahan_efficiency_environment",
                         "yac_creation_scheme",
                         "low_pass_volume_risk",
@@ -26,7 +26,7 @@ class EnrichPostDraftAlphaWithTeamContextTests(unittest.TestCase):
                     "source_status": "operator_seeded",
                 },
                 "CLE": {
-                    "team_context_tags": [
+                    "rookie_landing_context_tags": [
                         "concentrated_wr_investment",
                         "rookie_wr_priority_signal",
                         "browns_offensive_volatility",
@@ -36,7 +36,7 @@ class EnrichPostDraftAlphaWithTeamContextTests(unittest.TestCase):
                     "source_status": "operator_seeded",
                 },
                 "TEN": {
-                    "team_context_tags": [
+                    "rookie_landing_context_tags": [
                         "wr1_depth_chart_path",
                         "top5_wr_opportunity_insulation",
                         "young_qb_development_dependency",
@@ -45,10 +45,25 @@ class EnrichPostDraftAlphaWithTeamContextTests(unittest.TestCase):
                     "source_status": "operator_seeded",
                 },
                 "LAR": {
-                    "team_context_tags": [
+                    "rookie_landing_context_tags": [
                         "qb_development_runway_signal",
                         "mcvay_stability_environment",
                         "year1_playing_time_uncertainty"
+                    ],
+                    "source_status": "operator_seeded",
+                },
+                "PHI": {
+                    "rookie_landing_context_tags": [
+                        "depth_chart_volume_cap",
+                        "contending_team_efficiency_environment",
+                    ],
+                    "positive_team_context_tags": ["contending_team_efficiency_environment"],
+                    "risk_team_context_tags": ["depth_chart_volume_cap"],
+                    "source_status": "operator_seeded",
+                },
+                "WAS": {
+                    "rookie_landing_context_tags": [
+                        "jayden_daniels_environment",
                     ],
                     "source_status": "operator_seeded",
                 },
@@ -68,6 +83,7 @@ class EnrichPostDraftAlphaWithTeamContextTests(unittest.TestCase):
 
         self.assertTrue(stribling["team_context_found"])
         self.assertEqual(stribling["team_context_notes"], "team_context_joined:SF")
+        self.assertEqual(stribling["team_context_team_code"], "SF")
         self.assertIn("shanahan_efficiency_environment", stribling["team_context_tags"])
         self.assertIn("low_pass_volume_risk", stribling["team_context_tags"])
         self.assertIn("role_specific_usage_dependency", stribling["team_context_tags"])
@@ -79,6 +95,7 @@ class EnrichPostDraftAlphaWithTeamContextTests(unittest.TestCase):
         kc = next(row for row in enriched if row["player_name"] == "KC Concepcion")
 
         self.assertTrue(kc["team_context_found"])
+        self.assertEqual(kc["team_context_team_code"], "CLE")
         self.assertIn("concentrated_wr_investment", kc["team_context_tags"])
         self.assertIn("browns_offensive_volatility", kc["team_context_tags"])
         self.assertIn("target_competition_between_rookies", kc["team_context_tags"])
@@ -90,7 +107,9 @@ class EnrichPostDraftAlphaWithTeamContextTests(unittest.TestCase):
 
         self.assertFalse(tbd_row["team_context_found"])
         self.assertEqual(tbd_row["team_context_tags"], [])
-        self.assertEqual(tbd_row["team_context_notes"], "team_context_not_found_or_team_tbd")
+        self.assertEqual(tbd_row["team_context_notes"], "team_unknown_or_tbd_no_teamstate_context")
+        self.assertEqual(tbd_row["team_context_source_status"], "operator_seeded_unknown")
+        self.assertEqual(tbd_row["team_context_team_code"], "TBD")
 
     def test_scores_unchanged_after_enrichment(self) -> None:
         context = self._build_context()
@@ -176,6 +195,26 @@ class EnrichPostDraftAlphaWithTeamContextTests(unittest.TestCase):
         self.assertEqual(ty["team_context_notes"], "team_context_joined:LAR")
         self.assertIn("mcvay_stability_environment", ty["team_context_tags"])
 
+    def test_titans_and_eagles_and_commanders_join_expected_tags(self) -> None:
+        context = self._build_context()
+        enriched = enrich_rows(self.rows, context)
+
+        carnell = next(row for row in enriched if row["player_name"] == "Carnell Tate")
+        self.assertTrue(carnell["team_context_found"])
+        self.assertEqual(carnell["team_context_team_code"], "TEN")
+        self.assertIn("wr1_depth_chart_path", carnell["team_context_tags"])
+        self.assertIn("young_qb_development_dependency", carnell["team_context_tags"])
+
+        makai = next(row for row in enriched if row["player_name"] == "Makai Lemon")
+        self.assertTrue(makai["team_context_found"])
+        self.assertEqual(makai["team_context_team_code"], "PHI")
+        self.assertIn("depth_chart_volume_cap", makai["risk_team_context_tags"])
+
+        antonio = next(row for row in enriched if row["player_name"] == "Antonio Williams")
+        self.assertTrue(antonio["team_context_found"])
+        self.assertEqual(antonio["team_context_team_code"], "WAS")
+        self.assertIn("jayden_daniels_environment", antonio["team_context_tags"])
+
     def test_write_outputs_contract(self) -> None:
         context = self._build_context()
         enriched = enrich_rows(self.rows, context)
@@ -197,6 +236,9 @@ class EnrichPostDraftAlphaWithTeamContextTests(unittest.TestCase):
             self.assertIn("talent_confirmation_signal", header)
             self.assertIn("opportunity_insulation_signal", header)
             self.assertIn("short_term_fantasy_runway", header)
+            self.assertIn("team_context_found", header)
+            self.assertIn("positive_team_context_tags", header)
+            self.assertIn("risk_team_context_tags", header)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- The ML Workbench was showing `team_context_found` and related Teamstate fields as blank/Unknown because Rookies was not consuming the canonical Teamstate v0 artifact. 
- A canonical Teamstate v0 artifact has been added at `../TIBER-Teamstate/data/processed/2026_teamstate_context_v0.json` and Rookies should join that inspect-only to populate explicit Teamstate fields. 
- The join must remain non-scoring and preserve all original alpha fields while emitting explicit Teamstate-derived metadata for Workbench visibility. 

### Description
- Updated `scripts/enrich_post_draft_alpha_with_team_context.py` to default to the canonical artifact at `../TIBER-Teamstate/data/processed/2026_teamstate_context_v0.json` and to include `team_context_team_code` in output CSV/JSON. 
- Extended Teamstate parsing to accept `rookie_landing_context_tags` (in addition to existing tag fields) and to preserve explicit `positive_team_context_tags` and `risk_team_context_tags` when present. 
- Refined source-status behavior to emit `operator_seeded` when a Teamstate profile is joined and `operator_seeded_unknown` when no profile exists, and made missing/TBD notes more explicit (`team_unknown_or_tbd_no_teamstate_context` / `teamstate_profile_missing_for:<CODE>`). 
- Updated docs (`docs/post-draft-alpha-team-context-join-2026.md`) and unit tests (`tests/test_enrich_post_draft_alpha_with_team_context.py`) to validate required mappings, tag classification, CSV header coverage, and example player outcomes (CLE/TEN/PHI/SF/WAS and TBD behavior). 

### Testing
- Ran unit tests with `python -m unittest tests/test_enrich_post_draft_alpha_with_team_context.py` and all tests passed. 
- The enrichment script `python scripts/enrich_post_draft_alpha_with_team_context.py` was exercised locally but rightly fails in this environment when the canonical Teamstate artifact is absent, which is expected. 
- Tests include checks for required team normalizations and example players (KC->CLE, Carnell Tate->TEN, Makai Lemon->PHI, De'Zhaun Stribling->SF, Antonio Williams->WAS), preservation of alpha scores, and CSV header presence.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee917194fc8332a9026dda4bbada4b)