### PR TITLE
Add monthly Devy roster pulse candidate-delta validation workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,20 @@ non-promoted discovery artifact with an artifact-level `intake_audit` trail
 (issue/PR lineage, intake method, validator command, and downstream block status).
 
 
+
+## Monthly Devy roster pulse (candidate delta, discovery-only)
+
+The `monthly_devy_roster_pulse` lane is a quarantined discovery workflow that
+surfaces roster/program/class-context deltas for operator review. It does **not**
+mutate the curated seed watchlist automatically and is blocked from Rookie Alpha,
+NFL scoring, FORGE, Point Prediction, and TIBER-Fantasy active NFL surfaces.
+
+Validate the pulse artifact with:
+
+```bash
+python3 scripts/validate_devy_roster_pulse.py --artifact data/devy/monthly_pulse/devy_roster_pulse_2026_05.json
+```
+
 ## Parallel ML evaluation lane (phase 1, experimental)
 
 This repo now includes an **experimental parallel ML lane** that evaluates rookie hit probabilities from historical labeled rows. It is strictly additive and does **not** replace deterministic Rookie Alpha scoring.

--- a/data/devy/monthly_pulse/devy_roster_pulse_2026_05.json
+++ b/data/devy/monthly_pulse/devy_roster_pulse_2026_05.json
@@ -1,0 +1,50 @@
+{
+  "schema_version": "devy-roster-pulse-v0.1.0",
+  "artifact_type": "devy_roster_pulse_candidate_delta",
+  "pulse_month": "2026-05",
+  "generated_at": "2026-05-20T00:00:00Z",
+  "input_sources": [
+    "https://example.edu/football/roster",
+    "data/devy/devy_seed_watchlist_2026.json"
+  ],
+  "comparison_basis": "Compared current roster evidence vs May 2026 seed watchlist and prior pulse snapshot unavailable.",
+  "candidates": [
+    {
+      "player_name": "Fixture Candidate One",
+      "school": "Example University",
+      "position": "WR",
+      "roster_status": "new_on_roster",
+      "existing_seed_watchlist_match": false,
+      "matched_player_id": null,
+      "projected_draft_class_candidate": 2029,
+      "class_year_source": "roster",
+      "prior_college_production_found": false,
+      "candidate_tags": [
+        "potential_2029_candidate",
+        "no_prior_college_production_found",
+        "needs_class_year_verification"
+      ],
+      "confidence_band": "MEDIUM",
+      "freshman_status": "unconfirmed",
+      "needs_manual_review": true,
+      "auto_seed_watchlist_mutation": "none",
+      "source_urls": [
+        "https://example.edu/football/roster"
+      ],
+      "source_notes": [
+        "Roster confirms position-group membership and active listing.",
+        "No prior production found in current optional stat sources; this is not treated as confirmed freshman status."
+      ]
+    }
+  ],
+  "warnings": [
+    "Discovery-only artifact: candidate deltas require manual operator review before any seed-watchlist change.",
+    "Output is blocked from Rookie Alpha, NFL scoring, FORGE, Point Prediction, and TIBER-Fantasy active NFL surfaces."
+  ],
+  "intake_audit": {
+    "intake_method": "future_script_generated_candidate",
+    "promotion_status": "non_promoted_discovery_only",
+    "validation_command": "python3 scripts/validate_devy_roster_pulse.py --artifact data/devy/monthly_pulse/devy_roster_pulse_2026_05.json",
+    "downstream_block": "blocked_until_rookie_transition"
+  }
+}

--- a/docs/devy-signal-discovery.md
+++ b/docs/devy-signal-discovery.md
@@ -167,3 +167,62 @@ available.
 Do not route Devy rows into Rookie Alpha scoring unless a future issue explicitly
 adds a governed ingestion path with provenance, validation, and downstream
 contract review.
