### PR TITLE
Add sourced Devy seed watchlist with provenance and validation

### DIFF
--- a/data/devy/devy_seed_watchlist_2026.json
+++ b/data/devy/devy_seed_watchlist_2026.json
@@ -1,0 +1,252 @@
+{
+  "schema_version": "devy-prospect-registry-v0.1.0",
+  "artifact_type": "devy_seed_watchlist",
+  "as_of_year": 2026,
+  "generated_by": "manual_curated_seed_watchlist",
+  "disclaimer": "Non-promoted Devy seed watchlist for discovery only. Rows are not rankings, not Rookie Alpha inputs, not promoted scouting truth, not NFL draft predictions, and not exact draft-capital projections; stale fields must be re-verified before downstream use.",
+  "prospects": [
+    {
+      "player_id": "chris-henry-jr",
+      "player_name": "Chris Henry Jr.",
+      "school": "Ohio State",
+      "position": "WR",
+      "projected_draft_class": 2029,
+      "earliest_possible_draft_class": 2029,
+      "class_year": 2026,
+      "years_to_projected_draft": 3,
+      "development_horizon": "LONG_HORIZON",
+      "lifecycle_stage": "TRUE_FRESHMAN",
+      "development_tags": [
+        "LONG_HORIZON",
+        "HIGH_RECRUITING_CAPITAL",
+        "PRODUCTION_PENDING",
+        "ROLE_UNCERTAIN"
+      ],
+      "recruiting_stars": null,
+      "recruiting_rank_national": null,
+      "recruiting_rank_position": null,
+      "signal_strength_band": "STRONG",
+      "confidence_band": "LOW",
+      "actionability_band": "WATCHLIST",
+      "volatility_band": "EXTREME",
+      "summary": "Long-horizon Ohio State wide receiver seed row whose current value is timeline context, not near-term rookie scoring.",
+      "why_it_matters": "This row proves the Devy lane can hold an early real-name discovery target while preserving that a 2029-type path is not next-cycle actionable.",
+      "source_notes": [
+        "Official Ohio State roster profile used for name, school, and position verification as of 2026.",
+        "Timeline fields are manual Devy eligibility context from the 2026 class year; re-verify before any promoted use."
+      ],
+      "provenance": {
+        "source_type": "manual_curated_seed",
+        "source_urls": [
+          "https://ohiostatebuckeyes.com/sports/football/roster/chris-henry-jr/13356"
+        ],
+        "source_notes": [
+          "Official Ohio State roster profile used for name, school, and position verification as of 2026.",
+          "No numeric grade, exact draft capital, or scouting conclusion is asserted."
+        ],
+        "last_verified_year": 2026
+      }
+    },
+    {
+      "player_id": "bryce-underwood",
+      "player_name": "Bryce Underwood",
+      "school": "Michigan",
+      "position": "QB",
+      "projected_draft_class": 2028,
+      "earliest_possible_draft_class": 2028,
+      "class_year": 2025,
+      "years_to_projected_draft": 2,
+      "development_horizon": "MEDIUM_TERM",
+      "lifecycle_stage": "EMERGING",
+      "development_tags": [
+        "HIGH_RECRUITING_CAPITAL",
+        "ASCENDING",
+        "PRODUCTION_PENDING",
+        "ROLE_UNCERTAIN"
+      ],
+      "recruiting_stars": null,
+      "recruiting_rank_national": null,
+      "recruiting_rank_position": null,
+      "signal_strength_band": "STRONG",
+      "confidence_band": "MEDIUM",
+      "actionability_band": "MONITOR",
+      "volatility_band": "HIGH",
+      "summary": "Michigan quarterback seed row for medium-term Devy monitoring without converting early collegiate signal into a precise ranking.",
+      "why_it_matters": "Quarterback timelines are especially volatile, so the row captures watchlist context and uncertainty before Rookie Alpha inputs are available.",
+      "source_notes": [
+        "Official Michigan roster profile used for name, school, and position verification.",
+        "Projected draft-class timing is manual eligibility context, not a draft prediction."
+      ],
+      "provenance": {
+        "source_type": "manual_curated_seed",
+        "source_urls": [
+          "https://mgoblue.com/sports/football/roster/bryce-underwood/26792"
+        ],
+        "source_notes": [
+          "Official Michigan roster profile used for identity fields; timeline requires future re-verification."
+        ],
+        "last_verified_year": 2026
+      }
+    },
+    {
+      "player_id": "jeremiah-smith",
+      "player_name": "Jeremiah Smith",
+      "school": "Ohio State",
+      "position": "WR",
+      "projected_draft_class": 2027,
+      "earliest_possible_draft_class": 2027,
+      "class_year": 2024,
+      "years_to_projected_draft": 1,
+      "development_horizon": "NEAR_TERM",
+      "lifecycle_stage": "NFL_TRACK",
+      "development_tags": [
+        "EARLY_DECLARE_CANDIDATE",
+        "ASCENDING",
+        "INSULATED_PROGRAM"
+      ],
+      "recruiting_stars": null,
+      "recruiting_rank_national": null,
+      "recruiting_rank_position": null,
+      "signal_strength_band": "ELITE",
+      "confidence_band": "MEDIUM",
+      "actionability_band": "MONITOR",
+      "volatility_band": "MEDIUM",
+      "summary": "Near-term Ohio State wide receiver watchlist row that remains discovery context rather than a Rookie Alpha row.",
+      "why_it_matters": "The row gives future rookie-pipeline operators a sourced name to monitor while keeping Devy outputs separate from promoted scoring artifacts.",
+      "source_notes": [
+        "Official Ohio State roster profile used for name, school, and position verification as of 2026.",
+        "No draft slot, player comp, or exact grade is asserted."
+      ],
+      "provenance": {
+        "source_type": "manual_curated_seed",
+        "source_urls": [
+          "https://ohiostatebuckeyes.com/sports/football/roster/jeremiah-smith/13335"
+        ],
+        "source_notes": [
+          "Official Ohio State roster profile used for identity fields; Devy bands are manual watchlist labels."
+        ],
+        "last_verified_year": 2026
+      }
+    },
+    {
+      "player_id": "dakorien-moore",
+      "player_name": "Dakorien Moore",
+      "school": "Oregon",
+      "position": "WR",
+      "projected_draft_class": 2028,
+      "earliest_possible_draft_class": 2028,
+      "class_year": 2025,
+      "years_to_projected_draft": 2,
+      "development_horizon": "MEDIUM_TERM",
+      "lifecycle_stage": "EMERGING",
+      "development_tags": [
+        "HIGH_RECRUITING_CAPITAL",
+        "ASCENDING",
+        "PRODUCTION_PENDING"
+      ],
+      "recruiting_stars": null,
+      "recruiting_rank_national": null,
+      "recruiting_rank_position": null,
+      "signal_strength_band": "STRONG",
+      "confidence_band": "MEDIUM",
+      "actionability_band": "MONITOR",
+      "volatility_band": "HIGH",
+      "summary": "Oregon wide receiver seed row for medium-term discovery with sourced identity fields and coarse uncertainty bands.",
+      "why_it_matters": "The row preserves a notable underclass wide receiver in the discovery lane without promoting production, ranking, or draft-capital claims.",
+      "source_notes": [
+        "Official Oregon roster profile used for name, school, and position verification.",
+        "Development bands are manual seed-watchlist context only."
+      ],
+      "provenance": {
+        "source_type": "manual_curated_seed",
+        "source_urls": [
+          "https://goducks.com/sports/football/roster/dakorien-moore/17440"
+        ],
+        "source_notes": [
+          "Official Oregon roster profile used for identity fields; no external scouting text copied."
+        ],
+        "last_verified_year": 2026
+      }
+    },
+    {
+      "player_id": "caden-durham",
+      "player_name": "Caden Durham",
+      "school": "LSU",
+      "position": "RB",
+      "projected_draft_class": 2027,
+      "earliest_possible_draft_class": 2027,
+      "class_year": 2024,
+      "years_to_projected_draft": 1,
+      "development_horizon": "NEAR_TERM",
+      "lifecycle_stage": "BREAKOUT_WINDOW",
+      "development_tags": [
+        "ASCENDING",
+        "EARLY_DECLARE_CANDIDATE",
+        "ROLE_UNCERTAIN"
+      ],
+      "recruiting_stars": null,
+      "recruiting_rank_national": null,
+      "recruiting_rank_position": null,
+      "signal_strength_band": "STRONG",
+      "confidence_band": "MEDIUM",
+      "actionability_band": "MONITOR",
+      "volatility_band": "MEDIUM",
+      "summary": "Near-term LSU running back seed row for watchlist continuity before any rookie-model handoff exists.",
+      "why_it_matters": "Running back windows can change quickly, so this row captures a sourced monitoring state without declaring draft capital or role certainty.",
+      "source_notes": [
+        "Official LSU roster used for name, school, and position verification.",
+        "No exact future draft outcome or numeric grade is asserted."
+      ],
+      "provenance": {
+        "source_type": "manual_curated_seed",
+        "source_urls": [
+          "https://lsusports.net/sports/fb/roster/"
+        ],
+        "source_notes": [
+          "Official LSU roster used for identity fields; watchlist labels are manual and non-promoted."
+        ],
+        "last_verified_year": 2026
+      }
+    },
+    {
+      "player_id": "nate-frazier",
+      "player_name": "Nate Frazier",
+      "school": "Georgia",
+      "position": "RB",
+      "projected_draft_class": 2027,
+      "earliest_possible_draft_class": 2027,
+      "class_year": 2024,
+      "years_to_projected_draft": 1,
+      "development_horizon": "NEAR_TERM",
+      "lifecycle_stage": "BREAKOUT_WINDOW",
+      "development_tags": [
+        "ASCENDING",
+        "EARLY_DECLARE_CANDIDATE",
+        "ROLE_UNCERTAIN"
+      ],
+      "recruiting_stars": null,
+      "recruiting_rank_national": null,
+      "recruiting_rank_position": null,
+      "signal_strength_band": "STRONG",
+      "confidence_band": "MEDIUM",
+      "actionability_band": "MONITOR",
+      "volatility_band": "MEDIUM",
+      "summary": "Near-term Georgia running back seed row that is useful for monitoring but not for promoted rookie scoring.",
+      "why_it_matters": "The row demonstrates how near-term Devy names can be retained with provenance while still requiring a future governed Rookie Alpha intake path.",
+      "source_notes": [
+        "Official Georgia roster profile used for name, school, and position verification as of 2026.",
+        "Draft class timing is manual eligibility context, not a guaranteed declaration year."
+      ],
+      "provenance": {
+        "source_type": "manual_curated_seed",
+        "source_urls": [
+          "https://georgiadogs.com/sports/football/roster/nate-frazier/10638"
+        ],
+        "source_notes": [
+          "Official Georgia roster profile used for identity fields; no proprietary analyst content used."
+        ],
+        "last_verified_year": 2026
+      }
+    }
+  ]
+}

