### PR TITLE
Add deep Devy draft snapshot fixture + coverage-diff validator/workflow

### DIFF
--- a/data/devy/league_market_snapshots/deep_devy_draft_snapshot_2026_coverage_diff.json
+++ b/data/devy/league_market_snapshots/deep_devy_draft_snapshot_2026_coverage_diff.json
@@ -1,0 +1,235 @@
+{
+  "schema_version": "devy-league-market-coverage-diff-v0.1.0",
+  "artifact_type": "devy_league_market_snapshot_coverage_diff",
+  "snapshot_year": 2026,
+  "comparison_basis": "operator_supplied_snapshot_vs_devy_seed_watchlist",
+  "drafted_and_known_by_tiber": [
+    {
+      "draft_id": "startup_2025",
+      "pick": "1.01",
+      "player_name_normalized": "Jeremiah Smith",
+      "seed_player_id": "jeremiah-smith",
+      "school": "Ohio State",
+      "position": "WR",
+      "tiber_seed_watchlist_match": true
+    },
+    {
+      "draft_id": "supplemental_2026",
+      "pick": "5.05",
+      "player_name_normalized": "Derrek Cooper",
+      "seed_player_id": "derrek-cooper",
+      "school": "Texas",
+      "position": "RB",
+      "tiber_seed_watchlist_match": true
+    }
+  ],
+  "drafted_missing_from_tiber": [
+    {
+      "draft_id": "supplemental_2026",
+      "pick": "5.06",
+      "player_name_normalized": "Aaron Gregory",
+      "school_normalized": "Texas A&M",
+      "position_normalized": "WR",
+      "tiber_seed_watchlist_match": false,
+      "coverage_gap_candidate": true,
+      "auto_add_to_seed_watchlist": false
+    },
+    {
+      "draft_id": "supplemental_2026",
+      "pick": "3.02",
+      "player_name_normalized": "Brendan Sorsby",
+      "school_normalized": "unknown",
+      "position_normalized": "QB",
+      "tiber_seed_watchlist_match": false,
+      "coverage_gap_candidate": true,
+      "auto_add_to_seed_watchlist": false
+    }
+  ],
+  "tiber_seed_available_at_snapshot": [
+    {
+      "player_id": "chris-henry-jr",
+      "player_name": "Chris Henry Jr.",
+      "school": "Ohio State",
+      "position": "WR"
+    },
+    {
+      "player_id": "bryce-underwood",
+      "player_name": "Bryce Underwood",
+      "school": "Michigan",
+      "position": "QB"
+    },
+    {
+      "player_id": "dakorien-moore",
+      "player_name": "Dakorien Moore",
+      "school": "Oregon",
+      "position": "WR"
+    },
+    {
+      "player_id": "arch-manning",
+      "player_name": "Arch Manning",
+      "school": "Texas",
+      "position": "QB"
+    },
+    {
+      "player_id": "dj-lagway",
+      "player_name": "DJ Lagway",
+      "school": "Florida",
+      "position": "QB"
+    },
+    {
+      "player_id": "dylan-raiola",
+      "player_name": "Dylan Raiola",
+      "school": "Nebraska",
+      "position": "QB"
+    },
+    {
+      "player_id": "julian-sayin",
+      "player_name": "Julian Sayin",
+      "school": "Ohio State",
+      "position": "QB"
+    },
+    {
+      "player_id": "jeremiah-love",
+      "player_name": "Jeremiah Love",
+      "school": "Notre Dame",
+      "position": "RB"
+    },
+    {
+      "player_id": "nicholas-singleton",
+      "player_name": "Nicholas Singleton",
+      "school": "Penn State",
+      "position": "RB"
+    },
+    {
+      "player_id": "ryan-williams",
+      "player_name": "Ryan Williams",
+      "school": "Alabama",
+      "position": "WR"
+    },
+    {
+      "player_id": "cam-coleman",
+      "player_name": "Cam Coleman",
+      "school": "Auburn",
+      "position": "WR"
+    },
+    {
+      "player_id": "carnell-tate",
+      "player_name": "Carnell Tate",
+      "school": "Ohio State",
+      "position": "WR"
+    },
+    {
+      "player_id": "tristen-keys",
+      "player_name": "Tristen Keys",
+      "school": "unknown",
+      "position": "WR"
+    },
+    {
+      "player_id": "faizon-brandon",
+      "player_name": "Faizon Brandon",
+      "school": "Tennessee",
+      "position": "QB"
+    },
+    {
+      "player_id": "jared-curtis",
+      "player_name": "Jared Curtis",
+      "school": "Vanderbilt",
+      "position": "QB"
+    },
+    {
+      "player_id": "dia-bell",
+      "player_name": "Dia Bell",
+      "school": "Texas",
+      "position": "QB"
+    },
+    {
+      "player_id": "savion-hiter",
+      "player_name": "Savion Hiter",
+      "school": "Michigan",
+      "position": "RB"
+    },
+    {
+      "player_id": "ezavier-crowell",
+      "player_name": "Ezavier Crowell",
+      "school": "Alabama",
+      "position": "RB"
+    },
+    {
+      "player_id": "cederian-morgan",
+      "player_name": "Cederian Morgan",
+      "school": "Alabama",
+      "position": "WR"
+    },
+    {
+      "player_id": "calvin-russell",
+      "player_name": "Calvin Russell",
+      "school": "Syracuse",
+      "position": "WR"
+    },
+    {
+      "player_id": "kayden-dixon-wyatt",
+      "player_name": "Kayden Dixon-Wyatt",
+      "school": "unknown",
+      "position": "WR"
+    },
+    {
+      "player_id": "mark-bowman",
+      "player_name": "Mark Bowman",
+      "school": "USC",
+      "position": "TE"
+    }
+  ],
+  "identity_conflicts_or_unresolved": [
+    {
+      "draft_id": "supplemental_2026",
+      "pick": "3.02",
+      "player_name_normalized": "Brendan Sorsby",
+      "school_normalized": "unknown",
+      "position_normalized": "QB",
+      "issue": "missing_normalized_identity_fields"
+    }
+  ],
+  "coverage_gap_candidates": [
+    {
+      "draft_id": "supplemental_2026",
+      "pick": "5.06",
+      "player_name_normalized": "Aaron Gregory",
+      "school_normalized": "Texas A&M",
+      "position_normalized": "WR",
+      "tiber_seed_watchlist_match": false,
+      "coverage_gap_candidate": true,
+      "auto_add_to_seed_watchlist": false
+    },
+    {
+      "draft_id": "supplemental_2026",
+      "pick": "3.02",
+      "player_name_normalized": "Brendan Sorsby",
+      "school_normalized": "unknown",
+      "position_normalized": "QB",
+      "tiber_seed_watchlist_match": false,
+      "coverage_gap_candidate": true,
+      "auto_add_to_seed_watchlist": false
+    }
+  ],
+  "recommended_monthly_pulse_candidates": [
+    {
+      "player_name_normalized": "Aaron Gregory",
+      "draft_id": "supplemental_2026",
+      "pick": "5.06",
+      "reason": "drafted_in_operator_snapshot_missing_from_seed_watchlist",
+      "auto_seed_watchlist_mutation": "none"
+    },
+    {
+      "player_name_normalized": "Brendan Sorsby",
+      "draft_id": "supplemental_2026",
+      "pick": "3.02",
+      "reason": "drafted_in_operator_snapshot_missing_from_seed_watchlist",
+      "auto_seed_watchlist_mutation": "none"
+    }
+  ],
+  "warnings": [
+    "Coverage diff is discovery intelligence only and must not be treated as rankings/scouting truth.",
+    "No automatic seed-watchlist mutation is allowed from this artifact.",
+    "Do not route this artifact into Rookie Alpha, promoted rookie exports, or NFL scoring surfaces."
+  ]
+}

