### PR TITLE
Tighten analyst attribution + proprietary phrasing in 2026 summaries (Issue #248 PR 2b)

### DIFF
--- a/data/processed/2026_prospect_context.json
+++ b/data/processed/2026_prospect_context.json
@@ -158,7 +158,7 @@
       "one_hit_wonder_risk",
       "shared_backfield_love_2024"
     ],
-    "evidence_summary": "Transfer: Notre Dame (2024, shared backfield with Jeremiyah Love) \u2192 Texas A&M (2025). Breakout at age 20 at Notre Dame despite competing for carries with Love \u2014 a top-tier RB1 prospect. Production suppression from shared backfield is mitigating context for volume metrics. Dynasty community ranks him RB2 of class (overall top-5 rookie pick). Red flag: YAC+catch 2nd-best season 39.9 yd/game \u2014 among the weaker marks in the top-100 DC RB dataset since 2017 (named comparisons unverified). One-hit-wonder risk remains; YAC consistency gap is the primary model concern.",
+    "evidence_summary": "Transfer: Notre Dame (2024, shared backfield with Jeremiyah Love) \u2192 Texas A&M (2025). Breakout at age 20 at Notre Dame despite competing for carries with Love \u2014 a top-tier RB1 prospect. Production suppression from shared backfield is mitigating context for volume metrics. Some dynasty rankers place him among the top RBs in the class (specific source not cited). Red flag: YAC+catch 2nd-best season 39.9 yd/game \u2014 among the weaker marks in the top-100 DC RB dataset since 2017 (named comparisons unverified). One-hit-wonder risk remains; YAC consistency gap is the primary model concern.",
     "context_source": "@ffdataroma research note 2026-04-08 + research agent 2026-04-09",
     "dob": "2003-10-09",
     "breakout_strength": 0.219,
@@ -909,7 +909,7 @@
       "broken_offense_context",
       "late_declare"
     ],
-    "evidence_summary": "FR: 2 rec/15 yds (2022). SO: 5 rec/51 yds (2023) \u2014 suppressed by depth chart behind Rome Odunze, Ja'Lynn Polk, Jalen McMillan, Germie Bernard (all drafted R1-R3). JR 2024 (age 20): 63 rec / 834 yds / 9 TD \u2014 led Washington in receiving yards and TDs, honorable mention All-Big Ten. SR 2025 (age 21): 62 rec / 881 yds / 11 TD. Two consecutive elite seasons; consistent production profile. 73.4 YPG best season is in range of recent R1 producers (named comparisons unverified). Zone specialist: 6.25% contested target rate vs zone. Man coverage challenge: 25.71% CTT vs man \u2014 saved by 76.9% contested catch rate (10/13 in 2025). 1D/RR 0.136 (elite; class rank unverified). Career YPRR 2.02 \u2014 at the 2.00 threshold; historically a low-hit-rate profile (sample rate unverified). Pro day: 6.80 3-cone, 4.30 shuttle, 37.5\" vert at 210 lbs. Best RZ receiver in class per multiple evaluators. 3.1% drop rate. ADOT 14.4, man_YPRR 2.58 vs zone_YPRR 2.20. YAC/rec 5.3. Closest comp: Michael Wilson (Stanford). Non-early declare; 4 full seasons.",
+    "evidence_summary": "FR: 2 rec/15 yds (2022). SO: 5 rec/51 yds (2023) \u2014 suppressed by depth chart behind Rome Odunze, Ja'Lynn Polk, Jalen McMillan, Germie Bernard (all drafted R1-R3). JR 2024 (age 20): 63 rec / 834 yds / 9 TD \u2014 led Washington in receiving yards and TDs, honorable mention All-Big Ten. SR 2025 (age 21): 62 rec / 881 yds / 11 TD. Two consecutive elite seasons; consistent production profile. 73.4 YPG best season is in range of recent R1 producers (named comparisons unverified). Zone specialist: 6.25% contested target rate vs zone. Man coverage challenge: 25.71% CTT vs man \u2014 saved by 76.9% contested catch rate (10/13 in 2025). 1D/RR 0.136 (elite; class rank unverified). Career YPRR 2.02 \u2014 at the 2.00 threshold; historically a low-hit-rate profile (sample rate unverified). Pro day: 6.80 3-cone, 4.30 shuttle, 37.5\" vert at 210 lbs. Regarded by multiple evaluators as one of the best red-zone receivers in the class. 3.1% drop rate. ADOT 14.4, man_YPRR 2.58 vs zone_YPRR 2.20. YAC/rec 5.3. Closest comp: Michael Wilson (Stanford). Non-early declare; 4 full seasons.",
     "context_source": "Wikipedia + X research (2026 R1 FR/SO chart, zone/man splits, pro day data, contested catch analysis, production comps), retrieved 2026-04-18.",
     "mtf_source": "Scott Barrett / PFF chart (@ScottBarrettDFB) \u2014 College Career MTF per Reception, 2026 WR prospects",
     "first_down_per_route_run": 0.136,
