### PR TITLE
Add intake_audit trail to devy seed watchlist and validate it

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,10 @@ See `docs/devy-signal-discovery.md` for the lifecycle vocabulary, horizon logic,
 and guardrails that keep 2029-type long-horizon assets from being treated as
 next-cycle rookie prospects.
 
+The real seed watchlist (`data/devy/devy_seed_watchlist_2026.json`) is a curated
+non-promoted discovery artifact with an artifact-level `intake_audit` trail
+(issue/PR lineage, intake method, validator command, and downstream block status).
+
 
 ## Parallel ML evaluation lane (phase 1, experimental)
 

--- a/data/devy/devy_seed_watchlist_2026.json
+++ b/data/devy/devy_seed_watchlist_2026.json
@@ -1310,5 +1310,17 @@
         "last_verified_year": 2026
       }
     }
-  ]
+  ],
+  "intake_audit": {
+    "intake_method": "codex_curated_task",
+    "introduced_by_issue": 227,
+    "introduced_by_pr": 228,
+    "validation_command": "python3 scripts/devy_signal_registry.py --registry data/devy/devy_seed_watchlist_2026.json",
+    "promotion_status": "non_promoted_discovery_only",
+    "downstream_eligibility": "blocked_until_rookie_transition",
+    "notes": [
+      "Rows were added through curated operator/Codex task specs and are not autonomously ingested.",
+      "scripts/devy_signal_registry.py is used as schema/provenance validation guard, not as ingestion or scraping pipeline."
+    ]
+  }
 }

--- a/docs/devy-signal-discovery.md
+++ b/docs/devy-signal-discovery.md
@@ -52,9 +52,14 @@ claims.
 
 The key distinction from the fixture registry is provenance. Fixture rows are
 placeholder schema examples; seed-watchlist rows may contain real player names
-
-Current seed coverage intentionally spans near-term (2027), medium-term (2028), and long-horizon (2029) windows across QB/RB/WR/TE so operators can discover names without turning this artifact into rankings. The post-#226 discovery-v2 pass broadens 2029 coverage with additional deep-dynasty watchlist candidates sourced from player-level recruiting profiles while preserving unresolved program mappings as `unknown` when roster-level verification is unavailable.
 only when each row separates:
+
+Current seed coverage intentionally spans near-term (2027), medium-term (2028), and
+long-horizon (2029) windows across QB/RB/WR/TE so operators can discover names
+without turning this artifact into rankings. The post-#226 discovery-v2 pass broadens
+2029 coverage with additional deep-dynasty watchlist candidates sourced from
+player-level recruiting profiles while preserving unresolved program mappings as
+`unknown` when roster-level verification is unavailable.
 
 - `identity_provenance` (for name/school/position),
 - `timeline_provenance` (for projected/earliest draft-class context), and
@@ -91,6 +96,22 @@ a 2029-type player in an `as_of_year` 2026 artifact must validate as
 `LONG_HORIZON` and cannot be `TARGET` or `PRIORITY` actionable. This lets TIBER
 surface names before the fantasy market stabilizes while preserving that the row
 is not ready for a rookie-ranking or promoted-export workflow.
+
+
+### Intake audit trail
+
+The seed watchlist now carries an artifact-level `intake_audit` block to document
+how rows entered the registry and preserve honest Devy v1 claims:
+
+- `intake_method`: curated/manual/Codex lineage (not autonomous scraping),
+- `introduced_by_issue` and `introduced_by_pr`: traceability back to issue/PR,
+- `validation_command`: exact validator command used as the schema guardrail,
+- `promotion_status`: non-promoted discovery posture, and
+- `downstream_eligibility`: explicit block from rookie/NFL scoring surfaces
+  until a governed transition path exists.
+
+This captures the Derrek Cooper path (`Issue #227 -> PR #228 -> seed watchlist ->
+validator`) as a documented curated workflow rather than an ingestion pipeline.
 
 ## Horizon logic
 

--- a/scripts/devy_signal_registry.py
+++ b/scripts/devy_signal_registry.py
@@ -42,6 +42,21 @@ ALLOWED_PROVENANCE_SOURCE_TYPES_BY_CATEGORY: dict[str, frozenset[str]] = {
 }
 
 
+SEED_WATCHLIST_ALLOWED_INTAKE_METHODS = frozenset({
+    "manual_curated_seed_watchlist",
+    "codex_curated_task",
+    "future_script_generated_candidate",
+})
+SEED_WATCHLIST_ALLOWED_PROMOTION_STATUSES = frozenset({
+    "non_promoted_discovery_only",
+    "blocked_from_downstream_use",
+})
+SEED_WATCHLIST_ALLOWED_DOWNSTREAM_ELIGIBILITY = frozenset({
+    "blocked_until_rookie_transition",
+    "blocked",
+})
+
+
 class DevyPosition(StrEnum):
     QB = "QB"
     RB = "RB"