--- a/data/devy/league_market_snapshots/deep_devy_draft_snapshot_2026_coverage_diff.json
+++ b/data/devy/league_market_snapshots/deep_devy_draft_snapshot_2026_coverage_diff.json
@@ -45,7 +45,8 @@
       "auto_add_to_seed_watchlist": false
     }
   ],
-  "tiber_seed_available_at_snapshot": [
+  "snapshot_scope": "fixture_subset",
+  "tiber_seed_not_present_in_snapshot_fixture": [
     {
       "player_id": "chris-henry-jr",
       "player_name": "Chris Henry Jr.",

--- a/data/devy/league_market_snapshots/deep_devy_draft_snapshot_2026_fixture.json
+++ b/data/devy/league_market_snapshots/deep_devy_draft_snapshot_2026_fixture.json
@@ -1,0 +1,87 @@
+{
+  "schema_version": "devy-league-market-snapshot-v0.1.0",
+  "artifact_type": "operator_supplied_devy_draft_snapshot",
+  "snapshot_year": 2026,
+  "source_type": "operator_supplied_league_draft",
+  "league_format": "deep_devy",
+  "league_identifier": "operator_supplied_deep_devy_fixture",
+  "privacy_notes": [
+    "Fixture excludes manager names, team names, platform identifiers, and private communication.",
+    "Rows are limited to pick reference, player name, school, and position for anonymized coverage testing."
+  ],
+  "warnings": [
+    "Market/coverage intelligence only; not scouting truth, not player ranking, and not Rookie Alpha signal.",
+    "Do not route into promoted rookie exports, NFL scoring, FORGE, Point Prediction, or TIBER-Fantasy active NFL search."
+  ],
+  "intake_audit": {
+    "intake_method": "manual_operator_fixture_entry",
+    "promotion_status": "fixture_only_non_promoted",
+    "downstream_block": "discovery_only_no_rookie_alpha_no_seed_auto_mutation",
+    "source_label": "operator_supplied_deep_devy_fixture"
+  },
+  "drafts": [
+    {
+      "draft_id": "startup_2025",
+      "draft_label": "2025 startup draft fixture subset",
+      "picks": [
+        {
+          "draft_id": "startup_2025",
+          "pick": "1.01",
+          "round": 1,
+          "slot": 1,
+          "player_name_raw": "Jeremiah Smith",
+          "player_name_normalized": "Jeremiah Smith",
+          "school_raw": "Ohio State",
+          "school_normalized": "Ohio State",
+          "position_raw": "WR",
+          "position_normalized": "WR"
+        }
+      ]
+    },
+    {
+      "draft_id": "supplemental_2026",
+      "draft_label": "2026 supplemental draft fixture subset",
+      "picks": [
+        {
+          "draft_id": "supplemental_2026",
+          "pick": "5.05",
+          "round": 5,
+          "slot": 5,
+          "player_name_raw": "Derrek Cooper",
+          "player_name_normalized": "Derrek Cooper",
+          "school_raw": "Texas",
+          "school_normalized": "Texas",
+          "position_raw": "RB",
+          "position_normalized": "RB",
+          "operator_notes": "Known TIBER seed candidate surfaced as available at selection time."
+        },
+        {
+          "draft_id": "supplemental_2026",
+          "pick": "5.06",
+          "round": 5,
+          "slot": 6,
+          "player_name_raw": "Aaron Gregory",
+          "player_name_normalized": "Aaron Gregory",
+          "school_raw": "Texas A&M",
+          "school_normalized": "Texas A&M",
+          "position_raw": "WR",
+          "position_normalized": "WR",
+          "operator_notes": "Coverage-gap signal only; candidate for monthly pulse review, not auto-add."
+        },
+        {
+          "draft_id": "supplemental_2026",
+          "pick": "3.02",
+          "round": 3,
+          "slot": 2,
+          "player_name_raw": "Brendan Sorsby",
+          "player_name_normalized": "Brendan Sorsby",
+          "school_raw": "unknown",
+          "school_normalized": "unknown",
+          "position_raw": "QB",
+          "position_normalized": "QB",
+          "operator_notes": "Intentional unresolved-school fixture row for identity-normalization testing."
+        }
+      ]
+    }
+  ]
+}

--- a/data/devy/league_market_snapshots/deep_devy_draft_snapshot_2026_fixture.json
+++ b/data/devy/league_market_snapshots/deep_devy_draft_snapshot_2026_fixture.json
@@ -83,5 +83,6 @@
         }
       ]
     }
