### PR TITLE
Split Devy seed-watchlist provenance into identity/timeline/signal and tighten validation

### DIFF
--- a/data/devy/devy_seed_watchlist_2026.json
+++ b/data/devy/devy_seed_watchlist_2026.json
@@ -35,14 +35,27 @@
         "Official Ohio State roster profile used for name, school, and position verification as of 2026.",
         "Timeline fields are manual Devy eligibility context from the 2026 class year; re-verify before any promoted use."
       ],
-      "provenance": {
-        "source_type": "manual_curated_seed",
+      "identity_provenance": {
+        "source_type": "official_roster",
         "source_urls": [
           "https://ohiostatebuckeyes.com/sports/football/roster/chris-henry-jr/13356"
         ],
         "source_notes": [
-          "Official Ohio State roster profile used for name, school, and position verification as of 2026.",
-          "No numeric grade, exact draft capital, or scouting conclusion is asserted."
+          "Used for name, school, and position verification."
+        ],
+        "last_verified_year": 2026
+      },
+      "timeline_provenance": {
+        "source_type": "manual_eligibility_context",
+        "source_notes": [
+          "Projected draft-class timing is manual eligibility context, not a declaration prediction."
+        ],
+        "last_verified_year": 2026
+      },
+      "signal_provenance": {
+        "source_type": "manual_curated_seed_signal",
+        "source_notes": [
+          "Used for broad watchlist tags/bands only; not a ranking or scouting grade."
         ],
         "last_verified_year": 2026
       }
@@ -77,13 +90,27 @@
         "Official Michigan roster profile used for name, school, and position verification.",
         "Projected draft-class timing is manual eligibility context, not a draft prediction."
       ],
-      "provenance": {
-        "source_type": "manual_curated_seed",
+      "identity_provenance": {
+        "source_type": "official_roster",
         "source_urls": [
           "https://mgoblue.com/sports/football/roster/bryce-underwood/26792"
         ],
         "source_notes": [
-          "Official Michigan roster profile used for identity fields; timeline requires future re-verification."
+          "Used for name, school, and position verification."
+        ],
+        "last_verified_year": 2026
+      },
+      "timeline_provenance": {
+        "source_type": "manual_eligibility_context",
+        "source_notes": [
+          "Projected draft-class timing is manual eligibility context, not a declaration prediction."
+        ],
+        "last_verified_year": 2026
+      },
+      "signal_provenance": {
+        "source_type": "manual_curated_seed_signal",
+        "source_notes": [
+          "Used for broad watchlist tags/bands only; not a ranking or scouting grade."
         ],
         "last_verified_year": 2026
       }
@@ -117,13 +144,27 @@
         "Official Ohio State roster profile used for name, school, and position verification as of 2026.",
         "No draft slot, player comp, or exact grade is asserted."
       ],
-      "provenance": {
-        "source_type": "manual_curated_seed",
+      "identity_provenance": {
+        "source_type": "official_roster",
         "source_urls": [
           "https://ohiostatebuckeyes.com/sports/football/roster/jeremiah-smith/13335"
         ],
         "source_notes": [
-          "Official Ohio State roster profile used for identity fields; Devy bands are manual watchlist labels."
+          "Used for name, school, and position verification."
+        ],
+        "last_verified_year": 2026
+      },
+      "timeline_provenance": {
+        "source_type": "manual_eligibility_context",
+        "source_notes": [
+          "Projected draft-class timing is manual eligibility context, not a declaration prediction."
+        ],
+        "last_verified_year": 2026
+      },
+      "signal_provenance": {
+        "source_type": "manual_curated_seed_signal",
+        "source_notes": [
+          "Used for broad watchlist tags/bands only; not a ranking or scouting grade."
         ],
         "last_verified_year": 2026
       }
@@ -157,13 +198,27 @@
         "Official Oregon roster profile used for name, school, and position verification.",
         "Development bands are manual seed-watchlist context only."
       ],
-      "provenance": {
-        "source_type": "manual_curated_seed",
+      "identity_provenance": {
+        "source_type": "official_roster",
         "source_urls": [
           "https://goducks.com/sports/football/roster/dakorien-moore/17440"
         ],
         "source_notes": [
-          "Official Oregon roster profile used for identity fields; no external scouting text copied."
+          "Used for name, school, and position verification."
+        ],
+        "last_verified_year": 2026
+      },
+      "timeline_provenance": {
+        "source_type": "manual_eligibility_context",
+        "source_notes": [
+          "Projected draft-class timing is manual eligibility context, not a declaration prediction."
+        ],
+        "last_verified_year": 2026
+      },
+      "signal_provenance": {
+        "source_type": "manual_curated_seed_signal",
+        "source_notes": [
+          "Used for broad watchlist tags/bands only; not a ranking or scouting grade."
         ],
         "last_verified_year": 2026
       }
@@ -197,13 +252,27 @@
         "Official LSU roster used for name, school, and position verification.",
         "No exact future draft outcome or numeric grade is asserted."
       ],
