### PR TITLE
Add Jordyn Tyson operator-journal entry and three inspect-only signal candidates

### DIFF
--- a/data/operator-journal/processed/2026_operator_signal_candidates.json
+++ b/data/operator-journal/processed/2026_operator_signal_candidates.json
@@ -591,5 +591,122 @@
     "source_type": "operator_journal",
     "review_status": "needs_human_review",
     "candidate_theme": "receiving_move_te_archetype_correction"
+  },
+  {
+    "candidate_id": "cand_oj_2026_013_jordyn_tyson_saints_kellen_moore_premium_wr_environment",
+    "source_entry_id": "oj_2026_013_jordyn_tyson_saints",
+    "entity_type": "player",
+    "player_name": "Jordyn Tyson",
+    "team": "Saints",
+    "position": "WR",
+    "related_entities": [],
+    "claim_summary": "Jordyn Tyson\u2019s Saints landing spot may deserve a premium environment tag because Kellen Moore\u2019s offense projects as pass-aggressive, scheme-flexible, and capable of supporting multiple productive WRs.",
+    "positive_signal_tags": [
+      "kellen_moore_environment",
+      "premium_wr_capital",
+      "pass_volume_projection_watch",
+      "scheme_flexibility_signal",
+      "multiple_wr_production_environment",
+      "target_consolidation_path",
+      "high_value_route_environment"
+    ],
+    "risk_tags": [
+      "offense_projection_uncertainty",
+      "rookie_wr_ramp_risk",
+      "scheme_assumption_needs_verification",
+      "saints_2026_environment_variance"
+    ],
+    "context_tags": [
+      "pick_8_overall",
+      "saints_landing_spot",
+      "kellen_moore_pass_game_watch",
+      "non_generic_landing_spot_context"
+    ],
+    "model_impact": "upgrade_landing_context_review_priority_without_auto_adjusting_alpha",
+    "downstream_repos": [
+      "TIBER-Rookies",
+      "Role-and-Opportunity",
+      "TIBER-Teamstate"
+    ],
+    "confidence": "medium",
+    "needs_verification": true,
+    "source_type": "operator_journal",
+    "review_status": "needs_human_review",
+    "candidate_theme": "kellen_moore_premium_wr_environment"
+  },
+  {
+    "candidate_id": "cand_oj_2026_013_jordyn_tyson_saints_olave_hierarchy_challenge_wr1_path",
+    "source_entry_id": "oj_2026_013_jordyn_tyson_saints",
+    "entity_type": "player",
+    "player_name": "Jordyn Tyson",
+    "team": "Saints",
+    "position": "WR",
+    "related_entities": [],
+    "claim_summary": "Tyson has a plausible long-term WR1 outcome path if his premium draft capital and talent allow him to challenge Chris Olave in a thin Saints WR room.",
+    "positive_signal_tags": [
+      "wr1_outcome_path",
+      "olave_hierarchy_challenge",
+      "thin_wr_room_behind_olave",
+      "target_share_consolidation_watch",
+      "premium_rookie_role_path"
+    ],
+    "risk_tags": [
+      "olave_target_hierarchy",
+      "rookie_target_share_uncertainty",
+      "year1_role_uncertainty",
+      "bold_take_requires_verification"
+    ],
+    "context_tags": [
+      "olave_tyson_two_wr_consolidation_watch",
+      "saints_wr_room_watch",
+      "operator_bullish_thesis"
+    ],
+    "model_impact": "track_as_high_upside_hierarchy_challenge_not_base_projection",
+    "downstream_repos": [
+      "TIBER-Rookies",
+      "Role-and-Opportunity"
+    ],
+    "confidence": "medium",
+    "needs_verification": true,
+    "source_type": "operator_journal",
+    "review_status": "needs_human_review",
+    "candidate_theme": "olave_hierarchy_challenge_wr1_path"
+  },
+  {
+    "candidate_id": "cand_oj_2026_013_jordyn_tyson_saints_shough_tyson_qb_fit_watch",
+    "source_entry_id": "oj_2026_013_jordyn_tyson_saints",
+    "entity_type": "player",
+    "player_name": "Jordyn Tyson",
+    "team": "Saints",
+    "position": "WR",
+    "related_entities": [],
+    "claim_summary": "The operator is above consensus on Tyler Shough and views Shough\u2019s accuracy/intermediate profile as a potential positive fit for Tyson, but the QB stability assumption needs verification before promotion.",
+    "positive_signal_tags": [
+      "operator_above_consensus_qb_take",
+      "shough_accuracy_fit_watch",
+      "intermediate_passing_fit",
+      "moore_qb_development_environment"
+    ],
+    "risk_tags": [
+      "qb_stability_needs_verification",
+      "shough_market_disagreement",
+      "small_sample_qb_projection_risk",
+      "td_rate_growth_needed"
+    ],
+    "context_tags": [
+      "tyler_shough_fit_watch",
+      "saints_qb_context_watch",
+      "qb_wr_pairing_hypothesis"
+    ],
+    "model_impact": "flag_qb_environment_as_operator_watch_not_confirmed_context",
+    "downstream_repos": [
+      "TIBER-Rookies",
+      "TIBER-Teamstate"
+    ],
+    "confidence": "medium",
+    "needs_verification": true,
+    "source_type": "operator_journal",
+    "review_status": "needs_human_review",
+    "candidate_theme": "shough_tyson_qb_fit_watch"
   }
 ]