+
+## Monthly Devy roster pulse (v1 design)
+
+`monthly_devy_roster_pulse` is the next conservative discovery lane after Devy v1
+seed curation. It runs approximately monthly (manual or scheduled later), and
+its only output is a candidate-delta snapshot for human review.
+
+### Safety boundary
+
+- Discovery-only output. No scoring/ranking/promotion.
+- No direct mutation of `data/devy/devy_seed_watchlist_2026.json`.
+- No routing into Rookie Alpha, promoted rookie exports, NFL scoring identity
+  tables, FORGE, Point Prediction, or TIBER-Fantasy active NFL surfaces.
+- Missing truth remains explicit as `unknown`/`unresolved` and `needs_manual_review=true`.
+
+### Artifact shape
+
+Pulse artifacts live under:
+
+- `data/devy/monthly_pulse/devy_roster_pulse_YYYY_MM.json`
+
+Canonical v1 shape is validated by `scripts/validate_devy_roster_pulse.py` and
+uses `artifact_type = devy_roster_pulse_candidate_delta`.
+
+Each candidate row captures roster-status deltas, watchlist match context,
+class-year evidence source, optional production evidence, candidate tags,
+confidence, provenance URLs/notes, and a hard block against automatic seed
+watchlist mutation (`auto_seed_watchlist_mutation = "none"`).
+
+### Freshman inference guardrail
+
+Missing prior college production is **not** enough to confirm freshman status.
+
+Allowed examples:
+
+- `prior_college_production_found = false`
+- `candidate_tags` include `potential_2029_candidate`,
+  `no_prior_college_production_found`, `needs_class_year_verification`
+
+Disallowed examples:
+
+- `candidate_tags` includes `confirmed_freshman` when production is missing
+  without explicit class-year/recruiting evidence.
+- `freshman_status = confirmed` when `prior_college_production_found=false`
+  and `class_year_source=unknown`.
+
+### Validation + tests
+
+Validate sample artifact:
+
+```bash
+python3 scripts/validate_devy_roster_pulse.py --artifact data/devy/monthly_pulse/devy_roster_pulse_2026_05.json
+```
+
+Focused validator tests:
+
+```bash
+python3 -m pytest tests/test_devy_roster_pulse_validator.py
+```