-  ]
+  ],
+  "snapshot_scope": "fixture_subset"
 }

--- a/docs/devy-signal-discovery.md
+++ b/docs/devy-signal-discovery.md
@@ -226,3 +226,48 @@ Focused validator tests:
 ```bash
 python3 -m pytest tests/test_devy_roster_pulse_validator.py
 ```
+
+## Operator-supplied deep Devy draft market snapshots (fixture workflow)
+
+To capture real-world Devy draft coverage signals without polluting scoring or promotion layers,
+TIBER-Rookies now supports an anonymized fixture workflow for operator-supplied draft snapshots.
+
+Artifacts:
+
+- Snapshot fixture input:
+  - `data/devy/league_market_snapshots/deep_devy_draft_snapshot_2026_fixture.json`
+- Coverage diff output:
+  - `data/devy/league_market_snapshots/deep_devy_draft_snapshot_2026_coverage_diff.json`
+
+Guardrails:
+
+- Discovery intelligence only (market/coverage snapshot), not scouting truth or player-quality inference.
+- No Rookie Alpha wiring.
+- No automatic seed-watchlist mutation.
+- No promoted-artifact export behavior.
+- No NFL scoring, FORGE, Point Prediction, or TIBER-Fantasy active NFL search integration.
+
+The fixture includes explicit known test rows:
+
+- Derrek Cooper (supplemental `5.05`) should resolve as known by TIBER when present in
+  `data/devy/devy_seed_watchlist_2026.json`.
+- Aaron Gregory (supplemental `5.06`) should resolve as drafted-missing, coverage-gap candidate,
+  and monthly-pulse candidate (`auto_seed_watchlist_mutation = none`).
+
+Validation command:
+
+```bash
+python3 scripts/validate_devy_league_market_snapshot.py --artifact data/devy/league_market_snapshots/deep_devy_draft_snapshot_2026_fixture.json
+```
+
+Coverage diff command:
+
+```bash
+python3 scripts/compute_devy_league_market_snapshot_diff.py \
+  --snapshot data/devy/league_market_snapshots/deep_devy_draft_snapshot_2026_fixture.json \
+  --seed-watchlist data/devy/devy_seed_watchlist_2026.json \
+  --output data/devy/league_market_snapshots/deep_devy_draft_snapshot_2026_coverage_diff.json
+```
+
+Use this as a manual review helper only. Drafted-missing names are candidate deltas for
+monthly pulse/operator review and must not be auto-added to the seed watchlist.