--- a/data/operator-journal/raw/2026_rookie_journal_entries.json
+++ b/data/operator-journal/raw/2026_rookie_journal_entries.json
@@ -106,5 +106,14 @@
     "source_type": "operator_journal",
     "operator": "local",
     "review_status": "raw"
+  },
+  {
+    "entry_id": "oj_2026_013_jordyn_tyson_saints",
+    "entry_date": "2026-04-27",
+    "entry_title": "Jordyn Tyson Saints premium WR environment and WR1 path watch",
+    "entry_text": "Jordyn Tyson is clearly talented on tape and went 8th overall to the Saints under Kellen Moore, one of the operator’s favorite offensive coaches. The initial operator thesis is that this is a better landing spot than a generic Saints WR tag would suggest. Moore’s offenses have historically projected as aggressive, high-volume, scheme-flexible passing environments. Research notes point to Cowboys/Eagles/Chargers/Saints Moore offenses using pace, motion, 11 personnel, and selective 12/13 personnel in ways that can support multiple productive receivers and consolidate targets when only 1-2 WRs are on the field. Tyson lands with Chris Olave as the clear veteran target competition, but the WR room behind them appears thin. If Moore’s offense is pass-heavy and uses heavy/condensed personnel to keep top WRs on the field, Tyson and Olave could consolidate a large share of targets. The operator is also above consensus on Tyler Shough and views him as a stable enough QB to support the environment. Tyson should be tracked as a premium-capital WR with eventual WR1 outcome path rather than merely a delayed WR2. The bold upside case is that Tyson eventually challenges or overtakes Olave as the team’s WR1, though this requires verification and should be treated as a hypothesis, not a promoted conclusion.",
+    "source_type": "operator_journal",
+    "operator": "local",
+    "review_status": "raw"
   }
 ]

--- a/docs/operator-journal-signal-scanner.md
+++ b/docs/operator-journal-signal-scanner.md
@@ -56,6 +56,7 @@ Model-edge notes can be positive or negative and are always treated as candidate
 - Missing-data observations become audit candidates and profile-completeness review tasks, not retroactive score edits.
 - Journal entries may also flag stale model writeups/profile-completeness conflicts as a separate inspect-only audit candidate from landing-spot role takes.
 - Journal entries may also flag role-archetype correction candidates (for example, receiving-vs-blocking role mapping) as inspect-only context separate from any scoring change.
+- Journal entries may encode operator QB and environment hypotheses as needs-verification candidates for review, not confirmed model facts.
 
 Only reviewed/promoted items should be consumed by Teamstate, Role-Opportunity, post-draft alpha, or any TIBER-Data downstream workflows. The scanner's goal is to turn hobby notes into a repeatable information layer without bypassing model governance.
 

--- a/scripts/build_operator_signal_candidates.py
+++ b/scripts/build_operator_signal_candidates.py
@@ -571,6 +571,117 @@ def build_candidates_for_entry(entry: dict[str, Any]) -> list[dict[str, Any]]:
         )
         return [vertical_role_watch, profile_completeness_audit]
 
