### PR TITLE
Prefer role-context artifact in ML Workbench with graceful fallback chain

### DIFF
--- a/cards/rookies/workbench/workbench.js
+++ b/cards/rookies/workbench/workbench.js
@@ -1,4 +1,5 @@
 import { downloadCsv } from '/lib/rookies/exportCsv.js';
+import { normalizeFullRoleOpportunityFound } from '/lib/rookies/workbench/roleOpportunityNormalization.mjs';
 
 const ROLE_CONTEXT_PATH = '../../../exports/promoted/rookie-alpha/2026_rookie_alpha_postdraft_role_context_v0.json';
 const TEAM_CONTEXT_PATH = '../../../exports/promoted/rookie-alpha/2026_rookie_alpha_postdraft_team_context_v0.json';
@@ -125,12 +126,7 @@ function normalizeRow(row, index) {
           ? row.role_profile_found
           : null,
     role_baseline_found: typeof row.role_baseline_found === 'boolean' ? row.role_baseline_found : null,
-    full_role_opportunity_found:
-      typeof row.full_role_opportunity_found === 'boolean'
-        ? row.full_role_opportunity_found
-        : typeof row.role_opportunity_found === 'boolean'
-          ? row.role_opportunity_found
-          : null,
+    full_role_opportunity_found: normalizeFullRoleOpportunityFound(row),
   };
 }
 

--- a/cards/rookies/workbench/workbench.js
+++ b/cards/rookies/workbench/workbench.js
@@ -1,6 +1,7 @@
 import { downloadCsv } from '/lib/rookies/exportCsv.js';
 
-const PRIMARY_CONTEXT_PATH = '../../../exports/promoted/rookie-alpha/2026_rookie_alpha_postdraft_team_context_v0.json';
+const ROLE_CONTEXT_PATH = '../../../exports/promoted/rookie-alpha/2026_rookie_alpha_postdraft_role_context_v0.json';
+const TEAM_CONTEXT_PATH = '../../../exports/promoted/rookie-alpha/2026_rookie_alpha_postdraft_team_context_v0.json';
 const POST_DRAFT_FALLBACK_PATH = '../../../exports/promoted/rookie-alpha/2026_rookie_alpha_postdraft_v0.json';
 const MISSING_BASELINE_PATH = '../../../exports/promoted/rookie-alpha/2026_rookie_alpha_postdraft_missing_baselines_v0.json';
 const OUTCOME_SUMMARY_PATH = '../../../exports/promoted/nfl-fantasy-outcomes/context_flag_outcome_summary_v1.json';