@@ -2470,7 +2470,7 @@
       "pending_cfbd_verification",
       "low_1d_rr_below_avg"
     ],
-    "evidence_summary": "36 catches for 630 yards and 5 TDs at Notre Dame in 2025 with an elite 17.5 YPR; 9.98 RAS (top 2% ever) but 4.61 forty will be a concern for NFL evaluators. At 6'5\"/218 lbs he's a massive red-zone target; pure raw upside prospect limited by below-average speed.",
+    "evidence_summary": "36 catches for 630 yards and 5 TDs at Notre Dame in 2025 with an elite 17.5 YPR; 9.98 RAS (elite RAS composite; 'top 2% ever' not independently verified) but 4.61 forty will be a concern for NFL evaluators. At 6'5\"/218 lbs he's a massive red-zone target; pure raw upside prospect limited by below-average speed.",
     "context_source": "manual_seed_2026",
     "exceptional_metrics": [],
     "first_down_per_route_run": 0.0898,

--- a/exports/promoted/rookie-alpha/2026_manifest.json
+++ b/exports/promoted/rookie-alpha/2026_manifest.json
@@ -1,8 +1,8 @@
 {
   "season": 2026,
   "model_version": "rookie-alpha-predraft-v0.5.0",
-  "generated_at": "2026-06-14T12:53:00+00:00",
-  "run_id": "rookie-alpha-2026-2026-06-14T12:53:00+00:00",
+  "generated_at": "2026-06-14T13:05:39+00:00",
+  "run_id": "rookie-alpha-2026-2026-06-14T13:05:39+00:00",
   "input_files": [
     {
       "path": "data/raw/2026_combine_results.json",
@@ -21,7 +21,7 @@
     },
     {
       "path": "data/processed/2026_prospect_context.json",
-      "sha256": "77c04b7c42bd33b6279dc7a0a579ae3db47c2c6f0d861ca8462947a7c727f19a",
+      "sha256": "bdf16633076bb5fb28e9451028fc476fadf6ff727dc06bdb106eb026e741de0e",
       "row_count": 100
     },
     {
@@ -47,7 +47,7 @@
   "output_files": [
     {
       "path": "exports/promoted/rookie-alpha/2026_rookie_alpha_predraft_v0.json",
-      "sha256": "67bd6c8a1d4a53dbbf8ae3ea0b04af752a89354fc64be119431ca6e4b6babb29"
+      "sha256": "5a7c6c945ad477c1a54e61e7337e9f5bd6b5e69455669ca4700d7668fe9816e3"
     },
     {
       "path": "exports/promoted/rookie-alpha/2026_rookie_alpha_predraft_v0.csv",
@@ -57,8 +57,8 @@
   "export_metadata": {
     "season": 2026,
     "model_version": "rookie-alpha-predraft-v0.5.0",
-    "generated_at": "2026-06-14T12:53:00+00:00",
-    "run_id": "rookie-alpha-2026-2026-06-14T12:53:00+00:00",
+    "generated_at": "2026-06-14T13:05:39+00:00",
+    "run_id": "rookie-alpha-2026-2026-06-14T13:05:39+00:00",
     "coverage_summary": {
       "players_total": 48,
       "players_with_any_missing_input": 0,

--- a/exports/promoted/rookie-alpha/2026_rookie_alpha_predraft_v0.json
+++ b/exports/promoted/rookie-alpha/2026_rookie_alpha_predraft_v0.json
@@ -11,8 +11,8 @@
       "age_at_entry_supported": false
     }
   },
-  "generated_at": "2026-06-14T12:53:00+00:00",
-  "run_id": "rookie-alpha-2026-2026-06-14T12:53:00+00:00",
+  "generated_at": "2026-06-14T13:05:39+00:00",
+  "run_id": "rookie-alpha-2026-2026-06-14T13:05:39+00:00",
   "season": 2026,
   "coverage_summary": {
     "players_total": 48,
@@ -508,7 +508,7 @@
         "translation_flags": [
           "young_breakout"
         ],
-        "evidence_summary": "FR: 2 rec/15 yds (2022). SO: 5 rec/51 yds (2023) \u2014 suppressed by depth chart behind Rome Odunze, Ja'Lynn Polk, Jalen McMillan, Germie Bernard (all drafted R1-R3). JR 2024 (age 20): 63 rec / 834 yds / 9 TD \u2014 led Washington in receiving yards and TDs, honorable mention All-Big Ten. SR 2025 (age 21): 62 rec / 881 yds / 11 TD. Two consecutive elite seasons; consistent production profile. 73.4 YPG best season is in range of recent R1 producers (named comparisons unverified). Zone specialist: 6.25% contested target rate vs zone. Man coverage challenge: 25.71% CTT vs man \u2014 saved by 76.9% contested catch rate (10/13 in 2025). 1D/RR 0.136 (elite; class rank unverified). Career YPRR 2.02 \u2014 at the 2.00 threshold; historically a low-hit-rate profile (sample rate unverified). Pro day: 6.80 3-cone, 4.30 shuttle, 37.5\" vert at 210 lbs. Best RZ receiver in class per multiple evaluators. 3.1% drop rate. ADOT 14.4, man_YPRR 2.58 vs zone_YPRR 2.20. YAC/rec 5.3. Closest comp: Michael Wilson (Stanford). Non-early declare; 4 full seasons.",
+        "evidence_summary": "FR: 2 rec/15 yds (2022). SO: 5 rec/51 yds (2023) \u2014 suppressed by depth chart behind Rome Odunze, Ja'Lynn Polk, Jalen McMillan, Germie Bernard (all drafted R1-R3). JR 2024 (age 20): 63 rec / 834 yds / 9 TD \u2014 led Washington in receiving yards and TDs, honorable mention All-Big Ten. SR 2025 (age 21): 62 rec / 881 yds / 11 TD. Two consecutive elite seasons; consistent production profile. 73.4 YPG best season is in range of recent R1 producers (named comparisons unverified). Zone specialist: 6.25% contested target rate vs zone. Man coverage challenge: 25.71% CTT vs man \u2014 saved by 76.9% contested catch rate (10/13 in 2025). 1D/RR 0.136 (elite; class rank unverified). Career YPRR 2.02 \u2014 at the 2.00 threshold; historically a low-hit-rate profile (sample rate unverified). Pro day: 6.80 3-cone, 4.30 shuttle, 37.5\" vert at 210 lbs. Regarded by multiple evaluators as one of the best red-zone receivers in the class. 3.1% drop rate. ADOT 14.4, man_YPRR 2.58 vs zone_YPRR 2.20. YAC/rec 5.3. Closest comp: Michael Wilson (Stanford). Non-early declare; 4 full seasons.",
         "context_source": "Wikipedia + X research (2026 R1 FR/SO chart, zone/man splits, pro day data, contested catch analysis, production comps), retrieved 2026-04-18."
       },
       "rookie_alpha_rank": 5,
@@ -2780,7 +2780,7 @@
         "translation_flags": [
           "young_breakout"
         ],
-        "evidence_summary": "Transfer: Notre Dame (2024, shared backfield with Jeremiyah Love) \u2192 Texas A&M (2025). Breakout at age 20 at Notre Dame despite competing for carries with Love \u2014 a top-tier RB1 prospect. Production suppression from shared backfield is mitigating context for volume metrics. Dynasty community ranks him RB2 of class (overall top-5 rookie pick). Red flag: YAC+catch 2nd-best season 39.9 yd/game \u2014 among the weaker marks in the top-100 DC RB dataset since 2017 (named comparisons unverified). One-hit-wonder risk remains; YAC consistency gap is the primary model concern.",
+        "evidence_summary": "Transfer: Notre Dame (2024, shared backfield with Jeremiyah Love) \u2192 Texas A&M (2025). Breakout at age 20 at Notre Dame despite competing for carries with Love \u2014 a top-tier RB1 prospect. Production suppression from shared backfield is mitigating context for volume metrics. Some dynasty rankers place him among the top RBs in the class (specific source not cited). Red flag: YAC+catch 2nd-best season 39.9 yd/game \u2014 among the weaker marks in the top-100 DC RB dataset since 2017 (named comparisons unverified). One-hit-wonder risk remains; YAC consistency gap is the primary model concern.",
         "context_source": "@ffdataroma research note 2026-04-08 + research agent 2026-04-09"
       },
       "rookie_alpha_rank": 29,
@@ -2994,7 +2994,7 @@
         ],
         "context_flags": [],
         "translation_flags": [],
-        "evidence_summary": "36 catches for 630 yards and 5 TDs at Notre Dame in 2025 with an elite 17.5 YPR; 9.98 RAS (top 2% ever) but 4.61 forty will be a concern for NFL evaluators. At 6'5\"/218 lbs he's a massive red-zone target; pure raw upside prospect limited by below-average speed.",
+        "evidence_summary": "36 catches for 630 yards and 5 TDs at Notre Dame in 2025 with an elite 17.5 YPR; 9.98 RAS (elite RAS composite; 'top 2% ever' not independently verified) but 4.61 forty will be a concern for NFL evaluators. At 6'5\"/218 lbs he's a massive red-zone target; pure raw upside prospect limited by below-average speed.",
         "context_source": "manual_seed_2026"
       },
       "rookie_alpha_rank": 32,


### PR DESCRIPTION
**PR 2b of the Issue #248 PR 2 data pass** — the polish half (maintainer priorities **2 & 3**), following the merged PR 2a (#251). Source-first edits to `data/processed/2026_prospect_context.json`, export + manifest regenerated via `scripts/compute_rookie_alpha.py`. No hand-patched hashes.

## What changed (3 summaries)

**Priority 2 — analyst-board attribution tightening**
- **Jadarian Price**: "Dynasty community ranks him RB2 of class (overall top-5 rookie pick)" → "Some dynasty rankers place him among the top RBs in the class (specific source not cited)." (the only un-sourced board claim).
- **Denzel Boston**: "Best RZ receiver in class per multiple evaluators" → "Regarded by multiple evaluators as one of the best red-zone receivers in the class." (softens the class superlative; keeps the attribution).

**Priority 3 — proprietary-metric phrasing**
- **Malachi Fields**: "9.98 RAS (top 2% ever)" → "9.98 RAS (elite RAS composite; 'top 2% ever' not independently verified)".

## Why this PR is small (intentional)
After the policy (#250) and the safety-critical pass (#251), the remaining proprietary metrics were **already provider-attributed** — PFF grades ("overall PFF grade", "PFF WR11"), NGS ("NGS metric"), RAS values, SPORQ values, Reception Perception — i.e. already "clearly attributed" per the policy's §4.3 treatment rule, not presented as TIBER model truth. The remaining analyst boards (Brugler/The Athletic, Kiper/Tankathon, Bleacher Report, ESPN Scouts Inc., ESPN Matt Miller) were already phrased as attributed opinion. So no edits were appropriate there.

One judgment call left **unchanged**: inline analytical percentiles from informal research (e.g. Jonah Coleman, Dae'Quan Wright "Nth pctile") are computed descriptors, not paywalled-product claims presented as canonical model truth, so they don't trip the acceptance criterion. Happy to flag those as unverified too if you'd prefer.

## Guardrails / validation
- No scoring/rank/formula/projection/ordering change — `scores` blocks byte-identical pre/post.
- `pytest tests` → **376 passed**; `npm run test:card-disclosure` → **6 passed**; real export+manifest validation → **VALIDATION PASSED**.

Refs #248. Completes the PR 2 data application (2a + 2b).

https://claude.ai/code/session_01G9HP9Trg6pqjqvj88QAg91

---
_Generated by [Claude Code](https://claude.ai/code/session_01G9HP9Trg6pqjqvj88QAg91)_