### PR TITLE
Wire PPR data-gap and evidence disclosure into rookie cards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,3 +24,11 @@ jobs:
 
       - name: Run tests
         run: python3 -m pytest tests -q
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Run card disclosure tests
+        run: npm run test:card-disclosure

--- a/components/rookies/RookieCard.js
+++ b/components/rookies/RookieCard.js
@@ -1,5 +1,6 @@
 import { selectRookieEvidenceMetrics } from '/lib/rookies/selectRookieEvidenceMetrics.js';
 import { getCollegeLogoUrl, getNflTeamLogoUrl } from '/lib/rookies/teamLogos.js';
+import { renderPprProjection } from './renderPprProjection.js';
 
 function esc(str) {
   return String(str ?? '')
@@ -151,37 +152,6 @@ function renderBoarMetricRow(card) {
   const width = Math.max(0, Math.min(100, boar));
   const tierClass = boarTierClass(boar);
   return `<div class="metric-row"><div class="metric-header"><span>Breakout Age Rating (BOAR)</span><strong class="${tierClass}">${Math.round(boar)}</strong></div><div class="metric-track"><div class="metric-fill metric-fill-boar ${tierClass}" style="width:${width}%"></div></div></div>`;
-}
-
-function renderPprProjection(ppr) {
-  if (!ppr) return '';
-  const bandClass = { Elite: 'ppr-band-elite', Starter: 'ppr-band-starter', Contributor: 'ppr-band-contributor', Lottery: 'ppr-band-lottery' }[ppr.band] ?? 'ppr-band-lottery';
-  const floor = Number(ppr.floor);
-  const median = Number(ppr.median);
-  const ceiling = Number(ppr.ceiling);
-  const hasRange = Number.isFinite(floor) && Number.isFinite(median) && Number.isFinite(ceiling) && ceiling >= floor;
-  const maxForScale = hasRange
-    ? Math.max(1, Math.ceil(Math.max(floor, median, ceiling) / 25) * 25)
-    : 1;
-  const rangeLeft = hasRange ? Math.max(0, Math.min(100, (floor / maxForScale) * 100)) : 0;
-  const rangeWidth = hasRange ? Math.max(0, Math.min(100 - rangeLeft, ((ceiling - floor) / maxForScale) * 100)) : 0;
-  const medianLeft = hasRange ? Math.max(0, Math.min(100, (median / maxForScale) * 100)) : 0;
-  return `
-    <div class="ppr-card-section">
-      <div class="section-title">Year 1 PPR Projection</div>
-      <div class="ppr-card-row">
-        <div class="ppr-card-stat"><div class="ppr-stat-label">Floor</div><div class="ppr-stat-value">${esc(ppr.floor)}</div></div>
-        <div class="ppr-card-stat ppr-median"><div class="ppr-stat-label">Median</div><div class="ppr-stat-value ppr-median-value">${esc(ppr.median)}</div></div>
-        <div class="ppr-card-stat"><div class="ppr-stat-label">Ceiling</div><div class="ppr-stat-value">${esc(ppr.ceiling)}</div></div>
-        <div class="ppr-card-band"><span class="ppr-band ${bandClass}">${esc(ppr.band)}</span></div>
-      </div>
-      <div class="ppr-range-viz">
-        <div class="ppr-range-track">
-          ${hasRange ? `<div class="ppr-range-fill" style="left:${rangeLeft}%; width:${rangeWidth}%"></div>
-          <div class="ppr-range-median-marker" style="left:${medianLeft}%" aria-label="Median projection marker"></div>` : ''}
-        </div>
-      </div>
-    </div>`;
 }
 
 function renderAgeAdjMetric(ageAdjustedProduction) {
@@ -350,7 +320,7 @@ export function renderRookieCard(container, card) {
             ${renderRadarChart(card.athleticScore, card.productionScore, card.draftCapitalScore, card.athleticSource)}
           </section>
 
-          ${renderPprProjection(card.pprProjection)}
+          ${renderPprProjection(card.pprProjection, card)}
 
           <section class="metrics card-panel">
             <div class="section-title">Projection Comps</div>

--- a/components/rookies/renderPprProjection.js
+++ b/components/rookies/renderPprProjection.js
@@ -1,0 +1,49 @@
+function esc(str) {
+  return String(str ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+const DATA_GAP_FALLBACK_NOTE = 'Projection has limited supporting data; treat floor/median/ceiling as low-confidence.';
+const INSUFFICIENT_EVIDENCE_CAVEAT = 'Projection is grade-band based; limited evidence context applies.';
+
+export function renderPprProjection(ppr, card) {
+  if (!ppr) return '';
+  const bandClass = { Elite: 'ppr-band-elite', Starter: 'ppr-band-starter', Contributor: 'ppr-band-contributor', Lottery: 'ppr-band-lottery' }[ppr.band] ?? 'ppr-band-lottery';
+  const floor = Number(ppr.floor);
+  const median = Number(ppr.median);
+  const ceiling = Number(ppr.ceiling);
+  const hasRange = Number.isFinite(floor) && Number.isFinite(median) && Number.isFinite(ceiling) && ceiling >= floor;
+  const maxForScale = hasRange
+    ? Math.max(1, Math.ceil(Math.max(floor, median, ceiling) / 25) * 25)
+    : 1;
+  const rangeLeft = hasRange ? Math.max(0, Math.min(100, (floor / maxForScale) * 100)) : 0;
+  const rangeWidth = hasRange ? Math.max(0, Math.min(100 - rangeLeft, ((ceiling - floor) / maxForScale) * 100)) : 0;
+  const medianLeft = hasRange ? Math.max(0, Math.min(100, (median / maxForScale) * 100)) : 0;
+  const dataGapWarning = ppr.dataGapFlag === true
+    ? `<div class="ppr-data-gap-warning" role="alert">⚠️ ${esc(ppr.dataGapNote || DATA_GAP_FALLBACK_NOTE)}</div>`
+    : '';
+  const evidenceCaveat = card?.evidenceTier === 'insufficient_evidence'
+    ? `<div class="ppr-evidence-caveat">${esc(INSUFFICIENT_EVIDENCE_CAVEAT)}</div>`
+    : '';
+  return `
+    <div class="ppr-card-section">
+      <div class="section-title">Year 1 PPR Projection</div>
+      ${dataGapWarning}
+      <div class="ppr-card-row">
+        <div class="ppr-card-stat"><div class="ppr-stat-label">Floor</div><div class="ppr-stat-value">${esc(ppr.floor)}</div></div>
+        <div class="ppr-card-stat ppr-median"><div class="ppr-stat-label">Median</div><div class="ppr-stat-value ppr-median-value">${esc(ppr.median)}</div></div>
+        <div class="ppr-card-stat"><div class="ppr-stat-label">Ceiling</div><div class="ppr-stat-value">${esc(ppr.ceiling)}</div></div>
+        <div class="ppr-card-band"><span class="ppr-band ${bandClass}">${esc(ppr.band)}</span></div>
+      </div>
+      <div class="ppr-range-viz">
+        <div class="ppr-range-track">
+          ${hasRange ? `<div class="ppr-range-fill" style="left:${rangeLeft}%; width:${rangeWidth}%"></div>
+          <div class="ppr-range-median-marker" style="left:${medianLeft}%" aria-label="Median projection marker"></div>` : ''}
+        </div>
+      </div>
+      ${evidenceCaveat}
+    </div>`;
+}

--- a/components/rookies/rookieCardStyles.css
+++ b/components/rookies/rookieCardStyles.css
@@ -364,6 +364,23 @@ body {
   background: var(--accent-soft);
   box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.6);
 }
+.ppr-data-gap-warning {
+  margin-top: 8px;
+  padding: 8px 10px;
+  border-radius: 8px;
+  font-size: 12px;
+  line-height: 1.4;
+  color: #f1c27d;
+  background: rgba(217, 119, 87, 0.12);
+  border: 1px solid rgba(217, 119, 87, 0.5);
+}
+.ppr-evidence-caveat {
+  margin-top: 10px;
+  font-size: 11px;
+  line-height: 1.4;
+  color: var(--muted);
+  font-style: italic;
+}
 
 /* ─── PPR projection (board) ─────────────────────────────────────────────── */
 .board-ppr { line-height: 1.3; }

--- a/lib/rookies/mapRookieToCard.js
+++ b/lib/rookies/mapRookieToCard.js
@@ -97,7 +97,15 @@ export function mapRookieToCard({ alphaPlayer, statsRow, pprRow, dynastyRow, tre
     ? alphaPlayer.evidence.evidence_summary
     : null;
   const pprProjection = pprRow
-    ? { floor: pprRow.ppr_floor, median: pprRow.ppr_median, ceiling: pprRow.ppr_ceiling, band: pprRow.projection_band }
+    ? {
+        floor: pprRow.ppr_floor,
+        median: pprRow.ppr_median,
+        ceiling: pprRow.ppr_ceiling,
+        band: pprRow.projection_band,
+        projectionMethod: pprRow.projection_method ?? null,
+        dataGapFlag: pprRow.data_gap_flag === true,
+        dataGapNote: pprRow.data_gap_note ?? null,
+      }
     : null;
 
   const dynastyAdp = dynastyRow?.dynasty_adp_0_100 ?? null;

--- a/lib/rookies/normalizeRookieIdentity.js
+++ b/lib/rookies/normalizeRookieIdentity.js
@@ -8,7 +8,7 @@ const POSITION_LABELS = {
 const ROLE_BY_POSITION = {
   QB: 'Pocket passer',
   RB: 'Early-down runner',
-  WR: 'Perimeter receiver',
+  WR: 'Receiver profile',
   TE: 'Move tight end',
 };
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "node runtime-server.js",
     "test:runtime-smoke": "node --test tests/runtime-server.smoke.test.cjs",
+    "test:card-disclosure": "node --test tests/card-disclosure-wiring.test.mjs",
     "ops:rehearse-2026": "bash scripts/rehearse_draft_week_handoff_2026.sh"
   },
   "engines": {

--- a/tests/card-disclosure-wiring.test.mjs
+++ b/tests/card-disclosure-wiring.test.mjs
@@ -1,0 +1,83 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { mapRookieToCard } from '../lib/rookies/mapRookieToCard.js';
+import { renderPprProjection } from '../components/rookies/renderPprProjection.js';
+import { normalizeRookieIdentity } from '../lib/rookies/normalizeRookieIdentity.js';
+
+const baseAlphaPlayer = { player_id: 'wr-data-gap-test', position: 'WR' };
+
+test('mapRookieToCard preserves PPR data_gap_flag / data_gap_note metadata', () => {
+  const card = mapRookieToCard({
+    alphaPlayer: baseAlphaPlayer,
+    pprRow: {
+      ppr_floor: 40,
+      ppr_median: 70,
+      ppr_ceiling: 110,
+      projection_band: 'Contributor',
+      projection_method: 'alpha_band_v1',
+      data_gap_flag: true,
+      data_gap_note: 'Missing combine athletic inputs.',
+    },
+  });
+
+  assert.equal(card.pprProjection.dataGapFlag, true);
+  assert.equal(card.pprProjection.dataGapNote, 'Missing combine athletic inputs.');
+  assert.equal(card.pprProjection.projectionMethod, 'alpha_band_v1');
+});
+
+test('mapRookieToCard defaults data_gap_flag to false when absent', () => {
+  const card = mapRookieToCard({
+    alphaPlayer: baseAlphaPlayer,
+    pprRow: {
+      ppr_floor: 40,
+      ppr_median: 70,
+      ppr_ceiling: 110,
+      projection_band: 'Contributor',
+    },
+  });
+
+  assert.equal(card.pprProjection.dataGapFlag, false);
+  assert.equal(card.pprProjection.dataGapNote, null);
+});
+
+test('renderPprProjection shows the data-gap warning with the provided note', () => {
+  const html = renderPprProjection(
+    {
+      floor: 40,
+      median: 70,
+      ceiling: 110,
+      band: 'Contributor',
+      dataGapFlag: true,
+      dataGapNote: 'Missing combine athletic inputs.',
+    },
+    { evidenceTier: 'moderate_edge' },
+  );
+
+  assert.match(html, /ppr-data-gap-warning/);
+  assert.match(html, /Missing combine athletic inputs\./);
+});
+
+test('renderPprProjection omits the warning when there is no data gap', () => {
+  const html = renderPprProjection(
+    { floor: 40, median: 70, ceiling: 110, band: 'Contributor', dataGapFlag: false },
+    { evidenceTier: 'moderate_edge' },
+  );
+
+  assert.doesNotMatch(html, /ppr-data-gap-warning/);
+});
+
+test('renderPprProjection adds the grade-band caveat for insufficient-evidence cards', () => {
+  const html = renderPprProjection(
+    { floor: 40, median: 70, ceiling: 110, band: 'Contributor' },
+    { evidenceTier: 'insufficient_evidence' },
+  );
+
+  assert.match(html, /ppr-evidence-caveat/);
+  assert.match(html, /Projection is grade-band based; limited evidence context applies\./);
+});
+
+test('WR role label is a neutral receiver profile, not perimeter-specific', () => {
+  const identity = normalizeRookieIdentity({ alphaPlayer: { position: 'WR' } });
+  assert.equal(identity.roleLabel, 'Receiver profile');
+});


### PR DESCRIPTION
- Preserve projectionMethod, dataGapFlag, dataGapNote from pprRow in
  mapRookieToCard (projection math unchanged).
- Surface a visible data-gap warning in the PPR projection section,
  using dataGapNote when present, plus a grade-band caveat for
  insufficient-evidence cards.
- Extract renderPprProjection into its own module so the disclosure
  logic is unit-testable.
- Relabel generic WR role from 'Perimeter receiver' to neutral
  'Receiver profile'.
- Add tests covering metadata preservation, rendered disclosures, and
  the neutral WR role label.