### PR TITLE
Add Brenen Thompson operator journal entry and inspect-only signal candidates

### DIFF
--- a/data/operator-journal/processed/2026_operator_signal_candidates.json
+++ b/data/operator-journal/processed/2026_operator_signal_candidates.json
@@ -386,5 +386,91 @@
     "needs_verification": true,
     "source_type": "operator_journal",
     "review_status": "needs_human_review"
+  },
+  {
+    "candidate_id": "cand_oj_2026_011_brenen_thompson_chargers_profile_completeness_audit",
+    "source_entry_id": "oj_2026_011_brenen_thompson_chargers",
+    "entity_type": "player",
+    "player_name": "Brenen Thompson",
+    "team": "Chargers",
+    "position": "WR",
+    "related_entities": [],
+    "claim_summary": "TIBER profile may be incomplete or stale because the writeup says production profile pending CFBD fetch and no translation evidence tags available, despite available 2025 production/YPRR/aDOT/separation evidence.",
+    "positive_signal_tags": [
+      "production_data_available",
+      "translation_evidence_available",
+      "sec_2025_breakout",
+      "vertical_efficiency_signal"
+    ],
+    "risk_tags": [
+      "stale_profile_writeup",
+      "missing_translation_evidence_tags",
+      "possible_undergraded_production",
+      "profile_data_completeness_risk"
+    ],
+    "context_tags": [
+      "missing_data_audit",
+      "production_profile_pending_conflict",
+      "no_translation_tags_conflict",
+      "predraft_alpha_44_2",
+      "production_grade_43_7"
+    ],
+    "model_impact": "review_player_profile_data_completeness_before_final_role_take",
+    "downstream_repos": [
+      "TIBER-Rookies"
+    ],
+    "confidence": "high",
+    "needs_verification": true,
+    "source_type": "operator_journal",
+    "review_status": "needs_human_review",
+    "candidate_theme": "profile_completeness_audit"
+  },
+  {
+    "candidate_id": "cand_oj_2026_011_brenen_thompson_chargers_vertical_role_watch",
+    "source_entry_id": "oj_2026_011_brenen_thompson_chargers",
+    "entity_type": "player",
+    "player_name": "Brenen Thompson",
+    "team": "Chargers",
+    "position": "WR",
+    "related_entities": [],
+    "claim_summary": "Brenen Thompson has legitimate elite-speed vertical-stretcher traits and SEC production, but likely opens as a rotational WR4 whose fantasy path depends on a future Chargers depth-chart opening.",
+    "positive_signal_tags": [
+      "elite_speed_archetype",
+      "vertical_field_stretcher",
+      "sec_receiving_yardage_leader",
+      "explosive_yards_per_catch",
+      "power4_yprr_signal",
+      "cushion_creator",
+      "ball_tracking_downfield",
+      "adjusted_contested_target_rate_signal"
+    ],
+    "risk_tags": [
+      "rotational_wr4_path",
+      "low_volume_role_risk",
+      "undersized_frame_risk",
+      "durability_risk",
+      "limited_target_earning_profile",
+      "limited_prior_production",
+      "contested_catch_risk",
+      "drop_rate_risk",
+      "chargers_depth_chart_block",
+      "deep_protection_dependency"
+    ],
+    "context_tags": [
+      "predraft_alpha_44_2",
+      "tiber_edge_plus_4_7",
+      "chargers_vertical_role_watch",
+      "qj_future_departure_contingency"
+    ],
+    "model_impact": "track_as_vertical_role_watch_not_immediate_fantasy_bump",
+    "downstream_repos": [
+      "TIBER-Rookies",
+      "Role-and-Opportunity"
+    ],
+    "confidence": "medium",
+    "needs_verification": true,
+    "source_type": "operator_journal",
+    "review_status": "needs_human_review",
+    "candidate_theme": "vertical_field_stretcher_role_watch"
   }
 ]

--- a/data/operator-journal/raw/2026_rookie_journal_entries.json
+++ b/data/operator-journal/raw/2026_rookie_journal_entries.json
@@ -88,5 +88,14 @@
     "source_type": "operator_journal",
     "operator": "local",
     "review_status": "raw"