--- a/docs/devy-signal-discovery.md
+++ b/docs/devy-signal-discovery.md
@@ -239,6 +239,12 @@ Artifacts:
 - Coverage diff output:
   - `data/devy/league_market_snapshots/deep_devy_draft_snapshot_2026_coverage_diff.json`
 
+Scope semantics:
+
+- This fixture currently sets `snapshot_scope: "fixture_subset"`.
+- The diff field `tiber_seed_not_present_in_snapshot_fixture` means only that a seed row was not observed in the fixture rows provided.
+- It must **not** be interpreted as true league availability unless the snapshot includes complete anonymized draft history for the league window.
+
 Guardrails:
 
 - Discovery intelligence only (market/coverage snapshot), not scouting truth or player-quality inference.

--- a/scripts/compute_devy_league_market_snapshot_diff.py
+++ b/scripts/compute_devy_league_market_snapshot_diff.py
@@ -78,7 +78,7 @@ def compute_diff(snapshot_payload: dict[str, Any], seed_payload: dict[str, Any])
                     }
                 )
 
-    available_seed = [
+    not_present_in_snapshot_fixture = [
         {
             "player_id": prospect.get("player_id"),
             "player_name": prospect.get("player_name"),
@@ -96,7 +96,8 @@ def compute_diff(snapshot_payload: dict[str, Any], seed_payload: dict[str, Any])
         "comparison_basis": "operator_supplied_snapshot_vs_devy_seed_watchlist",
         "drafted_and_known_by_tiber": drafted_and_known,
         "drafted_missing_from_tiber": drafted_missing,
-        "tiber_seed_available_at_snapshot": available_seed,
+        "snapshot_scope": snapshot_payload.get("snapshot_scope", "unknown"),
+        "tiber_seed_not_present_in_snapshot_fixture": not_present_in_snapshot_fixture,
         "identity_conflicts_or_unresolved": unresolved,
         "coverage_gap_candidates": drafted_missing,
         "recommended_monthly_pulse_candidates": [

--- a/scripts/compute_devy_league_market_snapshot_diff.py
+++ b/scripts/compute_devy_league_market_snapshot_diff.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Compare operator-supplied deep Devy draft snapshots with the seed watchlist."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def slugify(value: str) -> str:
+    return "-".join("".join(ch.lower() if ch.isalnum() else " " for ch in value).split())
+
+
+def build_watchlist_map(seed_payload: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    prospects = seed_payload.get("prospects", [])
+    result: dict[str, dict[str, Any]] = {}
+    for prospect in prospects:
+        key = prospect.get("player_id") or slugify(prospect.get("player_name", ""))
+        if key:
+            result[key] = prospect
+    return result
+
+
+def compute_diff(snapshot_payload: dict[str, Any], seed_payload: dict[str, Any]) -> dict[str, Any]:
+    watchlist = build_watchlist_map(seed_payload)
+    drafted_keys: set[str] = set()
+
+    drafted_and_known: list[dict[str, Any]] = []
+    drafted_missing: list[dict[str, Any]] = []
+    unresolved: list[dict[str, Any]] = []
+
+    for draft in snapshot_payload.get("drafts", []):
+        for pick in draft.get("picks", []):
+            normalized = pick.get("player_name_normalized", "")
+            key = slugify(normalized)
+            drafted_keys.add(key)
+            school_norm = pick.get("school_normalized", "unknown")
+            position_norm = pick.get("position_normalized", "unknown")
+
+            if school_norm.lower() == "unknown" or position_norm.lower() == "unknown":
+                unresolved.append(
+                    {
+                        "draft_id": pick.get("draft_id"),
+                        "pick": pick.get("pick"),
+                        "player_name_normalized": normalized,
+                        "school_normalized": school_norm,
+                        "position_normalized": position_norm,
+                        "issue": "missing_normalized_identity_fields",
+                    }
+                )
+
+            if key in watchlist:
+                seeded = watchlist[key]
+                drafted_and_known.append(
+                    {
+                        "draft_id": pick.get("draft_id"),
+                        "pick": pick.get("pick"),
+                        "player_name_normalized": normalized,
+                        "seed_player_id": seeded.get("player_id"),
+                        "school": seeded.get("school", "unknown"),
+                        "position": seeded.get("position", "unknown"),
+                        "tiber_seed_watchlist_match": True,
+                    }
+                )
+            else:
+                drafted_missing.append(
+                    {
+                        "draft_id": pick.get("draft_id"),
+                        "pick": pick.get("pick"),
+                        "player_name_normalized": normalized,
+                        "school_normalized": school_norm,
+                        "position_normalized": position_norm,
+                        "tiber_seed_watchlist_match": False,
+                        "coverage_gap_candidate": True,
+                        "auto_add_to_seed_watchlist": False,
+                    }
+                )
+
+    available_seed = [
+        {
+            "player_id": prospect.get("player_id"),
+            "player_name": prospect.get("player_name"),
+            "school": prospect.get("school"),
+            "position": prospect.get("position"),
+        }
+        for player_id, prospect in watchlist.items()
+        if player_id not in drafted_keys
+    ]
+
+    return {
+        "schema_version": "devy-league-market-coverage-diff-v0.1.0",
+        "artifact_type": "devy_league_market_snapshot_coverage_diff",
+        "snapshot_year": snapshot_payload.get("snapshot_year"),
+        "comparison_basis": "operator_supplied_snapshot_vs_devy_seed_watchlist",
+        "drafted_and_known_by_tiber": drafted_and_known,
+        "drafted_missing_from_tiber": drafted_missing,
+        "tiber_seed_available_at_snapshot": available_seed,
+        "identity_conflicts_or_unresolved": unresolved,
+        "coverage_gap_candidates": drafted_missing,
+        "recommended_monthly_pulse_candidates": [
+            {
+                "player_name_normalized": row["player_name_normalized"],
+                "draft_id": row["draft_id"],
+                "pick": row["pick"],
+                "reason": "drafted_in_operator_snapshot_missing_from_seed_watchlist",
+                "auto_seed_watchlist_mutation": "none",
+            }
+            for row in drafted_missing
+        ],
+        "warnings": [
+            "Coverage diff is discovery intelligence only and must not be treated as rankings/scouting truth.",
+            "No automatic seed-watchlist mutation is allowed from this artifact.",
+            "Do not route this artifact into Rookie Alpha, promoted rookie exports, or NFL scoring surfaces.",
+        ],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Compute deep Devy league market snapshot coverage diff")
+    parser.add_argument("--snapshot", type=Path, required=True)
+    parser.add_argument("--seed-watchlist", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    snapshot_payload = json.loads(args.snapshot.read_text(encoding="utf-8"))
+    seed_payload = json.loads(args.seed_watchlist.read_text(encoding="utf-8"))
+    diff = compute_diff(snapshot_payload, seed_payload)
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(diff, indent=2) + "\n", encoding="utf-8")
+    print(f"WROTE {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_devy_league_market_snapshot.py
+++ b/scripts/validate_devy_league_market_snapshot.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Validate operator-supplied deep Devy league draft snapshot artifacts.
+
+Discovery-only guardrail: snapshot artifacts are market/coverage intelligence and
+must never be treated as scouting truth, rankings, Rookie Alpha inputs, or
+automatic seed-watchlist mutations.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+CURRENT_SCHEMA_VERSION = "devy-league-market-snapshot-v0.1.0"
+ARTIFACT_TYPE = "operator_supplied_devy_draft_snapshot"
+ALLOWED_SOURCE_TYPES = frozenset({"operator_supplied_league_draft"})
+ALLOWED_LEAGUE_FORMATS = frozenset({"deep_devy"})
+
+
+def _is_non_empty_string(value: Any) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def _is_int(value: Any) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _is_list_of_non_empty_strings(value: Any) -> bool:
+    return isinstance(value, list) and bool(value) and all(_is_non_empty_string(item) for item in value)
+
+
+def validate_devy_league_market_snapshot(payload: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+
+    if payload.get("schema_version") != CURRENT_SCHEMA_VERSION:
+        errors.append(f"schema_version must be {CURRENT_SCHEMA_VERSION!r}")
+    if payload.get("artifact_type") != ARTIFACT_TYPE:
+        errors.append(f"artifact_type must be {ARTIFACT_TYPE!r}")
+
+    if payload.get("source_type") not in ALLOWED_SOURCE_TYPES:
+        errors.append(f"source_type must be one of {sorted(ALLOWED_SOURCE_TYPES)!r}")
+    if payload.get("league_format") not in ALLOWED_LEAGUE_FORMATS:
+        errors.append(f"league_format must be one of {sorted(ALLOWED_LEAGUE_FORMATS)!r}")
+
+    if not _is_int(payload.get("snapshot_year")):
+        errors.append("snapshot_year must be an integer")
+
+    for field in ("league_identifier",):
+        if not _is_non_empty_string(payload.get(field)):
+            errors.append(f"{field} must be a non-empty string")
+
+    for field in ("privacy_notes", "warnings"):
+        if not _is_list_of_non_empty_strings(payload.get(field)):
+            errors.append(f"{field} must be a non-empty list of non-empty strings")
+
+    intake_audit = payload.get("intake_audit")
+    if not isinstance(intake_audit, dict):
+        errors.append("intake_audit must be an object")
+    else:
+        for field in ("intake_method", "promotion_status", "downstream_block", "source_label"):
+            if not _is_non_empty_string(intake_audit.get(field)):
+                errors.append(f"intake_audit.{field} must be a non-empty string")
+
+    drafts = payload.get("drafts")
+    if not isinstance(drafts, list) or not drafts:
+        errors.append("drafts must be a non-empty list")
+        return errors
+
+    for draft_idx, draft in enumerate(drafts):
+        prefix = f"drafts[{draft_idx}]"
+        if not isinstance(draft, dict):
+            errors.append(f"{prefix} must be an object")
+            continue
+
+        for field in ("draft_id", "draft_label"):
+            if not _is_non_empty_string(draft.get(field)):
+                errors.append(f"{prefix}.{field} must be a non-empty string")
+
+        picks = draft.get("picks")
+        if not isinstance(picks, list) or not picks:
+            errors.append(f"{prefix}.picks must be a non-empty list")
+            continue
+
+        for pick_idx, pick in enumerate(picks):
+            pick_prefix = f"{prefix}.picks[{pick_idx}]"
+            if not isinstance(pick, dict):
+                errors.append(f"{pick_prefix} must be an object")
+                continue
+
+            for field in (
+                "draft_id",
+                "pick",
+                "player_name_raw",
+                "player_name_normalized",
+                "school_raw",
+                "school_normalized",
+                "position_raw",
+                "position_normalized",
+            ):
+                if not _is_non_empty_string(pick.get(field)):
+                    errors.append(f"{pick_prefix}.{field} must be a non-empty string")
+
+            for int_field in ("round", "slot"):
+                if not _is_int(pick.get(int_field)):
+                    errors.append(f"{pick_prefix}.{int_field} must be an integer")
+
+            notes = pick.get("operator_notes")
+            if notes is not None and not _is_non_empty_string(notes):
+                errors.append(f"{pick_prefix}.operator_notes must be null or a non-empty string")
+
+    return errors
+
+
+def load_payload(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate deep Devy league market snapshot artifact")
+    parser.add_argument("--artifact", type=Path, required=True, help="Path to snapshot artifact JSON")
+    args = parser.parse_args()
+
+    errors = validate_devy_league_market_snapshot(load_payload(args.artifact))
+    if errors:
+        print("VALIDATION FAILED")
+        for error in errors:
+            print(f" - {error}")
+        return 1
+
+    print("VALIDATION PASSED")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_devy_league_market_snapshot_workflow.py
+++ b/tests/test_devy_league_market_snapshot_workflow.py
@@ -50,6 +50,11 @@ class DevyLeagueMarketSnapshotWorkflowTests(unittest.TestCase):
         errors = validate_devy_league_market_snapshot(invalid)
         self.assertTrue(any("privacy_notes must be a non-empty list" in error for error in errors))
 
+    def test_not_present_field_is_fixture_subset_not_true_availability(self) -> None:
+        diff = compute_diff(self.snapshot, self.seed)
+        self.assertEqual(diff["snapshot_scope"], "fixture_subset")
+        self.assertIn("tiber_seed_not_present_in_snapshot_fixture", diff)
+        self.assertNotIn("tiber_seed_available_at_snapshot", diff)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_devy_league_market_snapshot_workflow.py
+++ b/tests/test_devy_league_market_snapshot_workflow.py
@@ -1,0 +1,55 @@
+import copy
+import json
+import unittest
+from pathlib import Path
+
+from scripts.compute_devy_league_market_snapshot_diff import compute_diff
+from scripts.validate_devy_league_market_snapshot import validate_devy_league_market_snapshot
+
+
+class DevyLeagueMarketSnapshotWorkflowTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.snapshot_path = Path("data/devy/league_market_snapshots/deep_devy_draft_snapshot_2026_fixture.json")
+        self.seed_path = Path("data/devy/devy_seed_watchlist_2026.json")
+        self.snapshot = json.loads(self.snapshot_path.read_text(encoding="utf-8"))
+        self.seed = json.loads(self.seed_path.read_text(encoding="utf-8"))
+
+    def test_snapshot_fixture_validates(self) -> None:
+        self.assertEqual(validate_devy_league_market_snapshot(self.snapshot), [])
+
+    def test_derrek_cooper_resolves_as_known_seed_watchlist_player(self) -> None:
+        diff = compute_diff(self.snapshot, self.seed)
+        known = diff["drafted_and_known_by_tiber"]
+        self.assertTrue(any(row["seed_player_id"] == "derrek-cooper" for row in known))
+
+    def test_aaron_gregory_resolves_as_missing_and_monthly_pulse_candidate(self) -> None:
+        diff = compute_diff(self.snapshot, self.seed)
+        missing_rows = [row for row in diff["drafted_missing_from_tiber"] if row["player_name_normalized"] == "Aaron Gregory"]
+        self.assertEqual(len(missing_rows), 1)
+        self.assertTrue(missing_rows[0]["coverage_gap_candidate"])
+        self.assertFalse(missing_rows[0]["auto_add_to_seed_watchlist"])
+
+        pulse_rows = [row for row in diff["recommended_monthly_pulse_candidates"] if row["player_name_normalized"] == "Aaron Gregory"]
+        self.assertEqual(len(pulse_rows), 1)
+        self.assertEqual(pulse_rows[0]["auto_seed_watchlist_mutation"], "none")
+
+    def test_identity_unresolved_rows_are_flagged(self) -> None:
+        diff = compute_diff(self.snapshot, self.seed)
+        unresolved = diff["identity_conflicts_or_unresolved"]
+        self.assertTrue(any(row["player_name_normalized"] == "Brendan Sorsby" for row in unresolved))
+
+    def test_snapshot_workflow_has_scoring_truth_guardrails(self) -> None:
+        diff = compute_diff(self.snapshot, self.seed)
+        warnings_text = " ".join(diff["warnings"]).lower()
+        self.assertIn("not be treated as rankings", warnings_text)
+        self.assertIn("do not route", warnings_text)
+
+    def test_validation_fails_without_required_privacy_notes(self) -> None:
+        invalid = copy.deepcopy(self.snapshot)
+        invalid["privacy_notes"] = []
+        errors = validate_devy_league_market_snapshot(invalid)
+        self.assertTrue(any("privacy_notes must be a non-empty list" in error for error in errors))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Capture operator-supplied deep Devy draft signals as anonymized market/coverage snapshots to surface coverage gaps without turning draft picks into scouting truth or ranking inputs. 
- Provide a reproducible workflow to answer which drafted players TIBER already knows, which are missing, which seed-watchlist rows remained available, and which rows have identity-normalization issues. 
- Preserve discovery-only guardrails so snapshots cannot mutate the seed watchlist or flow into Rookie Alpha, promoted artifacts, NFL scoring, FORGE, or TIBER-Fantasy surfaces. 

### Description
- Add snapshot schema validation in `scripts/validate_devy_league_market_snapshot.py` enforcing required metadata, privacy notes, intake audit, and pick-level fields. 
- Add coverage-diff computation in `scripts/compute_devy_league_market_snapshot_diff.py` that compares a snapshot to `data/devy/devy_seed_watchlist_2026.json` and emits `drafted_and_known_by_tiber`, `drafted_missing_from_tiber`, `tiber_seed_available_at_snapshot`, `identity_conflicts_or_unresolved`, `coverage_gap_candidates`, and `recommended_monthly_pulse_candidates`. 
- Add an anonymized fixture input at `data/devy/league_market_snapshots/deep_devy_draft_snapshot_2026_fixture.json` containing the Derrek Cooper (5.05) and Aaron Gregory (5.06) cases plus an unresolved identity row for testing. 
- Add generated diff output at `data/devy/league_market_snapshots/deep_devy_draft_snapshot_2026_coverage_diff.json`, focused tests in `tests/test_devy_league_market_snapshot_workflow.py`, and documentation updates to `docs/devy-signal-discovery.md`. 
- Maintain guardrails in code and outputs: recommended pulse candidates include `auto_seed_watchlist_mutation: "none"`, and warnings explicitly state the artifact is discovery-only. 

### Testing
- Ran `python3 scripts/validate_devy_league_market_snapshot.py --artifact data/devy/league_market_snapshots/deep_devy_draft_snapshot_2026_fixture.json` and the validator reported `VALIDATION PASSED`. 
- Ran `python3 -m pytest tests/test_devy_league_market_snapshot_workflow.py -q` and all tests passed (`6 passed`). 
- The coverage-diff script was invoked to produce `data/devy/league_market_snapshots/deep_devy_draft_snapshot_2026_coverage_diff.json`, which shows Derrek Cooper resolving as a known seed watchlist match and Aaron Gregory flagged as a coverage-gap / monthly-pulse candidate without automatic seed-watchlist mutation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e71b15bcc83329e9b6b7ad963f94e)