@@ -214,6 +229,46 @@ def validate_devy_registry(payload: dict[str, Any]) -> list[str]:
     if not isinstance(as_of_year, int) or isinstance(as_of_year, bool):
         errors.append("as_of_year must be an integer season/year")
         as_of_year = None
+
+    if artifact_type == SEED_WATCHLIST_ARTIFACT_TYPE:
+        intake_audit = payload.get("intake_audit")
+        if not isinstance(intake_audit, dict):
+            errors.append("intake_audit must be an object for seed watchlist artifacts")
+        else:
+            intake_method = intake_audit.get("intake_method")
+            if intake_method not in SEED_WATCHLIST_ALLOWED_INTAKE_METHODS:
+                errors.append(
+                    f"intake_audit.intake_method must be one of {sorted(SEED_WATCHLIST_ALLOWED_INTAKE_METHODS)!r}"
+                )
+            for field in ("introduced_by_issue", "introduced_by_pr"):
+                value = intake_audit.get(field)
+                if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+                    errors.append(f"intake_audit.{field} must be a positive integer")
+
+            validation_command = intake_audit.get("validation_command")
+            if not isinstance(validation_command, str) or not validation_command.strip():
+                errors.append("intake_audit.validation_command must be a non-empty string")
+
+            promotion_status = intake_audit.get("promotion_status")
+            if promotion_status not in SEED_WATCHLIST_ALLOWED_PROMOTION_STATUSES:
+                errors.append(
+                    f"intake_audit.promotion_status must be one of {sorted(SEED_WATCHLIST_ALLOWED_PROMOTION_STATUSES)!r}"
+                )
+
+            downstream_eligibility = intake_audit.get("downstream_eligibility")
+            if downstream_eligibility not in SEED_WATCHLIST_ALLOWED_DOWNSTREAM_ELIGIBILITY:
+                errors.append(
+                    "intake_audit.downstream_eligibility must be one of "
+                    f"{sorted(SEED_WATCHLIST_ALLOWED_DOWNSTREAM_ELIGIBILITY)!r}"
+                )
+
+            notes = intake_audit.get("notes")
+            if not isinstance(notes, list) or not notes:
+                errors.append("intake_audit.notes must be a non-empty list")
+            else:
+                for note in notes:
+                    if not isinstance(note, str) or not note.strip():
+                        errors.append("intake_audit.notes entries must be non-empty strings")
 
     prospects = payload.get("prospects")
     if not isinstance(prospects, list):

--- a/tests/test_devy_signal_registry.py
+++ b/tests/test_devy_signal_registry.py
@@ -37,6 +37,19 @@ class DevySignalRegistryTests(unittest.TestCase):
         count = len(self.seed_payload["prospects"])
         self.assertLessEqual(count, 50)
 
+
+    def test_seed_watchlist_requires_intake_audit_block(self) -> None:
+        payload = copy.deepcopy(self.seed_payload)
+        payload.pop("intake_audit", None)
+        errors = validate_devy_registry(payload)
+        self.assertTrue(any("intake_audit must be an object" in error for error in errors))
+
+    def test_seed_watchlist_rejects_invalid_intake_method(self) -> None:
+        payload = copy.deepcopy(self.seed_payload)
+        payload["intake_audit"]["intake_method"] = "autonomous_scraper"
+        errors = validate_devy_registry(payload)
+        self.assertTrue(any("intake_audit.intake_method must be one of" in error for error in errors))
+
     def test_seed_watchlist_missing_provenance_notes_fails_validation(self) -> None:
         payload = copy.deepcopy(self.seed_payload)
         payload["prospects"][0]["identity_provenance"]["source_notes"] = []


### PR DESCRIPTION
### Motivation

- Capture provenance and operational intent for curated devy seed rows so the artifact documents how rows entered the registry and is explicitly non-promoted.

### Description

- Add an artifact-level `intake_audit` block to `data/devy/devy_seed_watchlist_2026.json` with `intake_method`, `introduced_by_issue`, `introduced_by_pr`, `validation_command`, `promotion_status`, `downstream_eligibility`, and `notes` fields.
- Extend `scripts/devy_signal_registry.py` with allowed intake enums and validate that seed-watchlist artifacts include a well-formed `intake_audit` object and that each field meets type/allowed-value constraints.
- Update docs (`README.md` and `docs/devy-signal-discovery.md`) to describe the intake audit trail and the non-promoted discovery posture for the seed watchlist.
- Add unit tests in `tests/test_devy_signal_registry.py` to assert the presence and validation behavior of the `intake_audit` block and to cover invalid intake methods and missing blocks.

### Testing

- Ran the devy registry unit tests via `pytest -q`, specifically `tests/test_devy_signal_registry.py`, and the suite passed.
- The fixture validation test `test_fixture_registry_validates` passed and the seed-watchlist validation tests including `test_seed_watchlist_requires_intake_audit_block` and `test_seed_watchlist_rejects_invalid_intake_method` passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e62e84eb883328b78431a91bb075e)