-      "provenance": {
-        "source_type": "manual_curated_seed",
+      "identity_provenance": {
+        "source_type": "official_roster",
         "source_urls": [
           "https://lsusports.net/sports/fb/roster/"
         ],
         "source_notes": [
-          "Official LSU roster used for identity fields; watchlist labels are manual and non-promoted."
+          "Used for name, school, and position verification."
+        ],
+        "last_verified_year": 2026
+      },
+      "timeline_provenance": {
+        "source_type": "manual_eligibility_context",
+        "source_notes": [
+          "Projected draft-class timing is manual eligibility context, not a declaration prediction."
+        ],
+        "last_verified_year": 2026
+      },
+      "signal_provenance": {
+        "source_type": "manual_curated_seed_signal",
+        "source_notes": [
+          "Used for broad watchlist tags/bands only; not a ranking or scouting grade."
         ],
         "last_verified_year": 2026
       }
@@ -237,13 +306,27 @@
         "Official Georgia roster profile used for name, school, and position verification as of 2026.",
         "Draft class timing is manual eligibility context, not a guaranteed declaration year."
       ],
-      "provenance": {
-        "source_type": "manual_curated_seed",
+      "identity_provenance": {
+        "source_type": "official_roster",
         "source_urls": [
           "https://georgiadogs.com/sports/football/roster/nate-frazier/10638"
         ],
         "source_notes": [
-          "Official Georgia roster profile used for identity fields; no proprietary analyst content used."
+          "Used for name, school, and position verification."
+        ],
+        "last_verified_year": 2026
+      },
+      "timeline_provenance": {
+        "source_type": "manual_eligibility_context",
+        "source_notes": [
+          "Projected draft-class timing is manual eligibility context, not a declaration prediction."
+        ],
+        "last_verified_year": 2026
+      },
+      "signal_provenance": {
+        "source_type": "manual_curated_seed_signal",
+        "source_notes": [
+          "Used for broad watchlist tags/bands only; not a ranking or scouting grade."
         ],
         "last_verified_year": 2026
       }

--- a/docs/devy-signal-discovery.md
+++ b/docs/devy-signal-discovery.md
@@ -52,10 +52,17 @@ claims.
 
 The key distinction from the fixture registry is provenance. Fixture rows are
 placeholder schema examples; seed-watchlist rows may contain real player names
-only when each row includes source notes, a manual-curation source type, source
-URLs when available, and a `last_verified_year`. This keeps the Devy lane from
-inventing continuity when rosters, transfers, development stages, or eligibility
-assumptions become stale.
+only when each row separates:
+
+- `identity_provenance` (for name/school/position),
+- `timeline_provenance` (for projected/earliest draft-class context), and
+- `signal_provenance` (for interpretive tags and bands).
+
+Each provenance object must include canonical `source_type`, non-empty
+`source_notes`, and a `last_verified_year` no later than artifact
+`as_of_year`; `source_urls` are optional but must be valid HTTP(S) links when
+present. This keeps the Devy lane from inventing continuity when rosters,
+transfers, development stages, or eligibility assumptions become stale.
 
 Real players can enter this lane when a human curator can represent the row with
 coarse, honest context:
@@ -115,7 +122,8 @@ python3 -m pytest tests/test_devy_signal_registry.py
 
 The validator checks required fields, canonical enum values, duplicate IDs,
 draft-class chronology, `years_to_projected_draft`, horizon consistency,
-artifact disclaimers, seed-watchlist provenance/source notes, and the
+artifact disclaimers, split seed-watchlist provenance categories, canonical
+source types, source URL format, `last_verified_year` bounds, and the
 long-horizon actionability guardrail.
 
 ## Relationship to Rookie Alpha

--- a/scripts/devy_signal_registry.py
+++ b/scripts/devy_signal_registry.py
@@ -19,7 +19,17 @@ VALID_ARTIFACT_TYPES = frozenset({
     "devy_seed_watchlist",
 })
 SEED_WATCHLIST_ARTIFACT_TYPE = "devy_seed_watchlist"
-SEED_WATCHLIST_SOURCE_TYPE = "manual_curated_seed"
+SEED_WATCHLIST_IDENTITY_FIELDS = frozenset({"player_name", "school", "position"})
+SEED_WATCHLIST_TIMELINE_FIELDS = frozenset({"projected_draft_class", "earliest_possible_draft_class", "class_year", "years_to_projected_draft"})
+SEED_WATCHLIST_SIGNAL_FIELDS = frozenset({"development_tags", "signal_strength_band", "confidence_band", "actionability_band", "volatility_band"})
+CANONICAL_PROVENANCE_SOURCE_TYPES = frozenset({
+    "official_roster",
+    "manual_eligibility_context",
+    "manual_curated_seed_signal",
+    "recruiting_profile",
+    "production_data",
+    "team_context_artifact",
+})
 
 
 class DevyPosition(StrEnum):
@@ -302,35 +312,47 @@ def validate_devy_registry(payload: dict[str, Any]) -> list[str]:
                     errors.append(f"{prefix}.source_notes entries must be non-empty strings")
 
         if artifact_type == SEED_WATCHLIST_ARTIFACT_TYPE:
-            provenance = prospect.get("provenance")
-            if not isinstance(provenance, dict):
-                errors.append(f"{prefix}.provenance must be an object for seed watchlist rows")
-            else:
-                if provenance.get("source_type") != SEED_WATCHLIST_SOURCE_TYPE:
+            required_map = {
+                "identity_provenance": SEED_WATCHLIST_IDENTITY_FIELDS,
+                "timeline_provenance": SEED_WATCHLIST_TIMELINE_FIELDS,
+                "signal_provenance": SEED_WATCHLIST_SIGNAL_FIELDS,
+            }
+            for provenance_key, expected_fields in required_map.items():
+                provenance = prospect.get(provenance_key)
+                if not isinstance(provenance, dict):
+                    errors.append(f"{prefix}.{provenance_key} must be an object for seed watchlist rows")
+                    continue
+
+                source_type = provenance.get("source_type")
+                if source_type not in CANONICAL_PROVENANCE_SOURCE_TYPES:
                     errors.append(
-                        f"{prefix}.provenance.source_type must be {SEED_WATCHLIST_SOURCE_TYPE!r}"
+                        f"{prefix}.{provenance_key}.source_type must be one of "
+                        f"{sorted(CANONICAL_PROVENANCE_SOURCE_TYPES)!r}"
                     )
+
+                provenance_fields = provenance.get("supports_fields")
+                if provenance_fields is not None:
+                    if not isinstance(provenance_fields, list) or not provenance_fields:
+                        errors.append(f"{prefix}.{provenance_key}.supports_fields must be a non-empty list when present")
+                    elif set(provenance_fields) != expected_fields:
+                        errors.append(f"{prefix}.{provenance_key}.supports_fields must match canonical field scope")
 
                 provenance_notes = provenance.get("source_notes")
                 if not isinstance(provenance_notes, list) or not provenance_notes:
-                    errors.append(f"{prefix}.provenance.source_notes must be a non-empty list")
+                    errors.append(f"{prefix}.{provenance_key}.source_notes must be a non-empty list")
                 else:
                     for note in provenance_notes:
                         if not isinstance(note, str) or not note.strip():
-                            errors.append(
-                                f"{prefix}.provenance.source_notes entries must be non-empty strings"
-                            )
+                            errors.append(f"{prefix}.{provenance_key}.source_notes entries must be non-empty strings")
 
                 source_urls = provenance.get("source_urls")
                 if source_urls is not None:
                     if not isinstance(source_urls, list) or not source_urls:
-                        errors.append(f"{prefix}.provenance.source_urls must be a non-empty list when present")
+                        errors.append(f"{prefix}.{provenance_key}.source_urls must be a non-empty list when present")
                     else:
                         for url in source_urls:
                             if not isinstance(url, str) or not url.startswith(("https://", "http://")):
-                                errors.append(
-                                    f"{prefix}.provenance.source_urls entries must be HTTP(S) URLs"
-                                )
+                                errors.append(f"{prefix}.{provenance_key}.source_urls entries must be HTTP(S) URLs")
 
                 last_verified_year = provenance.get("last_verified_year")
                 if (
@@ -338,9 +360,7 @@ def validate_devy_registry(payload: dict[str, Any]) -> list[str]:
                     or isinstance(last_verified_year, bool)
                     or (isinstance(as_of_year, int) and last_verified_year > as_of_year)
                 ):
-                    errors.append(
-                        f"{prefix}.provenance.last_verified_year must be an integer no later than as_of_year"
-                    )
+                    errors.append(f"{prefix}.{provenance_key}.last_verified_year must be an integer no later than as_of_year")
 
     return errors
 

--- a/tests/test_devy_signal_registry.py
+++ b/tests/test_devy_signal_registry.py
@@ -35,9 +35,9 @@ class DevySignalRegistryTests(unittest.TestCase):
 
     def test_seed_watchlist_missing_provenance_notes_fails_validation(self) -> None:
         payload = copy.deepcopy(self.seed_payload)
-        payload["prospects"][0]["provenance"]["source_notes"] = []
+        payload["prospects"][0]["identity_provenance"]["source_notes"] = []
         errors = validate_devy_registry(payload)
-        self.assertTrue(any("provenance.source_notes must be a non-empty list" in error for error in errors))
+        self.assertTrue(any("identity_provenance.source_notes must be a non-empty list" in error for error in errors))
 
     def test_seed_watchlist_duplicate_player_ids_fail_validation(self) -> None:
         payload = copy.deepcopy(self.seed_payload)
@@ -102,6 +102,35 @@ class DevySignalRegistryTests(unittest.TestCase):
         payload["prospects"][0]["actionability_band"] = "TARGET"
         errors = validate_devy_registry(payload)
         self.assertTrue(any("long-horizon prospect cannot be TARGET or PRIORITY" in error for error in errors))
+
+
+    def test_missing_identity_provenance_fails_validation(self) -> None:
+        payload = copy.deepcopy(self.seed_payload)
+        payload["prospects"][0].pop("identity_provenance", None)
+        errors = validate_devy_registry(payload)
+        self.assertTrue(any("identity_provenance must be an object" in error for error in errors))
+
+    def test_missing_signal_provenance_fails_when_signal_fields_present(self) -> None:
+        payload = copy.deepcopy(self.seed_payload)
+        payload["prospects"][0].pop("signal_provenance", None)
+        errors = validate_devy_registry(payload)
+        self.assertTrue(any("signal_provenance must be an object" in error for error in errors))
+
+    def test_missing_timeline_provenance_fails_when_timeline_fields_present(self) -> None:
+        payload = copy.deepcopy(self.seed_payload)
+        payload["prospects"][0].pop("timeline_provenance", None)
+        errors = validate_devy_registry(payload)
+        self.assertTrue(any("timeline_provenance must be an object" in error for error in errors))
+
+    def test_invalid_provenance_source_type_url_and_future_year_fail(self) -> None:
+        payload = copy.deepcopy(self.seed_payload)
+        payload["prospects"][0]["identity_provenance"]["source_type"] = "made_up_source"
+        payload["prospects"][0]["identity_provenance"]["source_urls"] = ["ftp://not-allowed"]
+        payload["prospects"][0]["identity_provenance"]["last_verified_year"] = payload["as_of_year"] + 1
+        errors = validate_devy_registry(payload)
+        self.assertTrue(any("source_type must be one of" in error for error in errors))
+        self.assertTrue(any("source_urls entries must be HTTP(S) URLs" in error for error in errors))
+        self.assertTrue(any("last_verified_year must be an integer no later than as_of_year" in error for error in errors))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Make provenance for real seed watchlist rows explicit and auditable by separating identity, timeline, and signal provenance instead of a single `provenance` object. 
- Prevent accidental promotion or misattribution by enforcing canonical provenance source types, URL format, and `last_verified_year` bounds per provenance category.
- Reduce downstream ambiguity when ingesting Devy discovery rows while preserving that Devy is upstream/additive to Rookie Alpha.

### Description
- Updated `scripts/devy_signal_registry.py` to require `identity_provenance`, `timeline_provenance`, and `signal_provenance` on `devy_seed_watchlist` rows and added `CANONICAL_PROVENANCE_SOURCE_TYPES`, canonical field sets (`SEED_WATCHLIST_IDENTITY_FIELDS`, `SEED_WATCHLIST_TIMELINE_FIELDS`, `SEED_WATCHLIST_SIGNAL_FIELDS`), optional `supports_fields` validation, HTTP(S) `source_urls` format checks, and per-category `last_verified_year <= as_of_year` checks. 
- Migrated `data/devy/devy_seed_watchlist_2026.json` from a single `provenance` object into the three provenance categories for each prospect. 
- Extended `tests/test_devy_signal_registry.py` with focused tests for missing provenance categories, invalid provenance `source_type`, invalid `source_urls` format, and future `last_verified_year`. 
- Updated `docs/devy-signal-discovery.md` to document the split provenance model and the validator rules enforced for seed-watchlist artifacts.

### Testing
- Ran the validator against the migrated artifact with `python3 scripts/devy_signal_registry.py --registry data/devy/devy_seed_watchlist_2026.json` which reported `DEVY REGISTRY VALIDATION PASSED`. 
- Ran the focused test suite with `python3 -m pytest tests/test_devy_signal_registry.py` which returned `17 passed` and no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bb22153e08332908263eb160ea2e0)