### PR TITLE
Add 2027 watchlist seed for early rookie candidates

### DIFF
--- a/data/raw/2027_watchlist_seed.json
+++ b/data/raw/2027_watchlist_seed.json
@@ -1,0 +1,32 @@
+[
+  {
+    "player_id": "wr-jeremiah-smith",
+    "player_name": "Jeremiah Smith",
+    "position": "WR",
+    "school": "Ohio State",
+    "class_year": 2027,
+    "watchlist_tier": "elite",
+    "early_flags": ["true_freshman_breakout", "power_conference"],
+    "notes": "Consensus top 2027 WR prospect entering draft-eligible season. No alpha scoring applied (pre-final-college-season)."
+  },
+  {
+    "player_id": "wr-malachi-toney",
+    "player_name": "Malachi Toney",
+    "position": "WR",
+    "school": "Miami (FL)",
+    "class_year": 2027,
+    "watchlist_tier": "primary",
+    "early_flags": ["true_freshman_contributor", "power_conference"],
+    "notes": "Watchlist add. No alpha scoring applied (pre-final-college-season)."
+  },
+  {
+    "player_id": "wr-mario-craver",
+    "player_name": "Mario Craver",
+    "position": "WR",
+    "school": "Texas A&M",
+    "class_year": 2027,
+    "watchlist_tier": "primary",
+    "early_flags": ["true_freshman_contributor", "transfer_portal", "power_conference"],
+    "notes": "Watchlist add. Transferred from Mississippi State. No alpha scoring applied (pre-final-college-season)."
+  }
+]

--- a/lib/rookies/rookieDataContract.js
+++ b/lib/rookies/rookieDataContract.js
@@ -1,7 +1,12 @@
 const ROOKIE_SEASONS = [2026, 2025, 2024, 2023, 2022];
+const WATCHLIST_SEASONS = [2027];
 
 export function rookieAlphaExportPath(season) {
   return `/exports/promoted/rookie-alpha/${season}_rookie_alpha_predraft_v0.json`;
+}
+
+export function rookieWatchlistPath(season) {
+  return `/data/raw/${season}_watchlist_seed.json`;
 }
 
 export function rookieDisplaySupplementPaths(season) {
@@ -16,4 +21,8 @@ export function rookieDisplaySupplementPaths(season) {
 
 export function getRookieSeasons() {
   return [...ROOKIE_SEASONS];
+}
+
+export function getWatchlistSeasons() {
+  return [...WATCHLIST_SEASONS];
 }


### PR DESCRIPTION
Introduces a separate watchlist tier (Smith, Toney, Craver) kept out
of the alpha pipeline so pre-final-college-season prospects don't
generate scores against incomplete inputs.