+  },
+  {
+    "entry_id": "oj_2026_011_brenen_thompson_chargers",
+    "entry_date": "2026-04-27",
+    "entry_title": "Brenen Thompson Chargers vertical role and model profile audit",
+    "entry_text": "Brenen Thompson is probably a rotational WR4 in the Chargers offense initially. He could take over as the primary field-stretcher if Quentin Johnston leaves after this year, but there is limited hope for a legitimate fantasy role without a depth-chart opening. The positive signal is his game speed. He has 4.26 speed, ridiculous field speed, and forces major cushion from defenders. He averaged strong yards per route in the SEC, led the SEC in receiving yards in 2025, and produced 57 receptions, 1,054 receiving yards, 18.49 yards per catch, 6 receiving TDs, and 1 rushing TD. He was third-team All-SEC and led the SEC in receiving yards. His profile includes elite aDOT / vertical production, strong Power 4 YPRR signal, ball tracking downfield, and a top adjusted contested target rate/separation signal. Concerns include being 5'9/164, fragile frame/durability risk, limited production before 2025, small catch radius, five drops in 2025, 35.3% career contested catch rate, limited target-earning profile, and likely low-volume field-stretcher role. The current TIBER writeup says production profile pending CFBD fetch and no translation evidence tags available, which appears stale/incomplete given the 2025 data and collected evidence. Pre-draft grade was 44.2 with ATH 50.0, production 43.7, draft capital 35.0, and model edge +4.7.",
+    "source_type": "operator_journal",
+    "operator": "local",
+    "review_status": "raw"
   }
 ]

--- a/docs/operator-journal-signal-scanner.md
+++ b/docs/operator-journal-signal-scanner.md
@@ -54,6 +54,7 @@ Model-edge notes can be positive or negative and are always treated as candidate
 - Positive model edge plus NFL/landing-spot confirmation is a validation-watch candidate.
 - Negative model edge plus better landing spot is tracked as a "landing spot over profile" candidate.
 - Missing-data observations become audit candidates and profile-completeness review tasks, not retroactive score edits.
+- Journal entries may also flag stale model writeups/profile-completeness conflicts as a separate inspect-only audit candidate from landing-spot role takes.
 
 Only reviewed/promoted items should be consumed by Teamstate, Role-Opportunity, post-draft alpha, or any TIBER-Data downstream workflows. The scanner's goal is to turn hobby notes into a repeatable information layer without bypassing model governance.
 

--- a/scripts/build_operator_signal_candidates.py
+++ b/scripts/build_operator_signal_candidates.py
@@ -370,6 +370,91 @@ def build_candidates_for_entry(entry: dict[str, Any]) -> list[dict[str, Any]]:
         )
         return [candidate]
 
+    if "brenen_thompson_chargers" in entry_id:
+        vertical_role_watch = _base_candidate(entry, "vertical_role_watch", "player")
+        vertical_role_watch.update(
+            {
+                "player_name": "Brenen Thompson",
+                "team": "Chargers",
+                "position": "WR",
+                "candidate_theme": "vertical_field_stretcher_role_watch",
+                "claim_summary": (
+                    "Brenen Thompson has legitimate elite-speed vertical-stretcher traits and SEC "
+                    "production, but likely opens as a rotational WR4 whose fantasy path depends on a "
+                    "future Chargers depth-chart opening."
+                ),
+                "positive_signal_tags": [
+                    "elite_speed_archetype",
+                    "vertical_field_stretcher",
+                    "sec_receiving_yardage_leader",
+                    "explosive_yards_per_catch",
+                    "power4_yprr_signal",
+                    "cushion_creator",
+                    "ball_tracking_downfield",
+                    "adjusted_contested_target_rate_signal",
+                ],
+                "risk_tags": [
+                    "rotational_wr4_path",
+                    "low_volume_role_risk",
+                    "undersized_frame_risk",
+                    "durability_risk",
+                    "limited_target_earning_profile",
+                    "limited_prior_production",
+                    "contested_catch_risk",
+                    "drop_rate_risk",
+                    "chargers_depth_chart_block",
+                    "deep_protection_dependency",
+                ],
+                "context_tags": [
+                    "predraft_alpha_44_2",
+                    "tiber_edge_plus_4_7",
+                    "chargers_vertical_role_watch",
+                    "qj_future_departure_contingency",
+                ],
+                "model_impact": "track_as_vertical_role_watch_not_immediate_fantasy_bump",
+                "downstream_repos": ["TIBER-Rookies", "Role-and-Opportunity"],
+                "confidence": "medium",
+            }
+        )
+
+        profile_completeness_audit = _base_candidate(entry, "profile_completeness_audit", "player")
+        profile_completeness_audit.update(
+            {
+                "player_name": "Brenen Thompson",
+                "team": "Chargers",
+                "position": "WR",
+                "candidate_theme": "profile_completeness_audit",
+                "claim_summary": (
+                    "TIBER profile may be incomplete or stale because the writeup says production profile "
+                    "pending CFBD fetch and no translation evidence tags available, despite available 2025 "
+                    "production/YPRR/aDOT/separation evidence."
+                ),
+                "positive_signal_tags": [
+                    "production_data_available",
+                    "translation_evidence_available",
+                    "sec_2025_breakout",
+                    "vertical_efficiency_signal",
+                ],
+                "risk_tags": [
+                    "stale_profile_writeup",
+                    "missing_translation_evidence_tags",
+                    "possible_undergraded_production",
+                    "profile_data_completeness_risk",
+                ],
+                "context_tags": [
+                    "missing_data_audit",
+                    "production_profile_pending_conflict",
+                    "no_translation_tags_conflict",
+                    "predraft_alpha_44_2",
+                    "production_grade_43_7",
+                ],
+                "model_impact": "review_player_profile_data_completeness_before_final_role_take",
+                "downstream_repos": ["TIBER-Rookies"],
+                "confidence": "high",
+            }
+        )
+        return [vertical_role_watch, profile_completeness_audit]
+
     return []
 
 

