### PR TITLE
Enforce category-scoped provenance source types for Devy seed rows

### DIFF
--- a/docs/devy-signal-discovery.md
+++ b/docs/devy-signal-discovery.md
@@ -61,8 +61,16 @@ only when each row separates:
 Each provenance object must include canonical `source_type`, non-empty
 `source_notes`, and a `last_verified_year` no later than artifact
 `as_of_year`; `source_urls` are optional but must be valid HTTP(S) links when
-present. This keeps the Devy lane from inventing continuity when rosters,
-transfers, development stages, or eligibility assumptions become stale.
+present. Source types are validated per provenance category, not only against
+a global canonical list:
+
+- `identity_provenance`: `official_roster` or `recruiting_profile`
+- `timeline_provenance`: `manual_eligibility_context` or `recruiting_profile`
+- `signal_provenance`: `manual_curated_seed_signal`, `recruiting_profile`,
+  `production_data`, or `team_context_artifact`
+
+This keeps the Devy lane from inventing continuity when rosters, transfers,
+development stages, or eligibility assumptions become stale.
 
 Real players can enter this lane when a human curator can represent the row with
 coarse, honest context:

--- a/scripts/devy_signal_registry.py
+++ b/scripts/devy_signal_registry.py
@@ -30,6 +30,16 @@ CANONICAL_PROVENANCE_SOURCE_TYPES = frozenset({
     "production_data",
     "team_context_artifact",
 })
+ALLOWED_PROVENANCE_SOURCE_TYPES_BY_CATEGORY: dict[str, frozenset[str]] = {
+    "identity_provenance": frozenset({"official_roster", "recruiting_profile"}),
+    "timeline_provenance": frozenset({"manual_eligibility_context", "recruiting_profile"}),
+    "signal_provenance": frozenset({
+        "manual_curated_seed_signal",
+        "recruiting_profile",
+        "production_data",
+        "team_context_artifact",
+    }),
+}
 
 
 class DevyPosition(StrEnum):
@@ -329,6 +339,13 @@ def validate_devy_registry(payload: dict[str, Any]) -> list[str]:
                         f"{prefix}.{provenance_key}.source_type must be one of "
                         f"{sorted(CANONICAL_PROVENANCE_SOURCE_TYPES)!r}"
                     )
+                else:
+                    allowed_source_types = ALLOWED_PROVENANCE_SOURCE_TYPES_BY_CATEGORY[provenance_key]
+                    if source_type not in allowed_source_types:
+                        errors.append(
+                            f"{prefix}.{provenance_key}.source_type {source_type!r} is not allowed for "
+                            f"{provenance_key}; allowed values are {sorted(allowed_source_types)!r}"
+                        )
 
                 provenance_fields = provenance.get("supports_fields")
                 if provenance_fields is not None:

--- a/tests/test_devy_signal_registry.py
+++ b/tests/test_devy_signal_registry.py
@@ -122,6 +122,31 @@ class DevySignalRegistryTests(unittest.TestCase):
         errors = validate_devy_registry(payload)
         self.assertTrue(any("timeline_provenance must be an object" in error for error in errors))
 
+
+    def test_identity_provenance_rejects_signal_only_source_type(self) -> None:
+        payload = copy.deepcopy(self.seed_payload)
+        payload["prospects"][0]["identity_provenance"]["source_type"] = "manual_curated_seed_signal"
+        errors = validate_devy_registry(payload)
+        self.assertTrue(any("identity_provenance.source_type 'manual_curated_seed_signal' is not allowed" in error for error in errors))
+
+    def test_timeline_provenance_rejects_roster_source_type(self) -> None:
+        payload = copy.deepcopy(self.seed_payload)
+        payload["prospects"][0]["timeline_provenance"]["source_type"] = "official_roster"
+        errors = validate_devy_registry(payload)
+        self.assertTrue(any("timeline_provenance.source_type 'official_roster' is not allowed" in error for error in errors))
+
+    def test_signal_provenance_rejects_roster_source_type(self) -> None:
+        payload = copy.deepcopy(self.seed_payload)
+        payload["prospects"][0]["signal_provenance"]["source_type"] = "official_roster"
+        errors = validate_devy_registry(payload)
+        self.assertTrue(any("signal_provenance.source_type 'official_roster' is not allowed" in error for error in errors))
+
+    def test_signal_provenance_accepts_team_context_artifact_source_type(self) -> None:
+        payload = copy.deepcopy(self.seed_payload)
+        payload["prospects"][0]["signal_provenance"]["source_type"] = "team_context_artifact"
+        errors = validate_devy_registry(payload)
+        self.assertEqual(errors, [])
+
     def test_invalid_provenance_source_type_url_and_future_year_fail(self) -> None:
         payload = copy.deepcopy(self.seed_payload)
         payload["prospects"][0]["identity_provenance"]["source_type"] = "made_up_source"


### PR DESCRIPTION
### Motivation
- Prevent semantically mismatched provenance `source_type` values from being accepted for seed watchlist rows by enforcing category-specific constraints. 
- Tighten Devy registry validation to surface provenance errors earlier and avoid downstream misinterpretation of identity/timeline/signal claims.

### Description
- Add `ALLOWED_PROVENANCE_SOURCE_TYPES_BY_CATEGORY` in `scripts/devy_signal_registry.py` and keep the existing global `CANONICAL_PROVENANCE_SOURCE_TYPES` check. 
- Extend `validate_devy_registry` to validate `source_type` first against the global canonical set and then against the per-category allowlist with clear, category-specific error messages. 
- Update `docs/devy-signal-discovery.md` to document the allowed `source_type` mapping per provenance category. 
- Add focused unit tests in `tests/test_devy_signal_registry.py` covering invalid category/source-type combinations and a positive case for `team_context_artifact` in `signal_provenance`.

### Testing
- Ran the validator against the real seed watchlist with `python3 scripts/devy_signal_registry.py --registry data/devy/devy_seed_watchlist_2026.json` and it printed `DEVY REGISTRY VALIDATION PASSED`. 
- Ran the Devy registry unit tests with `python3 -m pytest tests/test_devy_signal_registry.py` and all tests passed (`21 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bc59e5680833294ea5de093c4f3d2)