+    if entry_id == "oj_2026_013_jordyn_tyson_saints":
+        kellen_moore_environment = _base_candidate(entry, "kellen_moore_premium_wr_environment", "player")
+        kellen_moore_environment.update(
+            {
+                "player_name": "Jordyn Tyson",
+                "team": "Saints",
+                "position": "WR",
+                "candidate_theme": "kellen_moore_premium_wr_environment",
+                "claim_summary": (
+                    "Jordyn Tyson’s Saints landing spot may deserve a premium environment tag because "
+                    "Kellen Moore’s offense projects as pass-aggressive, scheme-flexible, and capable "
+                    "of supporting multiple productive WRs."
+                ),
+                "positive_signal_tags": [
+                    "kellen_moore_environment",
+                    "premium_wr_capital",
+                    "pass_volume_projection_watch",
+                    "scheme_flexibility_signal",
+                    "multiple_wr_production_environment",
+                    "target_consolidation_path",
+                    "high_value_route_environment",
+                ],
+                "risk_tags": [
+                    "offense_projection_uncertainty",
+                    "rookie_wr_ramp_risk",
+                    "scheme_assumption_needs_verification",
+                    "saints_2026_environment_variance",
+                ],
+                "context_tags": [
+                    "pick_8_overall",
+                    "saints_landing_spot",
+                    "kellen_moore_pass_game_watch",
+                    "non_generic_landing_spot_context",
+                ],
+                "model_impact": "upgrade_landing_context_review_priority_without_auto_adjusting_alpha",
+                "downstream_repos": ["TIBER-Rookies", "Role-and-Opportunity", "TIBER-Teamstate"],
+                "confidence": "medium",
+            }
+        )
+
+        olave_hierarchy_challenge = _base_candidate(entry, "olave_hierarchy_challenge_wr1_path", "player")
+        olave_hierarchy_challenge.update(
+            {
+                "player_name": "Jordyn Tyson",
+                "team": "Saints",
+                "position": "WR",
+                "candidate_theme": "olave_hierarchy_challenge_wr1_path",
+                "claim_summary": (
+                    "Tyson has a plausible long-term WR1 outcome path if his premium draft capital and "
+                    "talent allow him to challenge Chris Olave in a thin Saints WR room."
+                ),
+                "positive_signal_tags": [
+                    "wr1_outcome_path",
+                    "olave_hierarchy_challenge",
+                    "thin_wr_room_behind_olave",
+                    "target_share_consolidation_watch",
+                    "premium_rookie_role_path",
+                ],
+                "risk_tags": [
+                    "olave_target_hierarchy",
+                    "rookie_target_share_uncertainty",
+                    "year1_role_uncertainty",
+                    "bold_take_requires_verification",
+                ],
+                "context_tags": [
+                    "olave_tyson_two_wr_consolidation_watch",
+                    "saints_wr_room_watch",
+                    "operator_bullish_thesis",
+                ],
+                "model_impact": "track_as_high_upside_hierarchy_challenge_not_base_projection",
+                "downstream_repos": ["TIBER-Rookies", "Role-and-Opportunity"],
+                "confidence": "medium",
+            }
+        )
+
+        shough_fit_watch = _base_candidate(entry, "shough_tyson_qb_fit_watch", "player")
+        shough_fit_watch.update(
+            {
+                "player_name": "Jordyn Tyson",
+                "team": "Saints",
+                "position": "WR",
+                "candidate_theme": "shough_tyson_qb_fit_watch",
+                "claim_summary": (
+                    "The operator is above consensus on Tyler Shough and views Shough’s "
+                    "accuracy/intermediate profile as a potential positive fit for Tyson, but the QB "
+                    "stability assumption needs verification before promotion."
+                ),
+                "positive_signal_tags": [
+                    "operator_above_consensus_qb_take",
+                    "shough_accuracy_fit_watch",
+                    "intermediate_passing_fit",
+                    "moore_qb_development_environment",
+                ],
+                "risk_tags": [
+                    "qb_stability_needs_verification",
+                    "shough_market_disagreement",
+                    "small_sample_qb_projection_risk",
+                    "td_rate_growth_needed",
+                ],
+                "context_tags": [
+                    "tyler_shough_fit_watch",
+                    "saints_qb_context_watch",
+                    "qb_wr_pairing_hypothesis",
+                ],
+                "model_impact": "flag_qb_environment_as_operator_watch_not_confirmed_context",
+                "downstream_repos": ["TIBER-Rookies", "TIBER-Teamstate"],
+                "confidence": "medium",
+            }
+        )
+        return [kellen_moore_environment, olave_hierarchy_challenge, shough_fit_watch]
+
     return []
 
 

--- a/tests/test_build_operator_signal_candidates.py
+++ b/tests/test_build_operator_signal_candidates.py
@@ -136,6 +136,45 @@ class BuildOperatorSignalCandidatesTests(unittest.TestCase):
             self.assertEqual(candidate["source_type"], "operator_journal")
             self.assertEqual(candidate["review_status"], "needs_human_review")
 