@@ -959,23 +960,32 @@ async function initialize() {
   const messages = [];
 
   try {
-    const primaryPayload = await loadJson(PRIMARY_CONTEXT_PATH);
-    const rows = coerceRows(primaryPayload).map(normalizeRow);
+    const rolePayload = await loadJson(ROLE_CONTEXT_PATH);
+    const rows = coerceRows(rolePayload).map(normalizeRow);
     state.rows = rows;
-    messages.push(`Loaded primary team-context artifact (${rows.length} rows).`);
-  } catch (error) {
-    messages.push(`Primary team-context artifact unavailable (${error.message}).`);
+    messages.push(`Loaded primary role-context artifact (${rows.length} rows).`);
+  } catch (roleError) {
+    messages.push(`Primary role-context artifact unavailable (${roleError.message}).`);
 
     try {
-      const fallbackPayload = await loadJson(POST_DRAFT_FALLBACK_PATH);
-      const rows = coerceRows(fallbackPayload).map(normalizeRow);
+      const teamPayload = await loadJson(TEAM_CONTEXT_PATH);
+      const rows = coerceRows(teamPayload).map(normalizeRow);
       state.rows = rows;
-      messages.push(`Loaded fallback post-draft artifact (${rows.length} rows). Team-context fields may be sparse.`);
-    } catch (fallbackError) {
-      dom.artifactStatus.textContent = `Failed to load player artifact: ${fallbackError.message}`;
-      dom.summaryTiles.innerHTML = '<p class="meta">Unable to load any post-draft artifact.</p>';
-      dom.tbody.innerHTML = '<tr><td colspan="19" class="meta">No player data available.</td></tr>';
-      return;
+      messages.push(`Loaded fallback team-context artifact (${rows.length} rows). Role fields may be sparse.`);
+    } catch (teamError) {
+      messages.push(`Fallback team-context artifact unavailable (${teamError.message}).`);
+
+      try {
+        const fallbackPayload = await loadJson(POST_DRAFT_FALLBACK_PATH);
+        const rows = coerceRows(fallbackPayload).map(normalizeRow);
+        state.rows = rows;
+        messages.push(`Loaded fallback post-draft artifact (${rows.length} rows). Team/role fields may be sparse.`);
+      } catch (fallbackError) {
+        dom.artifactStatus.textContent = `Failed to load player artifact: ${fallbackError.message}`;
+        dom.summaryTiles.innerHTML = '<p class="meta">Unable to load any post-draft artifact.</p>';
+        dom.tbody.innerHTML = '<tr><td colspan="19" class="meta">No player data available.</td></tr>';
+        return;
+      }
     }
   }
 

--- a/lib/rookies/workbench/roleOpportunityNormalization.mjs
+++ b/lib/rookies/workbench/roleOpportunityNormalization.mjs
@@ -1,0 +1,11 @@
+export function normalizeFullRoleOpportunityFound(row) {
+  if (typeof row?.full_role_opportunity_found === 'boolean') {
+    return row.full_role_opportunity_found;
+  }
+
+  if (typeof row?.role_opportunity_found === 'boolean') {
+    return row.role_opportunity_found;
+  }
+
+  return null;
+}

--- a/runtime-server.js
+++ b/runtime-server.js
@@ -13,6 +13,7 @@ const CONTENT_TYPES = {
   '.html': 'text/html; charset=utf-8',
   '.ico': 'image/x-icon',
   '.js': 'text/javascript; charset=utf-8',
+  '.mjs': 'text/javascript; charset=utf-8',
   '.json': 'application/json; charset=utf-8',
   '.map': 'application/json; charset=utf-8',
   '.png': 'image/png',

--- a/runtime-server.js
+++ b/runtime-server.js
@@ -35,6 +35,10 @@ const ROUTE_ALIASES = new Map([
 
 const CONDITIONAL_FALLBACKS = new Map([
   [
+    '/exports/promoted/rookie-alpha/2026_rookie_alpha_postdraft_role_context_v0.json',
+    '/exports/promoted/rookie-alpha/2026_rookie_alpha_postdraft_team_context_v0.json',
+  ],
+  [
     '/exports/promoted/rookie-alpha/2026_rookie_alpha_postdraft_team_context_v0.json',
     '/exports/promoted/rookie-alpha/2026_rookie_alpha_postdraft_v0.json',
   ],
@@ -110,26 +114,33 @@ function resolveFilePath(requestPath, callback) {
       return;
     }
 
-    const fallbackPublicPath = CONDITIONAL_FALLBACKS.get(publicPath);
-    if (!fallbackPublicPath) {
-      callback(null, targetPath);
-      return;
-    }
+    const visited = new Set([publicPath]);
 
-    const fallbackTargetPath = resolveStaticPath(fallbackPublicPath);
-    if (!fallbackTargetPath) {
-      callback(null, targetPath);
-      return;
-    }
-
-    fs.stat(fallbackTargetPath, (fallbackError, fallbackStats) => {
-      if (!fallbackError && fallbackStats.isFile()) {
-        callback(null, fallbackTargetPath);
+    const tryFallback = (candidatePublicPath) => {
+      const fallbackPublicPath = CONDITIONAL_FALLBACKS.get(candidatePublicPath);
+      if (!fallbackPublicPath || visited.has(fallbackPublicPath)) {
+        callback(null, targetPath);
         return;
       }
 
-      callback(null, targetPath);
-    });
+      visited.add(fallbackPublicPath);
+      const fallbackTargetPath = resolveStaticPath(fallbackPublicPath);
+      if (!fallbackTargetPath) {
+        callback(null, targetPath);
+        return;
+      }
+
+      fs.stat(fallbackTargetPath, (fallbackError, fallbackStats) => {
+        if (!fallbackError && fallbackStats.isFile()) {
+          callback(null, fallbackTargetPath);
+          return;
+        }
+
+        tryFallback(fallbackPublicPath);
+      });
+    };
+
+    tryFallback(publicPath);
   });
 }
 

--- a/tests/role-opportunity-normalization.test.mjs
+++ b/tests/role-opportunity-normalization.test.mjs
@@ -1,0 +1,26 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { normalizeFullRoleOpportunityFound } from '../lib/rookies/workbench/roleOpportunityNormalization.mjs';
+
+test('normalizeFullRoleOpportunityFound prefers full_role_opportunity_found when present', () => {
+  const row = {
+    full_role_opportunity_found: false,
+    role_opportunity_found: true,
+  };
+
+  assert.equal(normalizeFullRoleOpportunityFound(row), false);
+});
+
+test('normalizeFullRoleOpportunityFound falls back to role_opportunity_found', () => {
+  const row = {
+    player_name: '__ROLE_ONLY__',
+    role_opportunity_found: true,
+  };
+
+  assert.equal(normalizeFullRoleOpportunityFound(row), true);
+});
+
+test('normalizeFullRoleOpportunityFound returns null when neither field is present', () => {
+  assert.equal(normalizeFullRoleOpportunityFound({ player_name: '__NO_ROLE__' }), null);
+});

--- a/tests/runtime-server.smoke.test.cjs
+++ b/tests/runtime-server.smoke.test.cjs
@@ -9,6 +9,14 @@ function buildUrl(port, route) {
 }
 
 test('standalone runtime smoke routes', async (t) => {
+  const roleContextPath = path.join(
+    __dirname,
+    '..',
+    'exports',
+    'promoted',
+    'rookie-alpha',
+    '2026_rookie_alpha_postdraft_role_context_v0.json',
+  );
   const teamContextPath = path.join(
     __dirname,
     '..',
@@ -26,8 +34,24 @@ test('standalone runtime smoke routes', async (t) => {
     '2026_rookie_alpha_postdraft_v0.json',
   );
 
-  const fallbackRaw = await fs.readFile(fallbackPath, 'utf8');
+  const [roleContextOriginalRaw, teamContextOriginalRaw, fallbackRaw] = await Promise.all([
+    fs.readFile(roleContextPath, 'utf8'),
+    fs.readFile(teamContextPath, 'utf8'),
+    fs.readFile(fallbackPath, 'utf8'),
+  ]);
   const fallbackPayload = JSON.parse(fallbackRaw);
+  const syntheticRoleContextPayload = {
+    rows: [
+      {
+        player_name: '__SMOKE_ROLE_CONTEXT__',
+        post_draft_alpha: 0,
+        team_context_found: true,
+        role_team_profile_found: true,
+        role_baseline_found: true,
+        role_opportunity_found: true,
+      },
+    ],
+  };
   const syntheticTeamContextPayload = {
     rows: [
       {
@@ -38,9 +62,11 @@ test('standalone runtime smoke routes', async (t) => {
     ],
   };
 
+  await fs.writeFile(roleContextPath, `${JSON.stringify(syntheticRoleContextPayload)}\n`, 'utf8');
   await fs.writeFile(teamContextPath, `${JSON.stringify(syntheticTeamContextPayload)}\n`, 'utf8');
   t.after(async () => {
-    await fs.rm(teamContextPath, { force: true });
+    await fs.writeFile(roleContextPath, roleContextOriginalRaw, 'utf8');
+    await fs.writeFile(teamContextPath, teamContextOriginalRaw, 'utf8');
   });
 
   const server = startServer(0);
@@ -99,6 +125,14 @@ test('standalone runtime smoke routes', async (t) => {
   assert.equal(workbenchCss.status, 200);
   assert.match(workbenchCss.headers.get('content-type') || '', /text\/css/);
 
+  const primaryRoleContext = await fetch(
+    buildUrl(port, '/exports/promoted/rookie-alpha/2026_rookie_alpha_postdraft_role_context_v0.json'),
+  );
+  assert.equal(primaryRoleContext.status, 200);
+  assert.match(primaryRoleContext.headers.get('content-type') || '', /application\/json/);
+  const primaryRolePayload = await primaryRoleContext.json();
+  assert.deepEqual(primaryRolePayload, syntheticRoleContextPayload);
+
   const primaryTeamContext = await fetch(
     buildUrl(port, '/exports/promoted/rookie-alpha/2026_rookie_alpha_postdraft_team_context_v0.json'),
   );
@@ -107,7 +141,25 @@ test('standalone runtime smoke routes', async (t) => {
   const primaryPayload = await primaryTeamContext.json();
   assert.deepEqual(primaryPayload, syntheticTeamContextPayload);
 
+  await fs.rm(roleContextPath, { force: true });
+
+  const roleContextFallbackToTeam = await fetch(
+    buildUrl(port, '/exports/promoted/rookie-alpha/2026_rookie_alpha_postdraft_role_context_v0.json'),
+  );
+  assert.equal(roleContextFallbackToTeam.status, 200);
+  assert.match(roleContextFallbackToTeam.headers.get('content-type') || '', /application\/json/);
+  const roleToTeamPayload = await roleContextFallbackToTeam.json();
+  assert.deepEqual(roleToTeamPayload, syntheticTeamContextPayload);
+
   await fs.rm(teamContextPath, { force: true });
+
+  const roleContextFallbackToPostDraft = await fetch(
+    buildUrl(port, '/exports/promoted/rookie-alpha/2026_rookie_alpha_postdraft_role_context_v0.json'),
+  );
+  assert.equal(roleContextFallbackToPostDraft.status, 200);
+  assert.match(roleContextFallbackToPostDraft.headers.get('content-type') || '', /application\/json/);
+  const roleToPostDraftPayload = await roleContextFallbackToPostDraft.json();
+  assert.deepEqual(roleToPostDraftPayload, fallbackPayload);
 
   const primaryTeamContextFallback = await fetch(
     buildUrl(port, '/exports/promoted/rookie-alpha/2026_rookie_alpha_postdraft_team_context_v0.json'),

--- a/tests/runtime-server.smoke.test.cjs
+++ b/tests/runtime-server.smoke.test.cjs
@@ -8,6 +8,19 @@ function buildUrl(port, route) {
   return `http://127.0.0.1:${port}${route}`;
 }
 
+async function readIfExists(filePath) {
+  try {
+    const raw = await fs.readFile(filePath, 'utf8');
+    return { exists: true, raw };
+  } catch (error) {
+    if (error && error.code === 'ENOENT') {
+      return { exists: false, raw: null };
+    }
+
+    throw error;
+  }
+}
+
 test('standalone runtime smoke routes', async (t) => {
   const roleContextPath = path.join(
     __dirname,
@@ -34,9 +47,9 @@ test('standalone runtime smoke routes', async (t) => {
     '2026_rookie_alpha_postdraft_v0.json',
   );
 
-  const [roleContextOriginalRaw, teamContextOriginalRaw, fallbackRaw] = await Promise.all([
-    fs.readFile(roleContextPath, 'utf8'),
-    fs.readFile(teamContextPath, 'utf8'),
+  const [roleContextOriginal, teamContextOriginal, fallbackRaw] = await Promise.all([
+    readIfExists(roleContextPath),
+    readIfExists(teamContextPath),
     fs.readFile(fallbackPath, 'utf8'),
   ]);
   const fallbackPayload = JSON.parse(fallbackRaw);
@@ -65,8 +78,17 @@ test('standalone runtime smoke routes', async (t) => {
   await fs.writeFile(roleContextPath, `${JSON.stringify(syntheticRoleContextPayload)}\n`, 'utf8');
   await fs.writeFile(teamContextPath, `${JSON.stringify(syntheticTeamContextPayload)}\n`, 'utf8');
   t.after(async () => {
-    await fs.writeFile(roleContextPath, roleContextOriginalRaw, 'utf8');
-    await fs.writeFile(teamContextPath, teamContextOriginalRaw, 'utf8');
+    if (roleContextOriginal.exists) {
+      await fs.writeFile(roleContextPath, roleContextOriginal.raw, 'utf8');
+    } else {
+      await fs.rm(roleContextPath, { force: true });
+    }
+
+    if (teamContextOriginal.exists) {
+      await fs.writeFile(teamContextPath, teamContextOriginal.raw, 'utf8');
+    } else {
+      await fs.rm(teamContextPath, { force: true });
+    }
   });
 
   const server = startServer(0);


### PR DESCRIPTION
### Motivation
- Ensure the ML Workbench shows enriched role joins (role-context) in the UI/CSV when available instead of only team-context or base post-draft artifacts. 
- Make artifact serving consistent so runtime requests resolve to the richest available artifact (role -> team -> post-draft) without changing generated artifacts or scoring.

### Description
- Updated Workbench initialization to prefer `2026_rookie_alpha_postdraft_role_context_v0.json`, then fall back to `2026_rookie_alpha_postdraft_team_context_v0.json`, then `2026_rookie_alpha_postdraft_v0.json`, and added explicit status messages for each step (`cards/rookies/workbench/workbench.js`).
- Introduced `ROLE_CONTEXT_PATH` and `TEAM_CONTEXT_PATH` constants and preserved boolean normalization so `full_role_opportunity_found` is read from `row.full_role_opportunity_found` or from `row.role_opportunity_found` when present to maintain compatibility with existing artifacts.
- Extended the static runtime server conditional fallback map and resolution logic to support chained fallbacks (`role_context -> team_context -> post_draft`) and iterative resolution to avoid single-step-only fallbacks (`runtime-server.js`).
- Expanded the runtime smoke test to validate role-context serving and the fallback chain and to restore original artifacts after the test to avoid mutating promoted exports (`tests/runtime-server.smoke.test.cjs`).

### Testing
- Ran the runtime smoke test with `node --test tests/runtime-server.smoke.test.cjs`, which completed successfully (all assertions passed).
- Programmatically inspected the local `2026_rookie_alpha_postdraft_role_context_v0.json` and verified `role_opportunity_found` (role-opportunity) is `true` for target players (e.g., Ty Simpson, De'Zhaun Stribling, Germie Bernard, Antonio Williams).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef4d5231f0833280d5397e28cf2e29)