### PR TITLE
Add Tanner Koziol operator journal entry and inspect-only signal candidates

### DIFF
--- a/data/operator-journal/processed/2026_operator_signal_candidates.json
+++ b/data/operator-journal/processed/2026_operator_signal_candidates.json
@@ -472,5 +472,124 @@
     "source_type": "operator_journal",
     "review_status": "needs_human_review",
     "candidate_theme": "vertical_field_stretcher_role_watch"
+  },
+  {
+    "candidate_id": "cand_oj_2026_012_tanner_koziol_jaguars_jaguars_red_zone_fit_watch",
+    "source_entry_id": "oj_2026_012_tanner_koziol_jaguars",
+    "entity_type": "player",
+    "player_name": "Tanner Koziol",
+    "team": "Jaguars",
+    "position": "TE",
+    "related_entities": [],
+    "claim_summary": "Koziol's contested-catch profile and size may create a Jaguars red-zone role path, but Trevor Lawrence / Jacksonville TE red-zone tendency needs play-by-play verification before promotion.",
+    "positive_signal_tags": [
+      "contested_catch_strength",
+      "red_zone_target_candidate",
+      "size_mismatch_te",
+      "trevor_lawrence_te_usage_watch",
+      "evan_engram_usage_comp_watch"
+    ],
+    "risk_tags": [
+      "requires_red_zone_target_verification",
+      "day3_capital_risk",
+      "depth_chart_path_uncertain",
+      "usage_projection_uncertainty"
+    ],
+    "context_tags": [
+      "red_zone_play_by_play_needed",
+      "jaguars_landing_spot_fit_watch",
+      "operator_signal_needs_verification"
+    ],
+    "model_impact": "flag_for_red_zone_usage_research_before_adjusting_role_confidence",
+    "downstream_repos": [
+      "TIBER-Rookies",
+      "Role-and-Opportunity",
+      "TIBER-Teamstate"
+    ],
+    "confidence": "medium",
+    "needs_verification": true,
+    "source_type": "operator_journal",
+    "review_status": "needs_human_review",
+    "candidate_theme": "jaguars_red_zone_fit_watch"
+  },
+  {
+    "candidate_id": "cand_oj_2026_012_tanner_koziol_jaguars_low_deep_usage_te_risk",
+    "source_entry_id": "oj_2026_012_tanner_koziol_jaguars",
+    "entity_type": "player",
+    "player_name": "Tanner Koziol",
+    "team": "Jaguars",
+    "position": "TE",
+    "related_entities": [],
+    "claim_summary": "Koziol's low deep-yardage share may cap his NFL receiving ceiling despite elite short/intermediate volume.",
+    "positive_signal_tags": [
+      "elite_short_intermediate_volume",
+      "power_conference_yptpa_signal",
+      "high_reception_share_te"
+    ],
+    "risk_tags": [
+      "low_deep_usage_risk",
+      "historical_deep_usage_threshold_risk",
+      "role_ceiling_uncertainty",
+      "fantasy_ceiling_risk"
+    ],
+    "context_tags": [
+      "under_10_percent_deep_yard_share",
+      "drafted_te_low_deep_usage_cohort",
+      "cade_otton_dalton_schultz_exception_watch"
+    ],
+    "model_impact": "track_as_volume_floor_te_with_deep_usage_ceiling_risk",
+    "downstream_repos": [
+      "TIBER-Rookies"
+    ],
+    "confidence": "medium",
+    "needs_verification": true,
+    "source_type": "operator_journal",
+    "review_status": "needs_human_review",
+    "candidate_theme": "low_deep_usage_te_risk"
+  },
+  {
+    "candidate_id": "cand_oj_2026_012_tanner_koziol_jaguars_receiving_move_te_archetype_correction",
+    "source_entry_id": "oj_2026_012_tanner_koziol_jaguars",
+    "entity_type": "player",
+    "player_name": "Tanner Koziol",
+    "team": "Jaguars",
+    "position": "TE",
+    "related_entities": [],
+    "claim_summary": "Tanner Koziol should be evaluated primarily as a receiving/move TE with blocking risk, not as a blocking-heavy rotational TE.",
+    "positive_signal_tags": [
+      "receiving_te_archetype",
+      "move_te_candidate",
+      "elite_te_reception_volume",
+      "non_screen_reception_volume_signal",
+      "contested_catch_strength",
+      "red_zone_target_candidate",
+      "body_control_at_size",
+      "high_ras_size_adjusted_signal",
+      "short_intermediate_target_earner"
+    ],
+    "risk_tags": [
+      "blocking_risk",
+      "day3_capital_risk",
+      "low_deep_usage_risk",
+      "limited_yac_profile",
+      "role_ceiling_uncertainty",
+      "year1_route_share_uncertainty"
+    ],
+    "context_tags": [
+      "jaguars_te_room_watch",
+      "tiber_role_archetype_correction",
+      "receiving_role_over_blocking_role",
+      "late_round_te_watch"
+    ],
+    "model_impact": "review_role_mapping_to_prioritize_move_te_receiving_role_over_blocking_rotational_te",
+    "downstream_repos": [
+      "TIBER-Rookies",
+      "Role-and-Opportunity"
+    ],
+    "confidence": "high",
+    "needs_verification": true,
+    "source_type": "operator_journal",
+    "review_status": "needs_human_review",
+    "candidate_theme": "receiving_move_te_archetype_correction"
   }
 ]