+    def test_jordyn_tyson_kellen_moore_environment_candidate_exists(self) -> None:
+        tyson = next(
+            c
+            for c in self.candidates
+            if c["source_entry_id"] == "oj_2026_013_jordyn_tyson_saints"
+            and c.get("candidate_theme") == "kellen_moore_premium_wr_environment"
+        )
+        self.assertIn("kellen_moore_environment", tyson["positive_signal_tags"])
+        self.assertIn("premium_wr_capital", tyson["positive_signal_tags"])
+        self.assertIn("pass_volume_projection_watch", tyson["positive_signal_tags"])
+
+    def test_jordyn_tyson_olave_hierarchy_challenge_candidate_exists(self) -> None:
+        tyson = next(
+            c
+            for c in self.candidates
+            if c["source_entry_id"] == "oj_2026_013_jordyn_tyson_saints"
+            and c.get("candidate_theme") == "olave_hierarchy_challenge_wr1_path"
+        )
+        self.assertIn("wr1_outcome_path", tyson["positive_signal_tags"])
+        self.assertIn("olave_hierarchy_challenge", tyson["positive_signal_tags"])
+        self.assertIn("olave_target_hierarchy", tyson["risk_tags"])
+
+    def test_jordyn_tyson_shough_fit_candidate_exists(self) -> None:
+        tyson = next(
+            c
+            for c in self.candidates
+            if c["source_entry_id"] == "oj_2026_013_jordyn_tyson_saints"
+            and c.get("candidate_theme") == "shough_tyson_qb_fit_watch"
+        )
+        self.assertIn("operator_above_consensus_qb_take", tyson["positive_signal_tags"])
+        self.assertIn("qb_stability_needs_verification", tyson["risk_tags"])
+
+    def test_jordyn_tyson_candidates_are_operator_journal_needs_review(self) -> None:
+        tyson_candidates = [c for c in self.candidates if c["source_entry_id"] == "oj_2026_013_jordyn_tyson_saints"]
+        self.assertEqual(len(tyson_candidates), 3)
+        for candidate in tyson_candidates:
+            self.assertEqual(candidate["source_type"], "operator_journal")
+            self.assertEqual(candidate["review_status"], "needs_human_review")
+
     def test_all_candidates_are_operator_journal_source(self) -> None:
         for candidate in self.candidates:
             self.assertEqual(candidate["source_type"], "operator_journal")


### PR DESCRIPTION
### Motivation
- Capture post-draft operator research on Jordyn Tyson as an inspect-only operator journal entry so analysts can review QB/environment hypotheses tied to his Saints landing. 
- Surface deterministic, review-only signal candidates derived from that entry to feed ML Workbench review without changing any alpha/scoring artifacts. 
- Preserve governance: outputs remain `source_type: operator_journal`, default `review_status: needs_human_review`, and candidate IDs remain derived from the source entry.

### Description
- Appended the raw entry `oj_2026_013_jordyn_tyson_saints` to `data/operator-journal/raw/2026_rookie_journal_entries.json` with `source_type: operator_journal` and `review_status: raw`.
- Added deterministic mapping in `scripts/build_operator_signal_candidates.py` to emit three Jordyn Tyson candidates: `kellen_moore_premium_wr_environment`, `olave_hierarchy_challenge_wr1_path`, and `shough_tyson_qb_fit_watch`, each including the requested positive tags, risk tags, context tags, model impact, downstream repos, and `needs_verification` semantics.
- Regenerated processed output `data/operator-journal/processed/2026_operator_signal_candidates.json` to include the three new `cand_oj_2026_013_jordyn_tyson_saints_...` candidate IDs.
- Added unit tests in `tests/test_build_operator_signal_candidates.py` covering existence of the three Tyson candidates, required tags, `source_type`/`review_status` defaults, and candidate ID uniqueness, and updated docs `docs/operator-journal-signal-scanner.md` to note QB/environment hypotheses are needs-verification candidates.

### Testing
- Ran the builder with `python scripts/build_operator_signal_candidates.py` and it completed successfully.
- Ran the test suite with `python -m unittest tests/test_build_operator_signal_candidates.py` and all tests passed (`27 tests, OK`).
- Verified the processed JSON contains the three new candidate entries with stable `candidate_id` values derived from the source entry.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef6491ab748332ac2774fca35030c6)