### PR TITLE
Fail loudly by default when role-opportunity artifacts are missing

### DIFF
--- a/scripts/enrich_post_draft_alpha_with_role_opportunity.py
+++ b/scripts/enrich_post_draft_alpha_with_role_opportunity.py
@@ -226,6 +226,28 @@ def load_role_baselines(path: Path) -> dict[str, dict[str, Any]]:
     return baselines
 
 
+def ensure_required_role_artifacts(
+    team_role_profiles_path: Path,
+    role_baselines_path: Path,
+    *,
+    allow_missing_role_artifacts: bool,
+) -> None:
+    if allow_missing_role_artifacts:
+        return
+
+    missing_paths = [path for path in (team_role_profiles_path, role_baselines_path) if not path.exists()]
+    if not missing_paths:
+        return
+
+    missing_paths_formatted = ", ".join(str(path) for path in missing_paths)
+    raise FileNotFoundError(
+        "Missing required role artifact(s): "
+        f"{missing_paths_formatted}. "
+        "Suggested fix: git clone https://github.com/Prometheus-Frameworks/Role-and-opportunity-model.git "
+        "or rerun with --allow-missing-role-artifacts for explicit partial builds."
+    )
+
+
 def enrich_rows(
     postdraft_rows: list[dict[str, Any]],
     team_role_profiles_by_team: dict[str, list[dict[str, Any]]],
@@ -373,6 +395,11 @@ def parse_args() -> argparse.Namespace:
         type=Path,
         default=Path("exports/promoted/rookie-alpha/2026_rookie_alpha_postdraft_role_context_v0.csv"),
     )
+    parser.add_argument(
+        "--allow-missing-role-artifacts",
+        action="store_true",
+        help="Allow fallback empty role context when role artifacts are missing.",
+    )
     return parser.parse_args()
 
 
@@ -380,6 +407,11 @@ def main() -> None:
     args = parse_args()
     postdraft_payload = json.loads(args.postdraft_path.read_text(encoding="utf-8"))
     rows = postdraft_payload.get("rows", []) if isinstance(postdraft_payload, dict) else []
+    ensure_required_role_artifacts(
+        args.team_role_profiles_path,
+        args.role_baselines_path,
+        allow_missing_role_artifacts=args.allow_missing_role_artifacts,
+    )
     team_profiles = load_team_role_profiles(args.team_role_profiles_path)
     baselines = load_role_baselines(args.role_baselines_path)
 

--- a/tests/test_enrich_post_draft_alpha_with_role_opportunity.py
+++ b/tests/test_enrich_post_draft_alpha_with_role_opportunity.py
@@ -4,7 +4,13 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from scripts.enrich_post_draft_alpha_with_role_opportunity import enrich_rows, load_role_baselines, load_team_role_profiles, write_outputs
+from scripts.enrich_post_draft_alpha_with_role_opportunity import (
+    enrich_rows,
+    ensure_required_role_artifacts,
+    load_role_baselines,
+    load_team_role_profiles,
+    write_outputs,
+)
 
 
 class EnrichPostDraftAlphaWithRoleOpportunityTests(unittest.TestCase):
@@ -198,6 +204,57 @@ class EnrichPostDraftAlphaWithRoleOpportunityTests(unittest.TestCase):
         self.assertIn("role_baseline_found", header)
         self.assertIn("candidate_roles", header)
         self.assertIn("combined_context_tags_with_role", header)
+
+    def test_missing_team_role_profiles_path_fails_by_default(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            existing_role_baselines = Path(temp_dir) / "role_baselines.json"
+            existing_role_baselines.write_text(json.dumps(self.role_baselines_payload), encoding="utf-8")
+            missing_team_profiles = Path(temp_dir) / "missing_team_profiles.json"
+
+            with self.assertRaises(FileNotFoundError) as context:
+                ensure_required_role_artifacts(
+                    missing_team_profiles,
+                    existing_role_baselines,
+                    allow_missing_role_artifacts=False,
+                )
+
+        message = str(context.exception)
+        self.assertIn(str(missing_team_profiles), message)
+        self.assertIn("git clone https://github.com/Prometheus-Frameworks/Role-and-opportunity-model.git", message)
+
+    def test_missing_role_baselines_path_fails_by_default(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            existing_team_profiles = Path(temp_dir) / "team_profiles.json"
+            existing_team_profiles.write_text(json.dumps(self.team_profiles_payload), encoding="utf-8")
+            missing_role_baselines = Path(temp_dir) / "missing_role_baselines.json"
+
+            with self.assertRaises(FileNotFoundError) as context:
+                ensure_required_role_artifacts(
+                    existing_team_profiles,
+                    missing_role_baselines,
+                    allow_missing_role_artifacts=False,
+                )
+
+        message = str(context.exception)
+        self.assertIn(str(missing_role_baselines), message)
+        self.assertIn("git clone https://github.com/Prometheus-Frameworks/Role-and-opportunity-model.git", message)
+
+    def test_allow_missing_role_artifacts_preserves_empty_role_context_behavior(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            missing_team_profiles = Path(temp_dir) / "missing_team_profiles.json"
+            missing_role_baselines = Path(temp_dir) / "missing_role_baselines.json"
+
+            ensure_required_role_artifacts(
+                missing_team_profiles,
+                missing_role_baselines,
+                allow_missing_role_artifacts=True,
+            )
+            enriched = enrich_rows(self.rows, load_team_role_profiles(missing_team_profiles), load_role_baselines(missing_role_baselines))
+
+        self.assertTrue(enriched)
+        self.assertTrue(all(row["role_team_profile_found"] is False for row in enriched))
+        self.assertTrue(all(row["role_baseline_found"] is False for row in enriched))
+        self.assertTrue(all(row["role_opportunity_found"] is False for row in enriched))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- The role-opportunity enrichment script was producing plausible-looking but empty outputs when the external `Role-and-opportunity-model` artifacts were not present, which is dangerous for downstream consumers. 
- The intent is to make missing required role artifacts an explicit, visible failure by default while allowing an opt-in fallback for partial builds.

### Description
- Added `ensure_required_role_artifacts(...)` to validate presence of both team role profiles and role baselines and raise a clear `FileNotFoundError` that includes the missing path(s) and the suggested fix `git clone https://github.com/Prometheus-Frameworks/Role-and-opportunity-model.git` when missing. 
- Wired the validator into `main()` in `scripts/enrich_post_draft_alpha_with_role_opportunity.py` so validation runs before loading role data. 
- Added a CLI opt-in flag `--allow-missing-role-artifacts` which preserves the previous empty/fallback behavior when explicitly requested. 
- Updated tests in `tests/test_enrich_post_draft_alpha_with_role_opportunity.py` to cover missing-path failures and the opt-in fallback, without changing scoring or generated artifact formats.

### Testing
- Ran targeted tests with `pytest -q tests/test_enrich_post_draft_alpha_with_role_opportunity.py` and observed the new and existing tests passing. 
- Ran the full test suite with `pytest -q` and observed all tests passing. 
- New tests assert that missing team profiles or missing baselines raise `FileNotFoundError` by default and that `--allow-missing-role-artifacts` permits the fallback empty role context. 
- No other tests regressed and artifact outputs/schema were not changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eeaf6a4e988332bae1f69939797719)