--- a/data/operator-journal/raw/2026_rookie_journal_entries.json
+++ b/data/operator-journal/raw/2026_rookie_journal_entries.json
@@ -97,5 +97,14 @@
     "source_type": "operator_journal",
     "operator": "local",
     "review_status": "raw"
+  },
+  {
+    "entry_id": "oj_2026_012_tanner_koziol_jaguars",
+    "entry_date": "2026-04-27",
+    "entry_title": "Tanner Koziol receiving TE archetype and Jaguars red-zone fit audit",
+    "entry_text": "Tanner Koziol should be treated as a receiving/move TE archetype with blocking risk, not primarily as a blocking rotational TE. His receiving profile is unusually strong. Since 2014 in PFF College history, he ranks third and sixth in non-screen receptions by a TE season, with 74 in 2024 and 70 in 2025. Across 2024-2025 he tied Junior Vandeross III for the FBS lead in receptions with 168, ahead of Jeremiah Smith. Over the last two years he posted 168 receptions, 2.12 YPRR, and 62.7 receiving yards per game. He finished his career with 237 receptions, 2,235 yards, and 24 touchdowns over 49 games. At Houston as a senior he posted 74 receptions, 727 yards, 6 TDs, a 73% contested catch rate, 2 recorded drops, and 2.21 YPRR. He is 6'7, 240 pounds, ran around 4.7, has a 9.72 RAS, and shows elite body control at his size. The red-zone angle may matter: a note flagged that Koziol went 46/67 on contested catch targets over the last two years and could be useful if paired with an accurate QB who will throw to him in the red zone. Jacksonville and Trevor Lawrence may plausibly fit that idea given prior Evan Engram red-zone usage, but this needs verification through red-zone play-by-play / target data before promotion. The risk case is real: since 2015, only 2 of 29 drafted TEs with under 10% of FBS receiving yards on deep passes have produced a 600+ yard NFL season, and Koziol\u2019s deep-yardage share is around 5%. That creates a low-deep-usage / role-ceiling concern. His profile should probably be tagged move_te / receiving_te / red_zone_target_candidate first, with blocking and deep-usage limitations as risk tags.",
+    "source_type": "operator_journal",
+    "operator": "local",
+    "review_status": "raw"
   }
 ]

--- a/docs/operator-journal-signal-scanner.md
+++ b/docs/operator-journal-signal-scanner.md
@@ -55,6 +55,7 @@ Model-edge notes can be positive or negative and are always treated as candidate
 - Negative model edge plus better landing spot is tracked as a "landing spot over profile" candidate.
 - Missing-data observations become audit candidates and profile-completeness review tasks, not retroactive score edits.
 - Journal entries may also flag stale model writeups/profile-completeness conflicts as a separate inspect-only audit candidate from landing-spot role takes.
+- Journal entries may also flag role-archetype correction candidates (for example, receiving-vs-blocking role mapping) as inspect-only context separate from any scoring change.
 
 Only reviewed/promoted items should be consumed by Teamstate, Role-Opportunity, post-draft alpha, or any TIBER-Data downstream workflows. The scanner's goal is to turn hobby notes into a repeatable information layer without bypassing model governance.
 

--- a/scripts/build_operator_signal_candidates.py
+++ b/scripts/build_operator_signal_candidates.py
@@ -157,7 +157,123 @@ def build_candidates_for_entry(entry: dict[str, Any]) -> list[dict[str, Any]]:
         )
         return [candidate]
 