--- a/docs/devy-signal-discovery.md
+++ b/docs/devy-signal-discovery.md
@@ -42,6 +42,39 @@ than player facts. The fixture covers:
 These rows validate schema behavior only. They must not be promoted, treated as
 rankings, or used as sourced scouting claims without documented provenance.
 
+## Real seed watchlist
+
+The first real-name seed watchlist lives at
+`data/devy/devy_seed_watchlist_2026.json`. It is still a **non-promoted seed
+artifact**: the rows are for discovery and operator monitoring only, not
+rankings, Rookie Alpha inputs, promoted scouting truth, or future NFL draft-capital
+claims.
+
+The key distinction from the fixture registry is provenance. Fixture rows are
+placeholder schema examples; seed-watchlist rows may contain real player names
+only when each row includes source notes, a manual-curation source type, source
+URLs when available, and a `last_verified_year`. This keeps the Devy lane from
+inventing continuity when rosters, transfers, development stages, or eligibility
+assumptions become stale.
+
+Real players can enter this lane when a human curator can represent the row with
+coarse, honest context:
+
+- identity fields such as name, school, and position come from documented public
+  sources;
+- timeline fields are framed as projected/earliest-possible draft context, not
+  guaranteed declaration years;
+- signal, confidence, actionability, and volatility remain broad bands instead of
+  numeric grades; and
+- `summary` / `why_it_matters` explain why the player is worth monitoring without
+  copying scouting reports or asserting unsupported traits.
+
+Long-horizon rows should be interpreted as early watchlist signals. For example,
+a 2029-type player in an `as_of_year` 2026 artifact must validate as
+`LONG_HORIZON` and cannot be `TARGET` or `PRIORITY` actionable. This lets TIBER
+surface names before the fantasy market stabilizes while preserving that the row
+is not ready for a rookie-ranking or promoted-export workflow.
+
 ## Horizon logic
 
 The validator derives horizon expectations from `years_to_projected_draft`:
@@ -68,6 +101,12 @@ Run the validator against the fixture registry:
 python3 scripts/devy_signal_registry.py --registry data/fixtures/devy_prospect_registry_v0_fixture.json
 ```
 
+Run the validator against the real seed watchlist:
+
+```bash
+python3 scripts/devy_signal_registry.py --registry data/devy/devy_seed_watchlist_2026.json
+```
+
 Run the focused Devy registry tests:
 
 ```bash
@@ -75,7 +114,8 @@ python3 -m pytest tests/test_devy_signal_registry.py
 ```
 
 The validator checks required fields, canonical enum values, duplicate IDs,
-draft-class chronology, `years_to_projected_draft`, horizon consistency, and the
+draft-class chronology, `years_to_projected_draft`, horizon consistency,
+artifact disclaimers, seed-watchlist provenance/source notes, and the
 long-horizon actionability guardrail.
 
 ## Relationship to Rookie Alpha

--- a/scripts/devy_signal_registry.py
+++ b/scripts/devy_signal_registry.py
@@ -14,6 +14,12 @@ from pathlib import Path
 from typing import Any
 
 CURRENT_DEVY_SCHEMA_VERSION = "devy-prospect-registry-v0.1.0"
+VALID_ARTIFACT_TYPES = frozenset({
+    "fixture_only_devy_signal_discovery_registry",
+    "devy_seed_watchlist",
+})
+SEED_WATCHLIST_ARTIFACT_TYPE = "devy_seed_watchlist"
+SEED_WATCHLIST_SOURCE_TYPE = "manual_curated_seed"
 
 
 class DevyPosition(StrEnum):
@@ -171,6 +177,19 @@ def validate_devy_registry(payload: dict[str, Any]) -> list[str]:
             f"schema_version must be {CURRENT_DEVY_SCHEMA_VERSION!r}; got {payload.get('schema_version')!r}"
         )
 
+    artifact_type = payload.get("artifact_type")
+    if artifact_type not in VALID_ARTIFACT_TYPES:
+        errors.append(f"artifact_type has invalid value {artifact_type!r}")
+
+    disclaimer = payload.get("disclaimer")
+    if not isinstance(disclaimer, str) or not disclaimer.strip():
+        errors.append("disclaimer must be a non-empty string")
+    elif artifact_type == SEED_WATCHLIST_ARTIFACT_TYPE:
+        disclaimer_lower = disclaimer.lower()
+        for required_phrase in ("seed watchlist", "not rankings", "not rookie alpha inputs"):
+            if required_phrase not in disclaimer_lower:
+                errors.append(f"seed watchlist disclaimer must include {required_phrase!r}")
+
     as_of_year = payload.get("as_of_year")
     if not isinstance(as_of_year, int) or isinstance(as_of_year, bool):
         errors.append("as_of_year must be an integer season/year")
@@ -281,6 +300,47 @@ def validate_devy_registry(payload: dict[str, Any]) -> list[str]:
             for note in source_notes:
                 if not isinstance(note, str) or not note.strip():
                     errors.append(f"{prefix}.source_notes entries must be non-empty strings")
+
+        if artifact_type == SEED_WATCHLIST_ARTIFACT_TYPE:
+            provenance = prospect.get("provenance")
+            if not isinstance(provenance, dict):
+                errors.append(f"{prefix}.provenance must be an object for seed watchlist rows")
+            else:
+                if provenance.get("source_type") != SEED_WATCHLIST_SOURCE_TYPE:
+                    errors.append(
+                        f"{prefix}.provenance.source_type must be {SEED_WATCHLIST_SOURCE_TYPE!r}"
+                    )
+
+                provenance_notes = provenance.get("source_notes")
+                if not isinstance(provenance_notes, list) or not provenance_notes:
+                    errors.append(f"{prefix}.provenance.source_notes must be a non-empty list")
+                else:
+                    for note in provenance_notes:
+                        if not isinstance(note, str) or not note.strip():
+                            errors.append(
+                                f"{prefix}.provenance.source_notes entries must be non-empty strings"
+                            )
+
+                source_urls = provenance.get("source_urls")
+                if source_urls is not None:
+                    if not isinstance(source_urls, list) or not source_urls:
+                        errors.append(f"{prefix}.provenance.source_urls must be a non-empty list when present")
+                    else:
+                        for url in source_urls:
+                            if not isinstance(url, str) or not url.startswith(("https://", "http://")):
+                                errors.append(
+                                    f"{prefix}.provenance.source_urls entries must be HTTP(S) URLs"
+                                )
+
+                last_verified_year = provenance.get("last_verified_year")
+                if (
+                    not isinstance(last_verified_year, int)
+                    or isinstance(last_verified_year, bool)
+                    or (isinstance(as_of_year, int) and last_verified_year > as_of_year)
+                ):
+                    errors.append(
+                        f"{prefix}.provenance.last_verified_year must be an integer no later than as_of_year"
+                    )
 
     return errors
 

--- a/tests/test_devy_signal_registry.py
+++ b/tests/test_devy_signal_registry.py
@@ -18,9 +18,40 @@ class DevySignalRegistryTests(unittest.TestCase):
     def setUp(self) -> None:
         self.fixture_path = Path("data/fixtures/devy_prospect_registry_v0_fixture.json")
         self.payload = json.loads(self.fixture_path.read_text(encoding="utf-8"))
+        self.seed_path = Path("data/devy/devy_seed_watchlist_2026.json")
+        self.seed_payload = json.loads(self.seed_path.read_text(encoding="utf-8"))
 
     def test_fixture_registry_validates(self) -> None:
         self.assertEqual(validate_devy_registry(self.payload), [])
+
+    def test_seed_watchlist_validates(self) -> None:
+        self.assertEqual(validate_devy_registry(self.seed_payload), [])
+
+    def test_seed_watchlist_long_horizon_player_is_not_near_term_actionable(self) -> None:
+        prospect = next(p for p in self.seed_payload["prospects"] if p["player_id"] == "chris-henry-jr")
+        self.assertEqual(prospect["development_horizon"], DevyDevelopmentHorizon.LONG_HORIZON.value)
+        self.assertEqual(prospect["actionability_band"], "WATCHLIST")
+        self.assertNotIn(prospect["actionability_band"], {"TARGET", "PRIORITY"})
+
+    def test_seed_watchlist_missing_provenance_notes_fails_validation(self) -> None:
+        payload = copy.deepcopy(self.seed_payload)
+        payload["prospects"][0]["provenance"]["source_notes"] = []
+        errors = validate_devy_registry(payload)
+        self.assertTrue(any("provenance.source_notes must be a non-empty list" in error for error in errors))
+
+    def test_seed_watchlist_duplicate_player_ids_fail_validation(self) -> None:
+        payload = copy.deepcopy(self.seed_payload)
+        payload["prospects"][1]["player_id"] = payload["prospects"][0]["player_id"]
+        errors = validate_devy_registry(payload)
+        self.assertTrue(any("player_id duplicates" in error for error in errors))
+
+    def test_seed_watchlist_invalid_horizon_and_tag_fail_validation(self) -> None:
+        payload = copy.deepcopy(self.seed_payload)
+        payload["prospects"][0]["development_horizon"] = DevyDevelopmentHorizon.NEAR_TERM.value
+        payload["prospects"][0]["development_tags"].append("UNSUPPORTED_TAG")
+        errors = validate_devy_registry(payload)
+        self.assertTrue(any("development_horizon must be" in error for error in errors))
+        self.assertTrue(any("development_tags has invalid value" in error for error in errors))
 
     def test_enums_are_centrally_exported(self) -> None:
         snapshot = enum_snapshot()


### PR DESCRIPTION
### Motivation

- Provide a non-promoted, real-name Devy seed watchlist for early discovery while preventing inadvertent promotion into Rookie Alpha or ranking workflows.
- Enforce provenance, artifact-level disclaimers, and horizon/actionability guardrails so seed watchlist rows carry verifiable source metadata and cannot be misinterpreted as promoted outputs.

### Description

- Add `data/devy/devy_seed_watchlist_2026.json`, a curated non-promoted seed watchlist containing sourced rows with `provenance` (source_type, source_notes, optional `source_urls`, and `last_verified_year`).
- Extend `scripts/devy_signal_registry.py` to declare `VALID_ARTIFACT_TYPES`, seed-watchlist constants, require artifact-level `disclaimer` phrases for seed watchlists, and validate per-row `provenance` fields and their constraints.
- Add focused tests in `tests/test_devy_signal_registry.py` to cover seed-watchlist validation, long-horizon actionability guardrails, missing provenance notes, duplicate player IDs, and invalid horizon/tag handling.
- Update `docs/devy-signal-discovery.md` to document the distinction between fixture-only registries and the real seed watchlist, provenance expectations, and the validator command for the seed watchlist.

### Testing

- Ran the validator against the fixture registry with `python3 scripts/devy_signal_registry.py --registry data/fixtures/devy_prospect_registry_v0_fixture.json` and it passed.
- Ran the validator against the new seed watchlist with `python3 scripts/devy_signal_registry.py --registry data/devy/devy_seed_watchlist_2026.json` and it passed.
- Ran the unit tests with `python3 -m pytest tests/test_devy_signal_registry.py` and all tests passed (`13 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ba2547bd8833294b75519a39a46a2)