--- a/scripts/validate_devy_roster_pulse.py
+++ b/scripts/validate_devy_roster_pulse.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Validate monthly Devy roster pulse candidate-delta artifacts.
+
+Discovery-only guardrail: these artifacts surface candidate changes for manual
+review and must not mutate the curated seed watchlist directly.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+CURRENT_PULSE_SCHEMA_VERSION = "devy-roster-pulse-v0.1.0"
+PULSE_ARTIFACT_TYPE = "devy_roster_pulse_candidate_delta"
+
+ALLOWED_ROSTER_STATUSES = frozenset({
+    "new_on_roster",
+    "still_present",
+    "missing_from_roster",
+    "program_changed",
+    "unresolved",
+})
+ALLOWED_CLASS_YEAR_SOURCES = frozenset({"roster", "recruiting_profile", "manual", "unknown"})
+ALLOWED_CONFIDENCE_BANDS = frozenset({"LOW", "MEDIUM", "HIGH"})
+ALLOWED_FRESHMAN_STATUSES = frozenset({"confirmed", "unconfirmed", "unknown"})
+ALLOWED_AUTO_MUTATIONS = frozenset({"none"})
+
+
+def _is_non_empty_string(value: Any) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def _is_bool(value: Any) -> bool:
+    return isinstance(value, bool)
+
+
+def _is_list_of_non_empty_strings(value: Any) -> bool:
+    return isinstance(value, list) and bool(value) and all(_is_non_empty_string(item) for item in value)
+
+
+def validate_devy_roster_pulse(payload: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+
+    if payload.get("schema_version") != CURRENT_PULSE_SCHEMA_VERSION:
+        errors.append(
+            f"schema_version must be {CURRENT_PULSE_SCHEMA_VERSION!r}; got {payload.get('schema_version')!r}"
+        )
+
+    if payload.get("artifact_type") != PULSE_ARTIFACT_TYPE:
+        errors.append(f"artifact_type must be {PULSE_ARTIFACT_TYPE!r}")
+
+    for field in ("pulse_month", "generated_at", "comparison_basis"):
+        if not _is_non_empty_string(payload.get(field)):
+            errors.append(f"{field} must be a non-empty string")
+
+    for field in ("input_sources", "warnings", "intake_audit"):
+        value = payload.get(field)
+        if field == "intake_audit":
+            if not isinstance(value, dict):
+                errors.append("intake_audit must be an object")
+        elif not _is_list_of_non_empty_strings(value):
+            errors.append(f"{field} must be a non-empty list of non-empty strings")
+
+    intake_audit = payload.get("intake_audit") if isinstance(payload.get("intake_audit"), dict) else {}
+    if intake_audit:
+        for field in ("intake_method", "promotion_status", "validation_command", "downstream_block"):
+            if not _is_non_empty_string(intake_audit.get(field)):
+                errors.append(f"intake_audit.{field} must be a non-empty string")
+
+    candidates = payload.get("candidates")
+    if not isinstance(candidates, list) or not candidates:
+        errors.append("candidates must be a non-empty list")
+        return errors
+
+    for idx, candidate in enumerate(candidates):
+        prefix = f"candidates[{idx}]"
+        if not isinstance(candidate, dict):
+            errors.append(f"{prefix} must be an object")
+            continue
+
+        for field in ("player_name", "school", "position", "roster_status", "class_year_source", "confidence_band"):
+            if not _is_non_empty_string(candidate.get(field)):
+                errors.append(f"{prefix}.{field} must be a non-empty string")
+
+        roster_status = candidate.get("roster_status")
+        if roster_status not in ALLOWED_ROSTER_STATUSES:
+            errors.append(f"{prefix}.roster_status must be one of {sorted(ALLOWED_ROSTER_STATUSES)!r}")
+
+        class_year_source = candidate.get("class_year_source")
+        if class_year_source not in ALLOWED_CLASS_YEAR_SOURCES:
+            errors.append(f"{prefix}.class_year_source must be one of {sorted(ALLOWED_CLASS_YEAR_SOURCES)!r}")
+
+        confidence_band = candidate.get("confidence_band")
+        if confidence_band not in ALLOWED_CONFIDENCE_BANDS:
+            errors.append(f"{prefix}.confidence_band must be one of {sorted(ALLOWED_CONFIDENCE_BANDS)!r}")
+
+        if not _is_bool(candidate.get("existing_seed_watchlist_match")):
+            errors.append(f"{prefix}.existing_seed_watchlist_match must be a boolean")
+        if not _is_bool(candidate.get("needs_manual_review")):
+            errors.append(f"{prefix}.needs_manual_review must be a boolean")
+
+        prior_found = candidate.get("prior_college_production_found")
+        if prior_found not in (True, False, None):
+            errors.append(f"{prefix}.prior_college_production_found must be true/false/null")
+
+        for list_field in ("candidate_tags", "source_urls", "source_notes"):
+            if not _is_list_of_non_empty_strings(candidate.get(list_field)):
+                errors.append(f"{prefix}.{list_field} must be a non-empty list of non-empty strings")
+
+        freshman_status = candidate.get("freshman_status", "unknown")
+        if freshman_status not in ALLOWED_FRESHMAN_STATUSES:
+            errors.append(f"{prefix}.freshman_status must be one of {sorted(ALLOWED_FRESHMAN_STATUSES)!r}")
+
+        auto_mutation = candidate.get("auto_seed_watchlist_mutation", "none")
+        if auto_mutation not in ALLOWED_AUTO_MUTATIONS:
+            errors.append(f"{prefix}.auto_seed_watchlist_mutation must be 'none'")
+
+        tags = candidate.get("candidate_tags") if isinstance(candidate.get("candidate_tags"), list) else []
+        if prior_found is False and "confirmed_freshman" in tags:
+            errors.append(
+                f"{prefix} cannot set confirmed_freshman from missing prior stats alone"
+            )
+        if prior_found is False and freshman_status == "confirmed" and class_year_source == "unknown":
+            errors.append(
+                f"{prefix} cannot mark freshman_status='confirmed' when class_year_source is unknown and prior stats are missing"
+            )
+
+    return errors
+
+
+def load_payload(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate monthly Devy roster pulse candidate-delta artifact")
+    parser.add_argument("--artifact", type=Path, required=True, help="Path to devy roster pulse artifact JSON")
+    args = parser.parse_args()
+
+    errors = validate_devy_roster_pulse(load_payload(args.artifact))
+    if errors:
+        print("VALIDATION FAILED")
+        for error in errors:
+            print(f" - {error}")
+        return 1
+    print("VALIDATION PASSED")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_devy_roster_pulse_validator.py
+++ b/tests/test_devy_roster_pulse_validator.py
@@ -1,0 +1,46 @@
+import copy
+import json
+import unittest
+from pathlib import Path
+
+from scripts.validate_devy_roster_pulse import validate_devy_roster_pulse
+
+
+class DevyRosterPulseValidatorTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.fixture_path = Path("data/devy/monthly_pulse/devy_roster_pulse_2026_05.json")
+        self.payload = json.loads(self.fixture_path.read_text(encoding="utf-8"))
+
+    def test_fixture_validates(self) -> None:
+        self.assertEqual(validate_devy_roster_pulse(self.payload), [])
+
+    def test_missing_source_notes_fails_closed(self) -> None:
+        payload = copy.deepcopy(self.payload)
+        payload["candidates"][0]["source_notes"] = []
+        errors = validate_devy_roster_pulse(payload)
+        self.assertTrue(any("source_notes must be a non-empty list" in error for error in errors))
+
+    def test_missing_prior_stats_does_not_allow_confirmed_freshman_tag(self) -> None:
+        payload = copy.deepcopy(self.payload)
+        payload["candidates"][0]["prior_college_production_found"] = False
+        payload["candidates"][0]["candidate_tags"].append("confirmed_freshman")
+        errors = validate_devy_roster_pulse(payload)
+        self.assertTrue(any("cannot set confirmed_freshman from missing prior stats alone" in error for error in errors))
+
+    def test_missing_prior_stats_and_unknown_class_source_cannot_confirm_freshman(self) -> None:
+        payload = copy.deepcopy(self.payload)
+        payload["candidates"][0]["prior_college_production_found"] = False
+        payload["candidates"][0]["class_year_source"] = "unknown"
+        payload["candidates"][0]["freshman_status"] = "confirmed"
+        errors = validate_devy_roster_pulse(payload)
+        self.assertTrue(any("cannot mark freshman_status='confirmed'" in error for error in errors))
+
+    def test_pulse_cannot_auto_mutate_seed_watchlist(self) -> None:
+        payload = copy.deepcopy(self.payload)
+        payload["candidates"][0]["auto_seed_watchlist_mutation"] = "append_to_seed_watchlist"
+        errors = validate_devy_roster_pulse(payload)
+        self.assertTrue(any("auto_seed_watchlist_mutation must be 'none'" in error for error in errors))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Introduce a conservative, discovery-only `monthly_devy_roster_pulse` lane to surface roster/program/class-context deltas for operator review without promoting or scoring players. 
- Provide strong guardrails so the pulse cannot auto-mutate the curated seed watchlist or leak candidates into Rookie Alpha / NFL scoring / FORGE / TIBER-Fantasy surfaces. 
- Make freshman inference and provenance requirements explicit so missing stats do not imply confirmed freshman status.

### Description
- Add a standalone validator `scripts/validate_devy_roster_pulse.py` that enforces artifact-level schema (`artifact_type = devy_roster_pulse_candidate_delta`), required provenance fields, intake audit fields, quarantine/downstream block, and guardrails against automatic seed-watchlist mutations and improper freshman inference. 
- Add a sample pulse artifact `data/devy/monthly_pulse/devy_roster_pulse_2026_05.json` as a canonical v1 fixture showing discovery-only warnings, intake audit metadata, and `auto_seed_watchlist_mutation = "none"`. 
- Add focused tests `tests/test_devy_roster_pulse_validator.py` that prove fail-closed behavior on missing provenance, that missing prior college stats cannot be used to confirm freshman status, and that auto-mutation fields are blocked. 
- Document the monthly pulse lane and validation command in `README.md` and `docs/devy-signal-discovery.md`, including the safety boundary and freshman-inference examples.

### Testing
- Ran the validator against the sample artifact with `python3 scripts/validate_devy_roster_pulse.py --artifact data/devy/monthly_pulse/devy_roster_pulse_2026_05.json`, which printed `VALIDATION PASSED`. 
- Ran focused and registry tests with `python3 -m pytest tests/test_devy_roster_pulse_validator.py tests/test_devy_signal_registry.py`, which completed successfully (all tests passed; full run reported 29 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e6693cc288332ac2617822c54e40f)