-    if "tanner_koziol" in entry_id:
+    if entry_id == "oj_2026_012_tanner_koziol_jaguars":
+        receiving_move_te = _base_candidate(entry, "receiving_move_te_archetype_correction", "player")
+        receiving_move_te.update(
+            {
+                "player_name": "Tanner Koziol",
+                "team": "Jaguars",
+                "position": "TE",
+                "candidate_theme": "receiving_move_te_archetype_correction",
+                "claim_summary": (
+                    "Tanner Koziol should be evaluated primarily as a receiving/move TE with blocking risk, "
+                    "not as a blocking-heavy rotational TE."
+                ),
+                "positive_signal_tags": [
+                    "receiving_te_archetype",
+                    "move_te_candidate",
+                    "elite_te_reception_volume",
+                    "non_screen_reception_volume_signal",
+                    "contested_catch_strength",
+                    "red_zone_target_candidate",
+                    "body_control_at_size",
+                    "high_ras_size_adjusted_signal",
+                    "short_intermediate_target_earner",
+                ],
+                "risk_tags": [
+                    "blocking_risk",
+                    "day3_capital_risk",
+                    "low_deep_usage_risk",
+                    "limited_yac_profile",
+                    "role_ceiling_uncertainty",
+                    "year1_route_share_uncertainty",
+                ],
+                "context_tags": [
+                    "jaguars_te_room_watch",
+                    "tiber_role_archetype_correction",
+                    "receiving_role_over_blocking_role",
+                    "late_round_te_watch",
+                ],
+                "model_impact": (
+                    "review_role_mapping_to_prioritize_move_te_receiving_role_over_blocking_rotational_te"
+                ),
+                "downstream_repos": ["TIBER-Rookies", "Role-and-Opportunity"],
+                "confidence": "high",
+            }
+        )
+
+        red_zone_fit_watch = _base_candidate(entry, "jaguars_red_zone_fit_watch", "player")
+        red_zone_fit_watch.update(
+            {
+                "player_name": "Tanner Koziol",
+                "team": "Jaguars",
+                "position": "TE",
+                "candidate_theme": "jaguars_red_zone_fit_watch",
+                "claim_summary": (
+                    "Koziol's contested-catch profile and size may create a Jaguars red-zone role path, but "
+                    "Trevor Lawrence / Jacksonville TE red-zone tendency needs play-by-play verification "
+                    "before promotion."
+                ),
+                "positive_signal_tags": [
+                    "contested_catch_strength",
+                    "red_zone_target_candidate",
+                    "size_mismatch_te",
+                    "trevor_lawrence_te_usage_watch",
+                    "evan_engram_usage_comp_watch",
+                ],
+                "risk_tags": [
+                    "requires_red_zone_target_verification",
+                    "day3_capital_risk",
+                    "depth_chart_path_uncertain",
+                    "usage_projection_uncertainty",
+                ],
+                "context_tags": [
+                    "red_zone_play_by_play_needed",
+                    "jaguars_landing_spot_fit_watch",
+                    "operator_signal_needs_verification",
+                ],
+                "model_impact": "flag_for_red_zone_usage_research_before_adjusting_role_confidence",
+                "downstream_repos": ["TIBER-Rookies", "Role-and-Opportunity", "TIBER-Teamstate"],
+                "confidence": "medium",
+            }
+        )
+
+        low_deep_usage_risk = _base_candidate(entry, "low_deep_usage_te_risk", "player")
+        low_deep_usage_risk.update(
+            {
+                "player_name": "Tanner Koziol",
+                "team": "Jaguars",
+                "position": "TE",
+                "candidate_theme": "low_deep_usage_te_risk",
+                "claim_summary": (
+                    "Koziol's low deep-yardage share may cap his NFL receiving ceiling despite elite "
+                    "short/intermediate volume."
+                ),
+                "positive_signal_tags": [
+                    "elite_short_intermediate_volume",
+                    "power_conference_yptpa_signal",
+                    "high_reception_share_te",
+                ],
+                "risk_tags": [
+                    "low_deep_usage_risk",
+                    "historical_deep_usage_threshold_risk",
+                    "role_ceiling_uncertainty",
+                    "fantasy_ceiling_risk",
+                ],
+                "context_tags": [
+                    "under_10_percent_deep_yard_share",
+                    "drafted_te_low_deep_usage_cohort",
+                    "cade_otton_dalton_schultz_exception_watch",
+                ],
+                "model_impact": "track_as_volume_floor_te_with_deep_usage_ceiling_risk",
+                "downstream_repos": ["TIBER-Rookies"],
+                "confidence": "medium",
+            }
+        )
+
+        return [receiving_move_te, red_zone_fit_watch, low_deep_usage_risk]
+
+    if entry_id == "oj_2026_005_tanner_koziol":
         candidate = _base_candidate(entry, "model_edge_validation", "player")
         candidate.update(
             {

--- a/tests/test_build_operator_signal_candidates.py
+++ b/tests/test_build_operator_signal_candidates.py
@@ -41,10 +41,46 @@ class BuildOperatorSignalCandidatesTests(unittest.TestCase):
         self.assertIn("round1_qb_experience_risk", ty["risk_tags"])
         self.assertIn("developmental_qb_variance", ty["risk_tags"])
 
-    def test_tanner_koziol_includes_model_edge_tags(self) -> None:
-        tanner = next(c for c in self.candidates if c["player_name"] == "Tanner Koziol")
-        self.assertIn("tiber_edge_plus_18", tanner["context_tags"])
-        self.assertIn("model_edge_confirmed_by_draft_capital", tanner["positive_signal_tags"])
+    def test_tanner_koziol_receiving_move_te_candidate_exists_with_key_tags(self) -> None:
+        tanner = next(
+            c
+            for c in self.candidates
+            if c["source_entry_id"] == "oj_2026_012_tanner_koziol_jaguars"
+            and c.get("candidate_theme") == "receiving_move_te_archetype_correction"
+        )
+        self.assertIn("receiving_te_archetype", tanner["positive_signal_tags"])
+        self.assertIn("move_te_candidate", tanner["positive_signal_tags"])
+        self.assertIn("contested_catch_strength", tanner["positive_signal_tags"])
+        self.assertIn("blocking_risk", tanner["risk_tags"])
+
+    def test_tanner_koziol_red_zone_fit_candidate_exists_with_key_tags(self) -> None:
+        tanner = next(
+            c
+            for c in self.candidates
+            if c["source_entry_id"] == "oj_2026_012_tanner_koziol_jaguars"
+            and c.get("candidate_theme") == "jaguars_red_zone_fit_watch"
+        )
+        self.assertIn("red_zone_play_by_play_needed", tanner["context_tags"])
+        self.assertIn("requires_red_zone_target_verification", tanner["risk_tags"])
+
+    def test_tanner_koziol_low_deep_usage_candidate_exists_with_key_tags(self) -> None:
+        tanner = next(
+            c
+            for c in self.candidates
+            if c["source_entry_id"] == "oj_2026_012_tanner_koziol_jaguars"
+            and c.get("candidate_theme") == "low_deep_usage_te_risk"
+        )
+        self.assertIn("low_deep_usage_risk", tanner["risk_tags"])
+        self.assertIn("historical_deep_usage_threshold_risk", tanner["risk_tags"])
+
+    def test_tanner_koziol_new_candidates_are_operator_journal_needs_review(self) -> None:
+        koziol_candidates = [
+            c for c in self.candidates if c["source_entry_id"] == "oj_2026_012_tanner_koziol_jaguars"
+        ]
+        self.assertEqual(len(koziol_candidates), 3)
+        for candidate in koziol_candidates:
+            self.assertEqual(candidate["source_type"], "operator_journal")
+            self.assertEqual(candidate["review_status"], "needs_human_review")
 
     def test_nick_singleton_includes_missing_data_audit_tags(self) -> None:
         nick = next(c for c in self.candidates if c["player_name"] == "Nick Singleton")


### PR DESCRIPTION
### Motivation
- Capture post-draft operator research on Tanner Koziol as inspect-only review candidates so analysts can evaluate role/archetype and red-zone fit without affecting scoring or alpha artifacts.
- Provide deterministic candidate outputs from the operator journal pipeline so downstream review tooling can surface Koziol-specific flags for human verification.

### Description
- Appended the raw operator journal entry `oj_2026_012_tanner_koziol_jaguars` to `data/operator-journal/raw/2026_rookie_journal_entries.json` with the provided title and text.
- Added deterministic mapping in `scripts/build_operator_signal_candidates.py` to emit three inspect-only player candidates for that entry: `receiving_move_te_archetype_correction`, `jaguars_red_zone_fit_watch`, and `low_deep_usage_te_risk`, preserving `source_type: operator_journal` and `review_status: needs_human_review` and keeping candidate IDs derived from the source entry.
- Regenerated the processed output at `data/operator-journal/processed/2026_operator_signal_candidates.json` to include the three new Koziol candidates and updated downstream repo targets and model impact strings as requested.
- Added unit tests in `tests/test_build_operator_signal_candidates.py` to assert presence and tag coverage for the three Koziol candidates and updated documentation in `docs/operator-journal-signal-scanner.md` to note role-archetype correction entries are inspect-only.

### Testing
- Ran the build script with `python scripts/build_operator_signal_candidates.py` and confirmed it completed successfully and produced updated processed output.
- Executed unit tests with `pytest -q tests/test_build_operator_signal_candidates.py` and observed all tests passed (`23 passed`).
- Verified new candidates appear in the processed JSON with `source_type` set to `operator_journal`, `review_status` set to `needs_human_review`, and that candidate IDs are source-entry-derived and unique.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef5cd188088332841dc621e79c8dcb)