--- a/tests/test_build_operator_signal_candidates.py
+++ b/tests/test_build_operator_signal_candidates.py
@@ -71,6 +71,35 @@ class BuildOperatorSignalCandidatesTests(unittest.TestCase):
         self.assertIn("man_coverage_struggle", fields["risk_tags"])
         self.assertIn("year1_route_path", fields["positive_signal_tags"])
 
+    def test_brenen_thompson_vertical_role_candidate_exists_with_key_tags(self) -> None:
+        brenen_vertical = next(
+            c
+            for c in self.candidates
+            if c["player_name"] == "Brenen Thompson"
+            and c.get("candidate_theme") == "vertical_field_stretcher_role_watch"
+        )
+        self.assertIn("elite_speed_archetype", brenen_vertical["positive_signal_tags"])
+        self.assertIn("vertical_field_stretcher", brenen_vertical["positive_signal_tags"])
+        self.assertIn("rotational_wr4_path", brenen_vertical["risk_tags"])
+        self.assertIn("undersized_frame_risk", brenen_vertical["risk_tags"])
+
+    def test_brenen_thompson_profile_audit_candidate_exists_with_key_tags(self) -> None:
+        brenen_audit = next(
+            c
+            for c in self.candidates
+            if c["player_name"] == "Brenen Thompson" and c.get("candidate_theme") == "profile_completeness_audit"
+        )
+        self.assertIn("missing_data_audit", brenen_audit["context_tags"])
+        self.assertIn("stale_profile_writeup", brenen_audit["risk_tags"])
+        self.assertIn("missing_translation_evidence_tags", brenen_audit["risk_tags"])
+
+    def test_brenen_thompson_candidates_are_operator_journal_needs_review(self) -> None:
+        brenen_candidates = [c for c in self.candidates if c["player_name"] == "Brenen Thompson"]
+        self.assertEqual(len(brenen_candidates), 2)
+        for candidate in brenen_candidates:
+            self.assertEqual(candidate["source_type"], "operator_journal")
+            self.assertEqual(candidate["review_status"], "needs_human_review")
+
     def test_all_candidates_are_operator_journal_source(self) -> None:
         for candidate in self.candidates:
             self.assertEqual(candidate["source_type"], "operator_journal")


### PR DESCRIPTION
### Motivation
- Add a post-draft operator journal entry for Brenen Thompson to capture vertical-field-stretcher observations and surface potential profile-completeness issues for Workbench review.
- Create deterministic, inspect-only candidates so analysts can review a landing-path watch and a profile audit without changing model scores or alpha artifacts.
- Keep governance intact: source type remains `operator_journal`, review status defaults to `needs_human_review`, candidate IDs stay derived from the source entry, and no auto-promotion or scoring changes are introduced.

### Description
- Appended the raw journal entry `oj_2026_011_brenen_thompson_chargers` to `data/operator-journal/raw/2026_rookie_journal_entries.json` containing the provided post-draft research text. 
- Added deterministic mapping rules to `scripts/build_operator_signal_candidates.py` that emit two player candidates for that entry: a `vertical_field_stretcher_role_watch` and a `profile_completeness_audit`, each with the requested positive/risk/context tags, `model_impact`, `downstream_repos`, `confidence`, `source_type`, and `review_status` defaults. 
- Regenerated `data/operator-journal/processed/2026_operator_signal_candidates.json` so both new candidates are present with unique `candidate_id` values derived from the source entry. 
- Added unit tests in `tests/test_build_operator_signal_candidates.py` to assert presence and tag coverage for both Brenen Thompson candidates and updated `docs/operator-journal-signal-scanner.md` to note that journal entries can emit separate stale-writeup/profile-completeness audit candidates.

### Testing
- Ran the builder with `python scripts/build_operator_signal_candidates.py` and it completed successfully and regenerated processed candidates. 
- Ran the test suite with `python -m unittest tests/test_build_operator_signal_candidates.py` and all tests passed (`Ran 20 tests — OK`).
- Verified the processed output contains two Brenen Thompson candidates (`cand_oj_2026_011_brenen_thompson_chargers_profile_completeness_audit` and `cand_oj_2026_011_brenen_thompson_chargers_vertical_role_watch`) with `source_type: operator_journal` and `review_status: needs_human_review`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eeba132c508332a4f3efd7fc06122e)