### PR TITLE
Phase 1A: restore temporal integrity to the rookie card seam (#272)

### DIFF
--- a/components/rookies/RookieBoardRow.js
+++ b/components/rookies/RookieBoardRow.js
@@ -1,4 +1,5 @@
 import { getCollegeLogoUrl, getNflTeamLogoUrl } from '/lib/rookies/teamLogos.js';
+import { athleticChipLabel, athleticChipTitle } from '/lib/rookies/athleticLabel.js';
 
 function esc(str) {
   return String(str ?? '')
@@ -31,18 +32,6 @@ const PPR_BAND_CLASS = {
  * Renders a compact 3-bar SVG showing Athletic / Production / Draft Capital (0–100).
  * Bars are colour-coded: Athletic (RAS/SPORQ/partial) = steel blue, Production = teal, Draft = coral.
  */
-function athChipLabel(source) {
-  if (source === 'SPORQ') return 'SPORQ';
-  if (source === 'COMBINE_FALLBACK') return 'ATH*';
-  return 'RAS';
-}
-
-function athChipTitle(source) {
-  if (source === 'SPORQ') return 'Athletic score (SPORQ composite)';
-  if (source === 'COMBINE_FALLBACK') return 'Athletic score (partial combine)';
-  return 'Relative Athletic Score';
-}
-
 function renderMiniScoreChart(row) {
   const bars = [
     { value: row.athleticScore,     color: '#6B9FD4', label: 'A' },
@@ -213,7 +202,7 @@ function renderMobileCard(row, { isQueued = false, queueAnnotation = null } = {}
       </div>
       <div class="bmc-signals">
         ${row.draftCapitalScore != null ? `<span class="bmc-signal-chip bmc-signal-capital" title="Draft Capital">CAP ${Math.round(row.draftCapitalScore)}</span>` : ''}
-        ${row.athleticScore    != null ? `<span class="bmc-signal-chip bmc-signal-ath${row.athleticSource === 'SPORQ' ? ' bmc-signal-ath-sporq' : ''}" title="${athChipTitle(row.athleticSource)}">${athChipLabel(row.athleticSource)} ${Math.round(row.athleticScore)}</span>` : ''}
+        ${row.athleticScore    != null ? `<span class="bmc-signal-chip bmc-signal-ath${row.athleticSource === 'SPORQ' ? ' bmc-signal-ath-sporq' : ''}" title="${athleticChipTitle(row.athleticSource)}">${athleticChipLabel(row.athleticSource)} ${Math.round(row.athleticScore)}</span>` : ''}
         ${row.productionScore  != null ? `<span class="bmc-signal-chip bmc-signal-prod"    title="Production Score">PRD ${Math.round(row.productionScore)}</span>` : ''}
         ${renderBoarChip(row)}
       </div>

--- a/components/rookies/RookieBoardRow.js
+++ b/components/rookies/RookieBoardRow.js
@@ -65,7 +65,7 @@ function renderMiniScoreChart(row) {
 
 function renderPprCell(row) {
   const proj = row.pprProjection;
-  if (!proj) return '<div class="board-cell" data-label="PPR Range"><span class="ppr-na">—</span></div>';
+  if (!proj || proj.stale === true) return '<div class="board-cell" data-label="PPR Range"><span class="ppr-na">—</span></div>';
   const bandClass = PPR_BAND_CLASS[proj.band] ?? 'ppr-band-lottery';
   return `
     <div class="board-cell board-ppr" data-label="PPR Range">
@@ -175,8 +175,6 @@ function renderEvidenceTierBadge(tier, reason) {
 function renderMobileCard(row, { isQueued = false, queueAnnotation = null } = {}) {
   const rank = row.classRank == null ? 'N/A' : `#${row.classRank}`;
   const preDraftGrade = row.preDraftGrade == null ? 'N/A' : row.preDraftGrade.toFixed(1);
-  const adjustedGrade = row.postDraftAdjustedGrade == null ? 'N/A' : row.postDraftAdjustedGrade.toFixed(1);
-  const hasPostDraft = row.postDraftAdjustedGrade != null;
   const slug = encodeURIComponent(String(row.slug ?? ''));
   const compareLeftHref = `/cards/rookies/compare/index.html?left=${slug}`;
   const compareRightHref = `/cards/rookies/compare/index.html?right=${slug}`;
@@ -188,18 +186,17 @@ function renderMobileCard(row, { isQueued = false, queueAnnotation = null } = {}
     row.draftClass ? String(row.draftClass) : null,
   ].filter(Boolean);
 
-  const pprBand = row.pprProjection?.band ?? null;
-  const pprRange = row.pprProjection
-    ? `${esc(row.pprProjection.floor)}–${esc(row.pprProjection.ceiling)}`
+  const pprLive = row.pprProjection && row.pprProjection.stale !== true ? row.pprProjection : null;
+  const pprBand = pprLive?.band ?? null;
+  const pprRange = pprLive
+    ? `${esc(pprLive.floor)}–${esc(pprLive.ceiling)}`
     : null;
 
   return `
     <div class="board-mobile-card">
       <div class="bmc-header">
         <span class="bmc-rank board-num">${esc(rank)}</span>
-        <span class="bmc-grade">${hasPostDraft
-    ? `Pre <strong class="bmc-grade-value">${esc(preDraftGrade)}</strong> · Post <strong class="bmc-grade-value">${esc(adjustedGrade)}</strong>`
-    : `Pre <strong class="bmc-grade-value">${esc(preDraftGrade)}</strong> · Post-Draft pending`}</span>
+        <span class="bmc-grade">Pre <strong class="bmc-grade-value">${esc(preDraftGrade)}</strong> · Post-draft grade not yet published</span>
       </div>
       <div class="bmc-name">
         ${renderTeamLogos(row.school, row.nflTeam)}
@@ -221,7 +218,6 @@ function renderMobileCard(row, { isQueued = false, queueAnnotation = null } = {}
         ${renderBoarChip(row)}
       </div>
       <div class="bmc-stats">
-        ${hasPostDraft ? `<div class="bmc-stat-row"><span class="bmc-stat-label">Post-Draft Delta</span><span>${deltaSpanInline(row.postDraftDelta)}</span></div>` : ''}
         <div class="bmc-stat-row"><span class="bmc-stat-label">vs. Consensus</span><span>${deltaSpanInline(row.consensusDelta)}</span></div>
         ${pprRange ? `<div class="bmc-stat-row"><span class="bmc-stat-label">Range</span><span class="bmc-ppr-range">${pprRange} PPR</span></div>` : ''}
       </div>
@@ -239,8 +235,6 @@ function renderMobileCard(row, { isQueued = false, queueAnnotation = null } = {}
 export function renderRookieBoardRow(row, { isQueued = false, queueAnnotation = null } = {}) {
   const rank = row.classRank == null ? 'N/A' : `#${row.classRank}`;
   const preDraftGrade = row.preDraftGrade == null ? 'N/A' : row.preDraftGrade.toFixed(1);
-  const adjustedGrade = row.postDraftAdjustedGrade == null ? 'N/A' : row.postDraftAdjustedGrade.toFixed(1);
-  const hasPostDraft = row.postDraftAdjustedGrade != null;
   const slug = encodeURIComponent(String(row.slug ?? ''));
   const compareLeftHref = `/cards/rookies/compare/index.html?left=${slug}`;
   const compareRightHref = `/cards/rookies/compare/index.html?right=${slug}`;
@@ -268,7 +262,7 @@ export function renderRookieBoardRow(row, { isQueued = false, queueAnnotation = 
       <div class="board-cell" data-label="School">${esc(row.school)}</div>
       <div class="board-cell board-grade board-num" data-label="Pre/Post Grade">
         <div>Pre ${esc(preDraftGrade)}</div>
-        <div class="meta">${hasPostDraft ? `Post ${esc(adjustedGrade)} · Δ ${deltaSpanInline(row.postDraftDelta)}` : 'Post-Draft pending'}</div>
+        <div class="meta">Post-draft grade not yet published</div>
         ${renderVolumeTrend(row)}
       </div>
       <div class="board-cell" data-label="Tier"><span class="board-tier-pill">${esc(row.tier.label)}</span></div>

--- a/components/rookies/RookieCard.js
+++ b/components/rookies/RookieCard.js
@@ -159,10 +159,13 @@ function renderOfficialOutcome(card) {
   const outcome = card.officialOutcome ?? null;
   if (!outcome) return '';
   if (outcome.status === 'unavailable') {
+    const reasonCopy = outcome.reason === 'governed_source_load_failed'
+      ? 'governed source did not load'
+      : 'governed outcome not available';
     return `
     <section class="metrics card-panel official-outcome-panel">
       <div class="section-title">Official NFL Outcome</div>
-      <div class="ppr-stale-warning" role="alert">⚠️ Official NFL outcome unavailable (governed source did not load).</div>
+      <div class="ppr-stale-warning" role="alert">⚠️ Official NFL outcome unavailable (${esc(reasonCopy)}).</div>
     </section>`;
   }
   const factBits = [

--- a/components/rookies/RookieCard.js
+++ b/components/rookies/RookieCard.js
@@ -183,7 +183,7 @@ function renderOfficialOutcome(card) {
   return `
     <section class="metrics card-panel official-outcome-panel">
       <div class="section-title">Official NFL Outcome</div>
-      <div class="meta">Governed transition profile · rookie_transition_profile_v0.2.0.</div>
+      <div class="meta">Governed transition profile${outcome.schemaVersion ? ` · ${esc(outcome.schemaVersion)}` : ''}.</div>
       <div class="official-outcome-facts">${factBits || 'Outcome not yet recorded'}</div>
       ${provLine}
     </section>`;

--- a/components/rookies/RookieCard.js
+++ b/components/rookies/RookieCard.js
@@ -161,6 +161,13 @@ function classRankLine(card) {
 function renderOfficialOutcome(card) {
   const outcome = card.officialOutcome ?? null;
   if (!outcome) return '';
+  if (outcome.status === 'unavailable') {
+    return `
+    <section class="metrics card-panel official-outcome-panel">
+      <div class="section-title">Official NFL Outcome</div>
+      <div class="ppr-stale-warning" role="alert">⚠️ Official NFL outcome unavailable (governed source did not load).</div>
+    </section>`;
+  }
   const factBits = [
     outcome.nflTeam ? `Team: ${esc(outcome.nflTeam)}` : '',
     outcome.draftRound != null ? `Round ${esc(outcome.draftRound)}` : '',

--- a/components/rookies/RookieCard.js
+++ b/components/rookies/RookieCard.js
@@ -70,7 +70,11 @@ function renderRadarChart(athleticScore, production, draftCapital, athleticSourc
   const centerX = 100;
   const centerY = 100;
   const radius = 80;
-  const athLabel = athleticSource === 'SPORQ' ? 'ATH (SPORQ)' : athleticSource === 'COMBINE_FALLBACK' ? 'ATH (partial)' : 'RAS';
+  const athLabel = athleticSource === 'SPORQ'
+    ? 'ATH (SPORQ)'
+    : (athleticSource === 'COMBINE_FALLBACK' || athleticSource === 'RAS_PARTIAL')
+      ? 'ATH (partial)'
+      : 'RAS';
   const axes = [
     { label: athLabel, angle: -Math.PI / 2, value: athleticScore },
     { label: 'Production', angle: Math.PI / 6, value: production },
@@ -131,6 +135,51 @@ function renderEvidenceTierBadge(card) {
   const label = EVIDENCE_TIER_LABELS[tier] ?? String(tier).replace(/_/g, ' ');
   const reason = card.evidenceTierReason ?? 'Evidence tier classification';
   return `<span class="evidence-tier-badge" title="${esc(reason)}">${esc(label)}</span>`;
+}
+
+function isoDate(value) {
+  return value ? String(value).slice(0, 10) : null;
+}
+
+function renderBaselineProvenance(card) {
+  const baseline = card.preDraftBaseline ?? null;
+  const bits = [
+    'Frozen snapshot',
+    baseline?.modelVersion ? esc(baseline.modelVersion) : null,
+    baseline?.generatedAt ? `generated ${esc(isoDate(baseline.generatedAt))}` : null,
+  ].filter(Boolean);
+  return bits.join(' · ');
+}
+
+function classRankLine(card) {
+  const classRank = card.summary.classRank == null ? 'N/A' : card.summary.classRank;
+  const posRank = card.summary.posRank;
+  const posBit = posRank != null ? ` · ${esc(card.identity.position)} #${esc(posRank)}` : '';
+  return `Class #${esc(classRank)}${posBit}`;
+}
+
+function renderOfficialOutcome(card) {
+  const outcome = card.officialOutcome ?? null;
+  if (!outcome) return '';
+  const factBits = [
+    outcome.nflTeam ? `Team: ${esc(outcome.nflTeam)}` : '',
+    outcome.draftRound != null ? `Round ${esc(outcome.draftRound)}` : '',
+    outcome.overallPick != null ? `Pick ${esc(outcome.overallPick)}` : '',
+    outcome.isUdfa ? 'UDFA' : '',
+  ].filter(Boolean).join(' · ');
+  const prov = outcome.provenance;
+  const provLine = prov
+    ? `<div class="meta official-outcome-provenance">Source: ${prov.sourceUrl
+        ? `<a href="${esc(prov.sourceUrl)}" target="_blank" rel="noopener noreferrer">${esc(prov.sourceName ?? 'source')}</a>`
+        : esc(prov.sourceName ?? 'source unavailable')}${prov.lastVerifiedAt ? ` · verified ${esc(isoDate(prov.lastVerifiedAt))}` : ''}${prov.confidenceBand ? ` · confidence ${esc(prov.confidenceBand)}` : ''}</div>`
+    : '';
+  return `
+    <section class="metrics card-panel official-outcome-panel">
+      <div class="section-title">Official NFL Outcome</div>
+      <div class="meta">Governed transition profile · rookie_transition_profile_v0.2.0.</div>
+      <div class="official-outcome-facts">${factBits || 'Outcome not yet recorded'}</div>
+      ${provLine}
+    </section>`;
 }
 
 function boarTierClass(boar) {
@@ -221,8 +270,8 @@ export function renderRookieCard(container, card) {
   const contextFlags = Array.isArray(card.contextSignals?.contextFlags) ? card.contextSignals.contextFlags : [];
   const evidenceSummary = card.contextSignals?.evidenceSummary ?? null;
   const athleticNotIncorporated = card.athleticSource === 'NEUTRAL_DEFAULT';
+  const athleticPartial = card.athleticSource === 'RAS_PARTIAL' || card.athleticSource === 'COMBINE_FALLBACK';
   const quickPprMedian = card.pprProjection?.median ?? null;
-  const hasPostDraft = card.postDraftAdjustedGrade != null;
   let selectedMetricFamily = 'all';
 
   const seasonsTable = card.seasons.length
@@ -259,12 +308,11 @@ export function renderRookieCard(container, card) {
             <p class="profile-summary">${esc(card.summary.profileSummary ?? card.summary.identityNote ?? 'Identity summary unavailable')}</p>
           </div>
           <div class="hero-score">
-            <div class="section-title">Pre-Draft Grade</div>
+            <div class="section-title">Rookie Alpha · Frozen Pre-Draft Baseline</div>
             <div class="score">${esc(heroScore)}</div>
-            <div class="meta">${hasPostDraft
-    ? `Post-Draft Adjusted Grade: ${esc(card.postDraftAdjustedGrade.toFixed(1))} · Delta ${esc((card.postDraftDelta >= 0 ? '+' : '') + card.postDraftDelta.toFixed(1))}`
-    : 'Post-draft adjustments pending official draft outcomes.'}</div>
-            <div class="meta">Class #${esc(card.summary.classRank ?? 'N/A')} · ${esc(card.identity.position)} #${esc(card.summary.posRank ?? 'N/A')}</div>
+            <div class="meta">${renderBaselineProvenance(card)}</div>
+            <div class="meta">Post-draft grade not yet published.</div>
+            <div class="meta">${classRankLine(card)}</div>
             ${renderEvidenceTierBadge(card)}
           </div>
         </div>
@@ -289,6 +337,8 @@ export function renderRookieCard(container, card) {
 
       <div class="card-columns">
         <div class="card-col">
+          ${renderOfficialOutcome(card)}
+
           <section class="metrics card-panel">
             <div class="section-title">Model Scores</div>
             <div class="meta">Deterministic model components from canonical artifacts.</div>
@@ -323,13 +373,15 @@ export function renderRookieCard(container, card) {
 
           ${renderPprProjection(card.pprProjection, card)}
 
-          <section class="metrics card-panel">
+          ${(card.comps?.high != null || card.comps?.low != null)
+            ? `<section class="metrics card-panel">
             <div class="section-title">Projection Comps</div>
             <div class="comp-grid">
               <div class="comp-card"><div class="pill-label">High-end</div><div class="comp-name">${esc(card.comps.high ?? 'N/A')}</div></div>
               <div class="comp-card"><div class="pill-label">Low-end</div><div class="comp-name">${esc(card.comps.low ?? 'N/A')}</div></div>
             </div>
-          </section>
+          </section>`
+            : ''}
 
           <section class="metrics card-panel">
             <div class="section-title">Research Notes & Translation Signals</div>
@@ -337,6 +389,9 @@ export function renderRookieCard(container, card) {
             <div class="meta">${esc(evidenceSummary ?? 'Translation summary unavailable in current artifacts.')}</div>
             ${athleticNotIncorporated
               ? '<div class="meta evidence-caveat">Athletic testing data was not incorporated into the model score.</div>'
+              : ''}
+            ${athleticPartial
+              ? `<div class="meta evidence-caveat">Partial athletic-testing composite (subset of combine events; not a full RAS).${card.athleticExplainer ? ` ${esc(card.athleticExplainer)}` : ''}</div>`
               : ''}
             ${translationFlags.length
               ? `<div class="tags tags-translation">${translationFlags.map((flag) => `<span class="tag">${esc(String(flag).replace(/_/g, ' '))}</span>`).join('')}</div>`

--- a/components/rookies/RookieCard.js
+++ b/components/rookies/RookieCard.js
@@ -1,5 +1,6 @@
 import { selectRookieEvidenceMetrics } from '/lib/rookies/selectRookieEvidenceMetrics.js';
 import { getCollegeLogoUrl, getNflTeamLogoUrl } from '/lib/rookies/teamLogos.js';
+import { athleticMetricLabel } from '/lib/rookies/athleticLabel.js';
 import { renderPprProjection } from './renderPprProjection.js';
 
 function esc(str) {
@@ -70,11 +71,7 @@ function renderRadarChart(athleticScore, production, draftCapital, athleticSourc
   const centerX = 100;
   const centerY = 100;
   const radius = 80;
-  const athLabel = athleticSource === 'SPORQ'
-    ? 'ATH (SPORQ)'
-    : (athleticSource === 'COMBINE_FALLBACK' || athleticSource === 'RAS_PARTIAL')
-      ? 'ATH (partial)'
-      : 'RAS';
+  const athLabel = athleticMetricLabel(athleticSource);
   const axes = [
     { label: athLabel, angle: -Math.PI / 2, value: athleticScore },
     { label: 'Production', angle: Math.PI / 6, value: production },

--- a/components/rookies/RookieCompareView.js
+++ b/components/rookies/RookieCompareView.js
@@ -306,6 +306,7 @@ function renderPprSideBySide(leftCard, rightCard) {
   if (!leftPpr && !rightPpr) return '';
 
   function pprPanel(card, ppr) {
+    if (ppr?.stale === true) return `<div class="compare-ppr-panel"><div class="meta">${esc(card.identity.name)}: Projection withheld (stale Alpha snapshot)</div></div>`;
     if (!ppr) return `<div class="compare-ppr-panel"><div class="meta">${esc(card.identity.name)}: No projection</div></div>`;
     const bandClass = { Elite: 'ppr-band-elite', Starter: 'ppr-band-starter', Contributor: 'ppr-band-contributor', Lottery: 'ppr-band-lottery' }[ppr.band] ?? 'ppr-band-lottery';
     const floor = Number(ppr.floor), median = Number(ppr.median), ceiling = Number(ppr.ceiling);

--- a/components/rookies/RookieCompareView.js
+++ b/components/rookies/RookieCompareView.js
@@ -247,11 +247,10 @@ function renderPlayerHeader(card, sideLabel) {
     `Class ${card.identity.classYear}`,
   ].filter(Boolean).join(' · ');
 
-  const hasPostDraft  = card.postDraftAdjustedGrade != null;
   const translation   = Array.isArray(card?.translationFlags) ? card.translationFlags : [];
   const contextFlags  = Array.isArray(card?.contextSignals?.contextFlags) ? card.contextSignals.contextFlags : [];
   const evidenceSummary = card?.contextSignals?.evidenceSummary ?? null;
-  const ppr = card.pprProjection;
+  const ppr = card.pprProjection && card.pprProjection.stale !== true ? card.pprProjection : null;
   const pprNote = ppr ? `Yr1 PPR ${esc(ppr.floor)}–${esc(ppr.ceiling)} med ${esc(ppr.median)}` : '';
 
   return `
@@ -268,7 +267,7 @@ function renderPlayerHeader(card, sideLabel) {
         <div class="compare-player-panel-grade">
           <div class="compare-grade">${esc(grade)}</div>
           <div class="meta">Class ${esc(rank)}${posRank}</div>
-          ${hasPostDraft ? `<div class="meta">Post ${esc(card.postDraftAdjustedGrade.toFixed(1))} Δ ${esc((card.postDraftDelta >= 0 ? '+' : '') + card.postDraftDelta.toFixed(1))}</div>` : ''}
+          <div class="meta">Post-draft grade not yet published</div>
           ${renderEvidenceTierBadge(card)}
         </div>
       </div>

--- a/components/rookies/RookieCompareView.js
+++ b/components/rookies/RookieCompareView.js
@@ -1,5 +1,6 @@
 import { compareRookies } from '/lib/rookies/compareRookies.js';
 import { getCollegeLogoUrl, getNflTeamLogoUrl } from '/lib/rookies/teamLogos.js';
+import { athleticMetricLabel } from '/lib/rookies/athleticLabel.js';
 
 function esc(str) {
   return String(str ?? '')
@@ -73,7 +74,8 @@ function renderSharedRadar(leftCard, rightCard) {
 
   const leftName  = leftCard.identity.name;
   const rightName = rightCard.identity.name;
-  const athLabel  = leftCard.athleticSource === 'SPORQ' ? 'ATH (SPORQ)' : leftCard.athleticSource === 'COMBINE_FALLBACK' ? 'ATH (partial)' : 'RAS';
+  const leftAthLabel  = athleticMetricLabel(leftCard.athleticSource);
+  const rightAthLabel = athleticMetricLabel(rightCard.athleticSource);
 
   function val(v) { return v == null ? '—' : Number(v).toFixed(1); }
 
@@ -82,7 +84,7 @@ function renderSharedRadar(leftCard, rightCard) {
       <div class="compare-radar-side compare-radar-side-left">
         <div class="compare-radar-metric">
           <span class="compare-radar-val compare-radar-val-left">${val(leftCard.athleticScore)}</span>
-          <span class="compare-radar-label">${esc(athLabel)}</span>
+          <span class="compare-radar-label">${esc(leftAthLabel)}</span>
         </div>
         <div class="compare-radar-metric">
           <span class="compare-radar-val compare-radar-val-left">${val(leftCard.productionScore)}</span>
@@ -107,7 +109,7 @@ function renderSharedRadar(leftCard, rightCard) {
       </div>
       <div class="compare-radar-side compare-radar-side-right">
         <div class="compare-radar-metric">
-          <span class="compare-radar-label">${esc(athLabel)}</span>
+          <span class="compare-radar-label">${esc(rightAthLabel)}</span>
           <span class="compare-radar-val compare-radar-val-right">${val(rightCard.athleticScore)}</span>
         </div>
         <div class="compare-radar-metric">

--- a/components/rookies/renderPprProjection.js
+++ b/components/rookies/renderPprProjection.js
@@ -9,8 +9,17 @@ function esc(str) {
 const DATA_GAP_FALLBACK_NOTE = 'Projection has limited supporting data; treat floor/median/ceiling as low-confidence.';
 const INSUFFICIENT_EVIDENCE_CAVEAT = 'Projection is grade-band based; limited evidence context applies.';
 
+const STALE_PROJECTION_NOTE = 'Year 1 PPR projection withheld: it was generated from a superseded Rookie Alpha snapshot and has not been regenerated against the current promoted Alpha.';
+
 export function renderPprProjection(ppr, card) {
   if (!ppr) return '';
+  if (ppr.stale === true) {
+    return `
+    <div class="ppr-card-section">
+      <div class="section-title">Year 1 PPR Projection</div>
+      <div class="ppr-stale-warning" role="alert">⚠️ ${esc(STALE_PROJECTION_NOTE)}</div>
+    </div>`;
+  }
   const bandClass = { Elite: 'ppr-band-elite', Starter: 'ppr-band-starter', Contributor: 'ppr-band-contributor', Lottery: 'ppr-band-lottery' }[ppr.band] ?? 'ppr-band-lottery';
   const floor = Number(ppr.floor);
   const median = Number(ppr.median);

--- a/components/rookies/rookieCardStyles.css
+++ b/components/rookies/rookieCardStyles.css
@@ -387,6 +387,29 @@ body {
   line-height: 1.4;
   font-style: italic;
 }
+.ppr-stale-warning {
+  margin-top: 8px;
+  padding: 8px 10px;
+  border-radius: 8px;
+  font-size: 12px;
+  line-height: 1.4;
+  color: #f1c27d;
+  background: rgba(217, 119, 87, 0.12);
+  border: 1px solid rgba(217, 119, 87, 0.5);
+}
+
+/* ─── Official NFL outcome (governed transition profile) ─────────────────── */
+.official-outcome-facts {
+  margin-top: 6px;
+  font-size: 15px;
+  font-weight: 700;
+}
+.official-outcome-provenance {
+  margin-top: 6px;
+  font-size: 11px;
+  line-height: 1.4;
+}
+.official-outcome-provenance a { color: var(--accent, #6aa9ff); }
 
 /* ─── PPR projection (board) ─────────────────────────────────────────────── */
 .board-ppr { line-height: 1.3; }

--- a/lib/rookies/athleticLabel.js
+++ b/lib/rookies/athleticLabel.js
@@ -1,0 +1,33 @@
+// Single source of truth for athletic-source display labels across every rookie
+// surface (card, board, compare). Keeping the mapping here prevents the surfaces
+// from drifting — e.g. one treating RAS_PARTIAL as a full RAS while another
+// labels it a partial composite.
+
+/** @returns {'sporq'|'partial'|'ras'} */
+export function athleticSourceCategory(source) {
+  if (source === 'SPORQ') return 'sporq';
+  if (source === 'COMBINE_FALLBACK' || source === 'RAS_PARTIAL') return 'partial';
+  return 'ras';
+}
+
+/** Full metric label (card + compare radar). */
+export function athleticMetricLabel(source) {
+  const category = athleticSourceCategory(source);
+  return category === 'sporq' ? 'ATH (SPORQ)' : category === 'partial' ? 'ATH (partial)' : 'RAS';
+}
+
+/** Compact chip label (board). */
+export function athleticChipLabel(source) {
+  const category = athleticSourceCategory(source);
+  return category === 'sporq' ? 'SPORQ' : category === 'partial' ? 'ATH*' : 'RAS';
+}
+
+/** Chip tooltip (board). */
+export function athleticChipTitle(source) {
+  const category = athleticSourceCategory(source);
+  return category === 'sporq'
+    ? 'Athletic score (SPORQ composite)'
+    : category === 'partial'
+      ? 'Athletic score (partial composite)'
+      : 'Relative Athletic Score';
+}

--- a/lib/rookies/buildRookieBoardRows.js
+++ b/lib/rookies/buildRookieBoardRows.js
@@ -12,7 +12,8 @@ function summarizeProfile(card) {
 export function buildRookieBoardRows(cards) {
   return cards.map((card) => {
     const rookieGrade = card.summary.rookieGrade;
-    const tier = deriveRookieTier(card.postDraftAdjustedGrade ?? rookieGrade);
+    // Tier from the frozen pre-draft Alpha; no client-invented post-draft grade.
+    const tier = deriveRookieTier(rookieGrade);
 
     return {
       slug: card.slug,
@@ -24,11 +25,7 @@ export function buildRookieBoardRows(cards) {
       rookieGrade,
       preDraftGrade: card.preDraftGrade ?? rookieGrade ?? null,
       preDraftRank: card.preDraftRank ?? card.summary.classRank ?? null,
-      postDraftAdjustedGrade: card.postDraftAdjustedGrade ?? null,
-      postDraftDelta: card.postDraftDelta ?? null,
-      postDraftTag: card.postDraftTag ?? null,
-      landingSpotNote: card.landingSpotNote ?? null,
-      opportunityNote: card.opportunityNote ?? null,
+      postDraftStatus: card.postDraftStatus ?? 'not_yet_published',
       classRank: card.summary.classRank,
       tier,
       profileSummary: summarizeProfile(card),
@@ -56,7 +53,7 @@ export function buildRookieBoardRows(cards) {
 
 export function sortRookieBoard(rows, sort = 'grade') {
   const copy = [...rows];
-  const boardGrade = (row) => row.postDraftAdjustedGrade ?? row.rookieGrade ?? Number.NEGATIVE_INFINITY;
+  const boardGrade = (row) => row.rookieGrade ?? Number.NEGATIVE_INFINITY;
 
   if (sort === 'rank') {
     return copy.sort((a, b) => (a.classRank ?? Number.MAX_SAFE_INTEGER) - (b.classRank ?? Number.MAX_SAFE_INTEGER));

--- a/lib/rookies/getRookieCardData.js
+++ b/lib/rookies/getRookieCardData.js
@@ -4,6 +4,7 @@ import {
   getRookieSeasons,
   rookieAlphaExportPath,
   rookieDisplaySupplementPaths,
+  rookieTransitionProfilePath,
 } from './rookieDataContract.js';
 
 let rookieCardsPromise = null;
@@ -25,13 +26,15 @@ async function loadSeasonCards(season) {
   if (!alphaExport || !Array.isArray(alphaExport.players)) return [];
 
   const supplementPaths = rookieDisplaySupplementPaths(season);
+  const transitionProfilePath = rookieTransitionProfilePath(season);
   const loadOrSkip = (path) => path ? loadJson(path).catch(() => []) : Promise.resolve([]);
-  const [statsRows, pprRows, dynastyRows, trendRows, draftResultRows] = await Promise.all([
+  const [statsRows, pprRows, dynastyRows, trendRows, draftResultRows, transitionProfile] = await Promise.all([
     loadOrSkip(supplementPaths.playerStats),
     loadOrSkip(supplementPaths.pprProjections),
     loadOrSkip(supplementPaths.dynastyAdp),
     loadOrSkip(supplementPaths.yoyTrends),
     loadOrSkip(supplementPaths.draftResults),
+    transitionProfilePath ? loadJson(transitionProfilePath).catch(() => null) : Promise.resolve(null),
   ]);
 
   const statsById = keyByPlayerId(statsRows);
@@ -39,6 +42,12 @@ async function loadSeasonCards(season) {
   const dynastyById = keyByPlayerId(dynastyRows);
   const trendById = keyByPlayerId(trendRows);
   const draftResultsById = keyDraftResultsByPlayerId(Array.isArray(draftResultRows) ? draftResultRows : []);
+  const transitionProfileRows = Array.isArray(transitionProfile?.rows) ? transitionProfile.rows : [];
+  const transitionProfileById = keyByPlayerId(transitionProfileRows);
+  // Frozen pre-draft baseline provenance, disclosed on the card so the Alpha
+  // reads as a dated snapshot rather than a live rating.
+  const alphaModel = alphaExport.model ?? null;
+  const alphaGeneratedAt = alphaExport.generated_at ?? null;
 
   return alphaExport.players.map((alphaPlayer, idx) => {
     const playerId = String(alphaPlayer.player_id ?? '').toLowerCase();
@@ -59,6 +68,9 @@ async function loadSeasonCards(season) {
       dynastyRow: dynastyById.get(playerId),
       trendRow: trendById.get(playerId),
       draftResultRow: draftResultsById.get(playerId) ?? null,
+      transitionProfileRow: transitionProfileById.get(playerId) ?? null,
+      alphaModel,
+      alphaGeneratedAt,
       rank: alphaPlayer.rookie_alpha_rank ?? idx + 1,
     });
   });

--- a/lib/rookies/getRookieCardData.js
+++ b/lib/rookies/getRookieCardData.js
@@ -55,6 +55,7 @@ async function loadSeasonCards(season) {
     : (transitionProfileValid ? 'loaded' : 'load_failed');
   const transitionProfileRows = transitionProfileValid ? transitionProfile.rows : [];
   const transitionProfileById = keyByPlayerId(transitionProfileRows);
+  const transitionProfileVersion = transitionProfileValid ? transitionProfile.schema_version : null;
   // Frozen pre-draft baseline provenance, disclosed on the card so the Alpha
   // reads as a dated snapshot rather than a live rating.
   const alphaModel = alphaExport.model ?? null;
@@ -81,6 +82,7 @@ async function loadSeasonCards(season) {
       draftResultRow: draftResultsById.get(playerId) ?? null,
       transitionProfileRow: transitionProfileById.get(playerId) ?? null,
       transitionProfileStatus,
+      transitionProfileVersion,
       alphaModel,
       alphaGeneratedAt,
       rank: alphaPlayer.rookie_alpha_rank ?? idx + 1,

--- a/lib/rookies/getRookieCardData.js
+++ b/lib/rookies/getRookieCardData.js
@@ -44,6 +44,13 @@ async function loadSeasonCards(season) {
   const draftResultsById = keyDraftResultsByPlayerId(Array.isArray(draftResultRows) ? draftResultRows : []);
   const transitionProfileRows = Array.isArray(transitionProfile?.rows) ? transitionProfile.rows : [];
   const transitionProfileById = keyByPlayerId(transitionProfileRows);
+  // Distinguish "no governed artifact by design" (pre-2026 classes) from an
+  // artifact that was expected but failed to load. On load failure we fail
+  // closed rather than silently substituting the ungoverned draft-results
+  // supplement for governed official facts.
+  const transitionProfileStatus = transitionProfilePath == null
+    ? 'not_expected'
+    : (transitionProfile && Array.isArray(transitionProfile.rows) ? 'loaded' : 'load_failed');
   // Frozen pre-draft baseline provenance, disclosed on the card so the Alpha
   // reads as a dated snapshot rather than a live rating.
   const alphaModel = alphaExport.model ?? null;
@@ -69,6 +76,7 @@ async function loadSeasonCards(season) {
       trendRow: trendById.get(playerId),
       draftResultRow: draftResultsById.get(playerId) ?? null,
       transitionProfileRow: transitionProfileById.get(playerId) ?? null,
+      transitionProfileStatus,
       alphaModel,
       alphaGeneratedAt,
       rank: alphaPlayer.rookie_alpha_rank ?? idx + 1,

--- a/lib/rookies/getRookieCardData.js
+++ b/lib/rookies/getRookieCardData.js
@@ -5,6 +5,7 @@ import {
   rookieAlphaExportPath,
   rookieDisplaySupplementPaths,
   rookieTransitionProfilePath,
+  isValidTransitionProfileEnvelope,
 } from './rookieDataContract.js';
 
 let rookieCardsPromise = null;
@@ -42,15 +43,18 @@ async function loadSeasonCards(season) {
   const dynastyById = keyByPlayerId(dynastyRows);
   const trendById = keyByPlayerId(trendRows);
   const draftResultsById = keyDraftResultsByPlayerId(Array.isArray(draftResultRows) ? draftResultRows : []);
-  const transitionProfileRows = Array.isArray(transitionProfile?.rows) ? transitionProfile.rows : [];
-  const transitionProfileById = keyByPlayerId(transitionProfileRows);
   // Distinguish "no governed artifact by design" (pre-2026 classes) from an
-  // artifact that was expected but failed to load. On load failure we fail
-  // closed rather than silently substituting the ungoverned draft-results
-  // supplement for governed official facts.
+  // artifact that was expected but failed to load or is malformed. Validate the
+  // envelope (schema family, season, rows) before treating it as loaded; on
+  // failure we fail closed rather than silently substituting the ungoverned
+  // draft-results supplement for governed official facts.
+  const transitionProfileValid = transitionProfilePath != null
+    && isValidTransitionProfileEnvelope(transitionProfile, season);
   const transitionProfileStatus = transitionProfilePath == null
     ? 'not_expected'
-    : (transitionProfile && Array.isArray(transitionProfile.rows) ? 'loaded' : 'load_failed');
+    : (transitionProfileValid ? 'loaded' : 'load_failed');
+  const transitionProfileRows = transitionProfileValid ? transitionProfile.rows : [];
+  const transitionProfileById = keyByPlayerId(transitionProfileRows);
   // Frozen pre-draft baseline provenance, disclosed on the card so the Alpha
   // reads as a dated snapshot rather than a live rating.
   const alphaModel = alphaExport.model ?? null;

--- a/lib/rookies/mapRookieToCard.js
+++ b/lib/rookies/mapRookieToCard.js
@@ -37,8 +37,11 @@ function readOfficialOutcome(transitionProfileRow) {
   // unverified provenance must not cross this fail-closed boundary.
   // (last_verified_at is not universal in the promoted artifact, so not required.)
   if (value.source_status !== 'external_verified') return null;
+  // Strict membership: the field must be present as explicit null or
+  // 'source_verified'. An omitted (undefined) status fails closed rather than
+  // being treated as an allowed explicit null.
   const upstream = value.upstream_provenance_status;
-  if (!(upstream == null || upstream === 'source_verified')) return null;
+  if (!(upstream === null || upstream === 'source_verified')) return null;
   if (!provenance || typeof provenance !== 'object') return null;
   if (provenance.source_type !== 'official_draft_result') return null;
   if (!nonEmpty(provenance.source_name) || !nonEmpty(provenance.source_url) || !nonEmpty(provenance.confidence_band)) return null;

--- a/lib/rookies/mapRookieToCard.js
+++ b/lib/rookies/mapRookieToCard.js
@@ -90,7 +90,7 @@ function toTitleLabel(tag) {
 }
 
 /** @returns {RookieCardData} */
-export function mapRookieToCard({ alphaPlayer, statsRow, pprRow, dynastyRow, trendRow, draftResultRow, transitionProfileRow, alphaModel, alphaGeneratedAt, rank }) {
+export function mapRookieToCard({ alphaPlayer, statsRow, pprRow, dynastyRow, trendRow, draftResultRow, transitionProfileRow, transitionProfileStatus, alphaModel, alphaGeneratedAt, rank }) {
   const identity = normalizeRookieIdentity({ alphaPlayer });
   const weight = null;
   const height = null;
@@ -212,21 +212,43 @@ export function mapRookieToCard({ alphaPlayer, statsRow, pprRow, dynastyRow, tre
   ].filter(Boolean);
 
   const nflContextTeam = alphaPlayer?.context?.nfl_team ?? null;
-  const officialOutcome = readOfficialOutcome(transitionProfileRow);
+
+  // Fail closed when the governed transition profile was expected but did not
+  // load: do not substitute the ungoverned draft-results supplement for
+  // official facts. Report the outcome as unavailable instead. A player simply
+  // absent from a loaded profile still falls back (documented behavior).
+  const governedLoadFailed = transitionProfileStatus === 'load_failed';
+  const officialOutcome = governedLoadFailed
+    ? {
+        status: 'unavailable',
+        reason: 'governed_source_load_failed',
+        nflTeam: null,
+        draftRound: null,
+        overallPick: null,
+        isUdfa: false,
+        sourceStatus: null,
+        provenance: null,
+      }
+    : readOfficialOutcome(transitionProfileRow);
+  const officialGoverned = officialOutcome != null && officialOutcome.status !== 'unavailable';
 
   // Official NFL identity/draft facts: prefer the governed transition profile
   // (carries provenance); fall back to the client draft-results supplement for
   // classes without a transition profile. No score is derived here — the
   // pre-draft Alpha stays frozen and no post-draft grade is computed.
-  const officialTeam = officialOutcome?.nflTeam ?? draftResultRow?.nfl_team ?? nflContextTeam;
-  const officialRound = officialOutcome?.draftRound
-    ?? (Number.isFinite(draftResultRow?.draft_round) ? draftResultRow.draft_round : null);
-  const officialPick = officialOutcome?.overallPick
-    ?? (Number.isFinite(draftResultRow?.overall_pick) ? draftResultRow.overall_pick : null);
-  const officialIsUdfa = officialOutcome?.isUdfa ?? (draftResultRow?.is_udfa === true);
+  const officialTeam = governedLoadFailed
+    ? null
+    : (officialOutcome?.nflTeam ?? draftResultRow?.nfl_team ?? nflContextTeam);
+  const officialRound = governedLoadFailed
+    ? null
+    : (officialOutcome?.draftRound ?? (Number.isFinite(draftResultRow?.draft_round) ? draftResultRow.draft_round : null));
+  const officialPick = governedLoadFailed
+    ? null
+    : (officialOutcome?.overallPick ?? (Number.isFinite(draftResultRow?.overall_pick) ? draftResultRow.overall_pick : null));
+  const officialIsUdfa = governedLoadFailed ? false : (officialOutcome?.isUdfa ?? (draftResultRow?.is_udfa === true));
   const hasDraftOutcome = Boolean(
-    officialOutcome
-    || (draftResultRow && (
+    officialGoverned
+    || (!governedLoadFailed && draftResultRow && (
       draftResultRow.is_udfa === true
       || Number.isFinite(draftResultRow.draft_round)
       || Number.isFinite(draftResultRow.overall_pick)
@@ -308,7 +330,9 @@ export function mapRookieToCard({ alphaPlayer, statsRow, pprRow, dynastyRow, tre
       draftCapitalTier: draftResultRow?.draft_capital_tier ?? null,
       isUdfa: officialIsUdfa,
       hasDraftOutcome,
-      provenanceSource: officialOutcome ? 'transition_profile' : (draftResultRow ? 'draft_results_supplement' : null),
+      provenanceSource: governedLoadFailed
+        ? null
+        : (officialGoverned ? 'transition_profile' : (draftResultRow ? 'draft_results_supplement' : null)),
     },
     // Governed official NFL outcome with per-field provenance (transition
     // profile). Null for classes without a transition profile artifact.

--- a/lib/rookies/mapRookieToCard.js
+++ b/lib/rookies/mapRookieToCard.js
@@ -14,28 +14,52 @@ import { athleticMetricLabel } from './athleticLabel.js';
 // 1-decimal Alpha copy, so anything within half a tenth is the same snapshot.
 const PPR_ALPHA_MATCH_TOLERANCE = 0.05;
 
+// Parse and validate a governed official outcome. Returns null (→ the caller
+// fails closed as unavailable) when the outcome is absent OR violates the
+// documented invariants, so malformed/inconsistent governed data is never shown
+// as authoritative.
 function readOfficialOutcome(transitionProfileRow) {
   const outcome = transitionProfileRow?.official_postdraft_outcome ?? null;
   if (!outcome || typeof outcome !== 'object') return null;
   const value = outcome.value ?? null;
   if (!value || typeof value !== 'object') return null;
   const provenance = outcome.provenance ?? null;
+
+  const status = value.status;
+  const isUdfa = value.is_udfa === true;
+  const team = typeof value.nfl_team === 'string' && value.nfl_team.trim() ? value.nfl_team : null;
+  const round = Number.isFinite(value.draft_round) ? value.draft_round : null;
+  const pick = Number.isFinite(value.overall_pick) ? value.overall_pick : null;
+
+  // Provenance must identify a source.
+  const hasProvenanceSource = provenance && typeof provenance === 'object'
+    && ((typeof provenance.source_name === 'string' && provenance.source_name.trim())
+      || (typeof provenance.source_url === 'string' && provenance.source_url.trim()));
+  if (!hasProvenanceSource) return null;
+
+  // Status-specific invariants.
+  if (status === 'drafted') {
+    if (isUdfa || round == null || pick == null || !team) return null;
+  } else if (status === 'udfa_signed') {
+    if (!isUdfa || round != null || pick != null) return null;
+  } else {
+    return null; // unrecognized status
+  }
+
   return {
-    status: value.status ?? null,
-    nflTeam: typeof value.nfl_team === 'string' ? value.nfl_team : null,
-    draftRound: Number.isFinite(value.draft_round) ? value.draft_round : null,
-    overallPick: Number.isFinite(value.overall_pick) ? value.overall_pick : null,
-    isUdfa: value.is_udfa === true,
+    status,
+    nflTeam: team,
+    draftRound: round,
+    overallPick: pick,
+    isUdfa,
     sourceStatus: value.source_status ?? null,
-    provenance: provenance
-      ? {
-          sourceName: provenance.source_name ?? null,
-          sourceUrl: provenance.source_url ?? null,
-          confidence: Number.isFinite(provenance.confidence) ? provenance.confidence : null,
-          confidenceBand: provenance.confidence_band ?? null,
-          lastVerifiedAt: provenance.last_verified_at ?? null,
-        }
-      : null,
+    provenance: {
+      sourceName: provenance.source_name ?? null,
+      sourceUrl: provenance.source_url ?? null,
+      confidence: Number.isFinite(provenance.confidence) ? provenance.confidence : null,
+      confidenceBand: provenance.confidence_band ?? null,
+      lastVerifiedAt: provenance.last_verified_at ?? null,
+    },
   };
 }
 

--- a/lib/rookies/mapRookieToCard.js
+++ b/lib/rookies/mapRookieToCard.js
@@ -7,7 +7,36 @@
 
 import { deriveRookieProfileSummary } from './deriveRookieProfileSummary.js';
 import { normalizeRookieIdentity } from './normalizeRookieIdentity.js';
-import { applyPostDraftAdjustments } from './postDraftAdjustments.js';
+
+// Rounding tolerance for reconciling the Alpha snapshot embedded in a PPR
+// projection row against the current promoted Alpha. The PPR export carries a
+// 1-decimal Alpha copy, so anything within half a tenth is the same snapshot.
+const PPR_ALPHA_MATCH_TOLERANCE = 0.05;
+
+function readOfficialOutcome(transitionProfileRow) {
+  const outcome = transitionProfileRow?.official_postdraft_outcome ?? null;
+  if (!outcome || typeof outcome !== 'object') return null;
+  const value = outcome.value ?? null;
+  if (!value || typeof value !== 'object') return null;
+  const provenance = outcome.provenance ?? null;
+  return {
+    status: value.status ?? null,
+    nflTeam: typeof value.nfl_team === 'string' ? value.nfl_team : null,
+    draftRound: Number.isFinite(value.draft_round) ? value.draft_round : null,
+    overallPick: Number.isFinite(value.overall_pick) ? value.overall_pick : null,
+    isUdfa: value.is_udfa === true,
+    sourceStatus: value.source_status ?? null,
+    provenance: provenance
+      ? {
+          sourceName: provenance.source_name ?? null,
+          sourceUrl: provenance.source_url ?? null,
+          confidence: Number.isFinite(provenance.confidence) ? provenance.confidence : null,
+          confidenceBand: provenance.confidence_band ?? null,
+          lastVerifiedAt: provenance.last_verified_at ?? null,
+        }
+      : null,
+  };
+}
 
 const METRIC_METADATA = {
   RAS: { family: 'athletic', direction: 'higher', source: 'combine+alpha' },
@@ -61,7 +90,7 @@ function toTitleLabel(tag) {
 }
 
 /** @returns {RookieCardData} */
-export function mapRookieToCard({ alphaPlayer, statsRow, pprRow, dynastyRow, trendRow, draftResultRow, rank }) {
+export function mapRookieToCard({ alphaPlayer, statsRow, pprRow, dynastyRow, trendRow, draftResultRow, transitionProfileRow, alphaModel, alphaGeneratedAt, rank }) {
   const identity = normalizeRookieIdentity({ alphaPlayer });
   const weight = null;
   const height = null;
@@ -96,17 +125,40 @@ export function mapRookieToCard({ alphaPlayer, statsRow, pprRow, dynastyRow, tre
   const evidenceSummary = typeof alphaPlayer?.evidence?.evidence_summary === 'string'
     ? alphaPlayer.evidence.evidence_summary
     : null;
-  const pprProjection = pprRow
-    ? {
-        floor: pprRow.ppr_floor,
-        median: pprRow.ppr_median,
-        ceiling: pprRow.ppr_ceiling,
-        band: pprRow.projection_band,
-        projectionMethod: pprRow.projection_method ?? null,
-        dataGapFlag: pprRow.data_gap_flag === true,
-        dataGapNote: pprRow.data_gap_note ?? null,
-      }
-    : null;
+  // Fail-closed reconciliation: the PPR export embeds a copy of the Alpha it was
+  // built from. If that snapshot no longer matches the current promoted Alpha,
+  // the projection is stale and its numbers are withheld rather than shown as
+  // current. Matching projections render normally.
+  const pprAlphaEmbedded = Number.isFinite(pprRow?.rookie_alpha_0_100) ? pprRow.rookie_alpha_0_100 : null;
+  const pprAlphaMatches = pprRow != null
+    && pprAlphaEmbedded != null
+    && rookieGrade != null
+    && Math.abs(pprAlphaEmbedded - rookieGrade) <= PPR_ALPHA_MATCH_TOLERANCE;
+  const pprProjection = !pprRow
+    ? null
+    : pprAlphaMatches
+      ? {
+          floor: pprRow.ppr_floor,
+          median: pprRow.ppr_median,
+          ceiling: pprRow.ppr_ceiling,
+          band: pprRow.projection_band,
+          projectionMethod: pprRow.projection_method ?? null,
+          dataGapFlag: pprRow.data_gap_flag === true,
+          dataGapNote: pprRow.data_gap_note ?? null,
+          stale: false,
+        }
+      : {
+          stale: true,
+          embeddedAlpha: pprAlphaEmbedded,
+          currentAlpha: rookieGrade,
+          floor: null,
+          median: null,
+          ceiling: null,
+          band: null,
+          projectionMethod: pprRow.projection_method ?? null,
+          dataGapFlag: pprRow.data_gap_flag === true,
+          dataGapNote: pprRow.data_gap_note ?? null,
+        };
 
   const dynastyAdp = dynastyRow?.dynasty_adp_0_100 ?? null;
   const dynastyDelta = (rookieGrade != null && dynastyAdp != null)
@@ -123,7 +175,13 @@ export function mapRookieToCard({ alphaPlayer, statsRow, pprRow, dynastyRow, tre
   const volume2024 = trendRow?.volume_2024 ?? null;
   const volume2025 = trendRow?.volume_2025 ?? null;
 
-  const athLabel = athleticSource === 'SPORQ' ? 'ATH (SPORQ)' : athleticSource === 'COMBINE_FALLBACK' ? 'ATH (partial)' : 'RAS';
+  // RAS_PARTIAL and COMBINE_FALLBACK are partial athletic-testing composites
+  // (a subset of combine events, no SPORQ supplement) — never a full RAS.
+  const athLabel = athleticSource === 'SPORQ'
+    ? 'ATH (SPORQ)'
+    : (athleticSource === 'COMBINE_FALLBACK' || athleticSource === 'RAS_PARTIAL')
+      ? 'ATH (partial)'
+      : 'RAS';
   const metrics = [
     { label: athLabel, value: athleticScore, display: athleticScore != null ? athleticScore.toFixed(1) : 'N/A', percent: athleticScore },
     { label: 'Production Score', value: production, display: production != null ? production.toFixed(1) : 'N/A', percent: production },
@@ -153,21 +211,39 @@ export function mapRookieToCard({ alphaPlayer, statsRow, pprRow, dynastyRow, tre
     ...evidenceTags.slice(0, 2).map(toTitleLabel),
   ].filter(Boolean);
 
-  const nflTeam = alphaPlayer?.context?.nfl_team ?? null;
+  const nflContextTeam = alphaPlayer?.context?.nfl_team ?? null;
+  const officialOutcome = readOfficialOutcome(transitionProfileRow);
+
+  // Official NFL identity/draft facts: prefer the governed transition profile
+  // (carries provenance); fall back to the client draft-results supplement for
+  // classes without a transition profile. No score is derived here — the
+  // pre-draft Alpha stays frozen and no post-draft grade is computed.
+  const officialTeam = officialOutcome?.nflTeam ?? draftResultRow?.nfl_team ?? nflContextTeam;
+  const officialRound = officialOutcome?.draftRound
+    ?? (Number.isFinite(draftResultRow?.draft_round) ? draftResultRow.draft_round : null);
+  const officialPick = officialOutcome?.overallPick
+    ?? (Number.isFinite(draftResultRow?.overall_pick) ? draftResultRow.overall_pick : null);
+  const officialIsUdfa = officialOutcome?.isUdfa ?? (draftResultRow?.is_udfa === true);
   const hasDraftOutcome = Boolean(
-    draftResultRow
-    && (
+    officialOutcome
+    || (draftResultRow && (
       draftResultRow.is_udfa === true
       || Number.isFinite(draftResultRow.draft_round)
       || Number.isFinite(draftResultRow.overall_pick)
       || typeof draftResultRow.nfl_team === 'string'
-    )
+    ))
   );
-  const postDraft = applyPostDraftAdjustments({
-    preDraftGrade: rookieGrade,
-    draftResult: draftResultRow,
-    hasDraftOutcome,
-  });
+
+  // Frozen, dated pre-draft baseline. The Alpha is disclosed as a snapshot with
+  // its model version and generation date, not as a live player rating. No
+  // post-draft numeric grade is published on the card.
+  const preDraftBaseline = {
+    grade: rookieGrade,
+    modelVersion: alphaModel?.model_version ?? null,
+    stage: alphaModel?.stage ?? 'pre-draft',
+    generatedAt: alphaGeneratedAt ?? null,
+  };
+  const postDraftStatus = 'not_yet_published';
 
   return {
     playerId: alphaPlayer.player_id,
@@ -176,7 +252,7 @@ export function mapRookieToCard({ alphaPlayer, statsRow, pprRow, dynastyRow, tre
       ...identity,
       height,
       weight,
-      nflTeam,
+      nflTeam: officialTeam,
     },
     summary: {
       rookieGrade,
@@ -189,9 +265,7 @@ export function mapRookieToCard({ alphaPlayer, statsRow, pprRow, dynastyRow, tre
     },
     comps: { high: null, low: null },
     scores: [
-      { label: 'Pre-Draft Grade', value: postDraft.preDraftGrade },
-      { label: 'Post-Draft Adjusted Grade', value: postDraft.postDraftAdjustedGrade },
-      { label: 'Delta', value: postDraft.postDraftDelta },
+      { label: 'Pre-Draft Grade', value: rookieGrade },
       { label: 'ATH', value: athleticScore },
       { label: 'Production', value: production },
       { label: 'Draft Capital', value: draftCapital },
@@ -227,26 +301,25 @@ export function mapRookieToCard({ alphaPlayer, statsRow, pprRow, dynastyRow, tre
     volume2025,
     pprProjection,
     draft: {
-      nflTeam: draftResultRow?.nfl_team ?? nflTeam,
-      draftRound: draftResultRow?.draft_round ?? null,
-      overallPick: draftResultRow?.overall_pick ?? null,
+      nflTeam: officialTeam,
+      draftRound: officialRound,
+      overallPick: officialPick,
       draftDay: draftResultRow?.draft_day ?? null,
       draftCapitalTier: draftResultRow?.draft_capital_tier ?? null,
-      isUdfa: draftResultRow?.is_udfa ?? false,
+      isUdfa: officialIsUdfa,
       hasDraftOutcome,
+      provenanceSource: officialOutcome ? 'transition_profile' : (draftResultRow ? 'draft_results_supplement' : null),
     },
-    postDraft: {
-      ...postDraft,
-      preDraftRank: rank,
-      adjustmentComponents: postDraft.components,
-    },
-    preDraftGrade: postDraft.preDraftGrade,
+    // Governed official NFL outcome with per-field provenance (transition
+    // profile). Null for classes without a transition profile artifact.
+    officialOutcome,
+    preDraftBaseline,
+    preDraftGrade: rookieGrade,
     preDraftRank: rank,
-    postDraftAdjustedGrade: postDraft.postDraftAdjustedGrade,
-    postDraftDelta: postDraft.postDraftDelta,
-    postDraftTag: postDraft.postDraftTag,
-    landingSpotNote: postDraft.landingSpotNote,
-    opportunityNote: postDraft.opportunityNote,
+    // No competing post-draft grade is computed in browser code; the card
+    // discloses status only.
+    postDraftGrade: null,
+    postDraftStatus,
     contextSignals: {
       evidenceTags,
       contextFlags,

--- a/lib/rookies/mapRookieToCard.js
+++ b/lib/rookies/mapRookieToCard.js
@@ -7,6 +7,7 @@
 
 import { deriveRookieProfileSummary } from './deriveRookieProfileSummary.js';
 import { normalizeRookieIdentity } from './normalizeRookieIdentity.js';
+import { athleticMetricLabel } from './athleticLabel.js';
 
 // Rounding tolerance for reconciling the Alpha snapshot embedded in a PPR
 // projection row against the current promoted Alpha. The PPR export carries a
@@ -175,13 +176,7 @@ export function mapRookieToCard({ alphaPlayer, statsRow, pprRow, dynastyRow, tre
   const volume2024 = trendRow?.volume_2024 ?? null;
   const volume2025 = trendRow?.volume_2025 ?? null;
 
-  // RAS_PARTIAL and COMBINE_FALLBACK are partial athletic-testing composites
-  // (a subset of combine events, no SPORQ supplement) — never a full RAS.
-  const athLabel = athleticSource === 'SPORQ'
-    ? 'ATH (SPORQ)'
-    : (athleticSource === 'COMBINE_FALLBACK' || athleticSource === 'RAS_PARTIAL')
-      ? 'ATH (partial)'
-      : 'RAS';
+  const athLabel = athleticMetricLabel(athleticSource);
   const metrics = [
     { label: athLabel, value: athleticScore, display: athleticScore != null ? athleticScore.toFixed(1) : 'N/A', percent: athleticScore },
     { label: 'Production Score', value: production, display: production != null ? production.toFixed(1) : 'N/A', percent: production },
@@ -213,42 +208,57 @@ export function mapRookieToCard({ alphaPlayer, statsRow, pprRow, dynastyRow, tre
 
   const nflContextTeam = alphaPlayer?.context?.nfl_team ?? null;
 
-  // Fail closed when the governed transition profile was expected but did not
-  // load: do not substitute the ungoverned draft-results supplement for
-  // official facts. Report the outcome as unavailable instead. A player simply
-  // absent from a loaded profile still falls back (documented behavior).
-  const governedLoadFailed = transitionProfileStatus === 'load_failed';
-  const officialOutcome = governedLoadFailed
-    ? {
-        status: 'unavailable',
-        reason: 'governed_source_load_failed',
-        nflTeam: null,
-        draftRound: null,
-        overallPick: null,
-        isUdfa: false,
-        sourceStatus: null,
-        provenance: null,
-      }
-    : readOfficialOutcome(transitionProfileRow);
+  // Official NFL identity/draft facts. The governed transition profile is the
+  // sole authority whenever it is expected (loaded or load_failed). The
+  // ungoverned draft-results supplement may fill display facts ONLY for classes
+  // that have no governed profile by design (not_expected, i.e. pre-2026).
+  //
+  //   loaded      → use the player's governed outcome; a missing or malformed
+  //                 outcome fails closed as unavailable (no supplement fallback).
+  //   load_failed → unavailable (governed source did not load).
+  //   not_expected→ fall back to the draft-results supplement (no governed layer).
+  //
+  // No score is derived here — the pre-draft Alpha stays frozen and no
+  // post-draft grade is computed.
+  const governedExpected = transitionProfileStatus === 'loaded' || transitionProfileStatus === 'load_failed';
+  const allowSupplementFallback = !governedExpected; // only 'not_expected'
+  const unavailable = (reason) => ({
+    status: 'unavailable',
+    reason,
+    nflTeam: null,
+    draftRound: null,
+    overallPick: null,
+    isUdfa: false,
+    sourceStatus: null,
+    provenance: null,
+  });
+
+  let officialOutcome;
+  if (transitionProfileStatus === 'load_failed') {
+    officialOutcome = unavailable('governed_source_load_failed');
+  } else if (transitionProfileStatus === 'loaded') {
+    officialOutcome = readOfficialOutcome(transitionProfileRow) ?? unavailable('governed_outcome_missing');
+  } else {
+    // not_expected (or unspecified): no governed layer.
+    officialOutcome = null;
+  }
   const officialGoverned = officialOutcome != null && officialOutcome.status !== 'unavailable';
 
-  // Official NFL identity/draft facts: prefer the governed transition profile
-  // (carries provenance); fall back to the client draft-results supplement for
-  // classes without a transition profile. No score is derived here — the
-  // pre-draft Alpha stays frozen and no post-draft grade is computed.
-  const officialTeam = governedLoadFailed
-    ? null
-    : (officialOutcome?.nflTeam ?? draftResultRow?.nfl_team ?? nflContextTeam);
-  const officialRound = governedLoadFailed
-    ? null
-    : (officialOutcome?.draftRound ?? (Number.isFinite(draftResultRow?.draft_round) ? draftResultRow.draft_round : null));
-  const officialPick = governedLoadFailed
-    ? null
-    : (officialOutcome?.overallPick ?? (Number.isFinite(draftResultRow?.overall_pick) ? draftResultRow.overall_pick : null));
-  const officialIsUdfa = governedLoadFailed ? false : (officialOutcome?.isUdfa ?? (draftResultRow?.is_udfa === true));
+  const officialTeam = officialGoverned
+    ? officialOutcome.nflTeam
+    : (allowSupplementFallback ? (draftResultRow?.nfl_team ?? nflContextTeam) : null);
+  const officialRound = officialGoverned
+    ? officialOutcome.draftRound
+    : (allowSupplementFallback && Number.isFinite(draftResultRow?.draft_round) ? draftResultRow.draft_round : null);
+  const officialPick = officialGoverned
+    ? officialOutcome.overallPick
+    : (allowSupplementFallback && Number.isFinite(draftResultRow?.overall_pick) ? draftResultRow.overall_pick : null);
+  const officialIsUdfa = officialGoverned
+    ? officialOutcome.isUdfa
+    : (allowSupplementFallback ? (draftResultRow?.is_udfa === true) : false);
   const hasDraftOutcome = Boolean(
     officialGoverned
-    || (!governedLoadFailed && draftResultRow && (
+    || (allowSupplementFallback && draftResultRow && (
       draftResultRow.is_udfa === true
       || Number.isFinite(draftResultRow.draft_round)
       || Number.isFinite(draftResultRow.overall_pick)
@@ -330,9 +340,9 @@ export function mapRookieToCard({ alphaPlayer, statsRow, pprRow, dynastyRow, tre
       draftCapitalTier: draftResultRow?.draft_capital_tier ?? null,
       isUdfa: officialIsUdfa,
       hasDraftOutcome,
-      provenanceSource: governedLoadFailed
-        ? null
-        : (officialGoverned ? 'transition_profile' : (draftResultRow ? 'draft_results_supplement' : null)),
+      provenanceSource: officialGoverned
+        ? 'transition_profile'
+        : (allowSupplementFallback && draftResultRow ? 'draft_results_supplement' : null),
     },
     // Governed official NFL outcome with per-field provenance (transition
     // profile). Null for classes without a transition profile artifact.

--- a/lib/rookies/mapRookieToCard.js
+++ b/lib/rookies/mapRookieToCard.js
@@ -28,20 +28,29 @@ function readOfficialOutcome(transitionProfileRow) {
   const status = value.status;
   const isUdfa = value.is_udfa === true;
   const team = typeof value.nfl_team === 'string' && value.nfl_team.trim() ? value.nfl_team : null;
-  const round = Number.isFinite(value.draft_round) ? value.draft_round : null;
-  const pick = Number.isFinite(value.overall_pick) ? value.overall_pick : null;
+  const round = value.draft_round;
+  const pick = value.overall_pick;
+  const nonEmpty = (s) => typeof s === 'string' && s.trim().length > 0;
 
-  // Provenance must identify a source.
-  const hasProvenanceSource = provenance && typeof provenance === 'object'
-    && ((typeof provenance.source_name === 'string' && provenance.source_name.trim())
-      || (typeof provenance.source_url === 'string' && provenance.source_url.trim()));
-  if (!hasProvenanceSource) return null;
+  // Promoted-artifact provenance invariants: externally verified, with a named,
+  // linked source and a confidence band. (last_verified_at is not universal in
+  // the promoted artifact, so it is not required.)
+  if (value.source_status !== 'external_verified') return null;
+  if (!provenance || typeof provenance !== 'object') return null;
+  if (!nonEmpty(provenance.source_name) || !nonEmpty(provenance.source_url) || !nonEmpty(provenance.confidence_band)) return null;
 
-  // Status-specific invariants.
+  // Team identity is required for any recognized outcome.
+  if (!team) return null;
+
+  // Status-specific consistency: drafted needs integer round/pick and is_udfa=false;
+  // udfa_signed needs is_udfa=true and no round/pick. Anything else fails closed.
   if (status === 'drafted') {
-    if (isUdfa || round == null || pick == null || !team) return null;
+    if (isUdfa) return null;
+    if (!Number.isInteger(round) || round < 1) return null;
+    if (!Number.isInteger(pick) || pick < 1) return null;
   } else if (status === 'udfa_signed') {
-    if (!isUdfa || round != null || pick != null) return null;
+    if (!isUdfa) return null;
+    if (round != null || pick != null) return null;
   } else {
     return null; // unrecognized status
   }
@@ -49,10 +58,10 @@ function readOfficialOutcome(transitionProfileRow) {
   return {
     status,
     nflTeam: team,
-    draftRound: round,
-    overallPick: pick,
+    draftRound: round ?? null,
+    overallPick: pick ?? null,
     isUdfa,
-    sourceStatus: value.source_status ?? null,
+    sourceStatus: value.source_status,
     provenance: {
       sourceName: provenance.source_name ?? null,
       sourceUrl: provenance.source_url ?? null,
@@ -232,20 +241,20 @@ export function mapRookieToCard({ alphaPlayer, statsRow, pprRow, dynastyRow, tre
 
   const nflContextTeam = alphaPlayer?.context?.nfl_team ?? null;
 
-  // Official NFL identity/draft facts. The governed transition profile is the
-  // sole authority whenever it is expected (loaded or load_failed). The
-  // ungoverned draft-results supplement may fill display facts ONLY for classes
-  // that have no governed profile by design (not_expected, i.e. pre-2026).
+  // Official NFL identity/draft facts. The ungoverned draft-results supplement
+  // may fill display facts ONLY for classes that have no governed profile by
+  // design (transitionProfileStatus === 'not_expected', i.e. pre-2026). Every
+  // other status — including unknown/missing/unrecognized — fails closed.
   //
-  //   loaded      → use the player's governed outcome; a missing or malformed
-  //                 outcome fails closed as unavailable (no supplement fallback).
-  //   load_failed → unavailable (governed source did not load).
-  //   not_expected→ fall back to the draft-results supplement (no governed layer).
+  //   not_expected → fall back to the draft-results supplement (no governed layer).
+  //   loaded       → use the player's governed outcome; a missing or malformed
+  //                  outcome fails closed as unavailable (no supplement fallback).
+  //   load_failed  → unavailable (governed source did not load).
+  //   anything else→ unavailable (unknown status; no fallback).
   //
   // No score is derived here — the pre-draft Alpha stays frozen and no
   // post-draft grade is computed.
-  const governedExpected = transitionProfileStatus === 'loaded' || transitionProfileStatus === 'load_failed';
-  const allowSupplementFallback = !governedExpected; // only 'not_expected'
+  const allowSupplementFallback = transitionProfileStatus === 'not_expected';
   const unavailable = (reason) => ({
     status: 'unavailable',
     reason,
@@ -258,13 +267,15 @@ export function mapRookieToCard({ alphaPlayer, statsRow, pprRow, dynastyRow, tre
   });
 
   let officialOutcome;
-  if (transitionProfileStatus === 'load_failed') {
-    officialOutcome = unavailable('governed_source_load_failed');
+  if (transitionProfileStatus === 'not_expected') {
+    officialOutcome = null; // no governed layer; supplement may fill display facts
   } else if (transitionProfileStatus === 'loaded') {
     officialOutcome = readOfficialOutcome(transitionProfileRow) ?? unavailable('governed_outcome_missing');
+  } else if (transitionProfileStatus === 'load_failed') {
+    officialOutcome = unavailable('governed_source_load_failed');
   } else {
-    // not_expected (or unspecified): no governed layer.
-    officialOutcome = null;
+    // Unknown, missing, or unrecognized status — fail closed, no fallback.
+    officialOutcome = unavailable('governed_status_unknown');
   }
   const officialGoverned = officialOutcome != null && officialOutcome.status !== 'unavailable';
 

--- a/lib/rookies/mapRookieToCard.js
+++ b/lib/rookies/mapRookieToCard.js
@@ -32,24 +32,28 @@ function readOfficialOutcome(transitionProfileRow) {
   const pick = value.overall_pick;
   const nonEmpty = (s) => typeof s === 'string' && s.trim().length > 0;
 
-  // Promoted-artifact provenance invariants: externally verified, with a named,
-  // linked source and a confidence band. (last_verified_at is not universal in
-  // the promoted artifact, so it is not required.)
+  // Promoted-artifact provenance invariants: an externally verified, official
+  // draft result with a named, linked source and a confidence band. Proxy or
+  // unverified provenance must not cross this fail-closed boundary.
+  // (last_verified_at is not universal in the promoted artifact, so not required.)
   if (value.source_status !== 'external_verified') return null;
+  const upstream = value.upstream_provenance_status;
+  if (!(upstream == null || upstream === 'source_verified')) return null;
   if (!provenance || typeof provenance !== 'object') return null;
+  if (provenance.source_type !== 'official_draft_result') return null;
   if (!nonEmpty(provenance.source_name) || !nonEmpty(provenance.source_url) || !nonEmpty(provenance.confidence_band)) return null;
 
   // Team identity is required for any recognized outcome.
   if (!team) return null;
 
-  // Status-specific consistency: drafted needs integer round/pick and is_udfa=false;
-  // udfa_signed needs is_udfa=true and no round/pick. Anything else fails closed.
+  // Status-specific consistency: is_udfa must be an explicit boolean agreeing
+  // with the status; drafted needs integer round/pick; udfa_signed needs none.
   if (status === 'drafted') {
-    if (isUdfa) return null;
+    if (value.is_udfa !== false) return null;
     if (!Number.isInteger(round) || round < 1) return null;
     if (!Number.isInteger(pick) || pick < 1) return null;
   } else if (status === 'udfa_signed') {
-    if (!isUdfa) return null;
+    if (value.is_udfa !== true) return null;
     if (round != null || pick != null) return null;
   } else {
     return null; // unrecognized status
@@ -124,7 +128,7 @@ function toTitleLabel(tag) {
 }
 
 /** @returns {RookieCardData} */
-export function mapRookieToCard({ alphaPlayer, statsRow, pprRow, dynastyRow, trendRow, draftResultRow, transitionProfileRow, transitionProfileStatus, alphaModel, alphaGeneratedAt, rank }) {
+export function mapRookieToCard({ alphaPlayer, statsRow, pprRow, dynastyRow, trendRow, draftResultRow, transitionProfileRow, transitionProfileStatus, transitionProfileVersion, alphaModel, alphaGeneratedAt, rank }) {
   const identity = normalizeRookieIdentity({ alphaPlayer });
   const weight = null;
   const height = null;
@@ -270,7 +274,10 @@ export function mapRookieToCard({ alphaPlayer, statsRow, pprRow, dynastyRow, tre
   if (transitionProfileStatus === 'not_expected') {
     officialOutcome = null; // no governed layer; supplement may fill display facts
   } else if (transitionProfileStatus === 'loaded') {
-    officialOutcome = readOfficialOutcome(transitionProfileRow) ?? unavailable('governed_outcome_missing');
+    const parsed = readOfficialOutcome(transitionProfileRow);
+    officialOutcome = parsed
+      ? { ...parsed, schemaVersion: transitionProfileVersion ?? null }
+      : unavailable('governed_outcome_missing');
   } else if (transitionProfileStatus === 'load_failed') {
     officialOutcome = unavailable('governed_source_load_failed');
   } else {

--- a/lib/rookies/rookieDataContract.js
+++ b/lib/rookies/rookieDataContract.js
@@ -11,8 +11,21 @@ const SUPPLEMENT_FIRST_SEASON = {
   draftResults:    2022,
 };
 
+// Season (inclusive) from which the governed rookie transition profile exists.
+// The artifact is the authoritative source for official NFL identity/draft
+// facts and their provenance; it does not exist for pre-2026 classes.
+const TRANSITION_PROFILE_FIRST_SEASON = 2026;
+
 export function rookieAlphaExportPath(season) {
   return `/exports/promoted/rookie-alpha/${season}_rookie_alpha_predraft_v0.json`;
+}
+
+// Returns the governed transition-profile path for seasons that have one,
+// or null when the artifact is known not to exist. Callers should skip null.
+export function rookieTransitionProfilePath(season) {
+  return season >= TRANSITION_PROFILE_FIRST_SEASON
+    ? `/exports/promoted/rookie-transition-profile/${season}_rookie_transition_profile_v0.json`
+    : null;
 }
 
 // Returns a path string for supplements that exist for the given season,

--- a/lib/rookies/rookieDataContract.js
+++ b/lib/rookies/rookieDataContract.js
@@ -28,6 +28,24 @@ export function rookieTransitionProfilePath(season) {
     : null;
 }
 
+// Expected transition-profile schema family. A minor-version bump within the
+// v0.2 line stays compatible; a different major/minor is treated as unloadable
+// so the card fails closed rather than reading an unexpected envelope shape.
+export const TRANSITION_PROFILE_SCHEMA_PREFIX = 'rookie-transition-profile-v0.2';
+
+// Minimal envelope validation before an artifact is treated as loaded:
+// expected schema family, matching season, and a rows array.
+export function isValidTransitionProfileEnvelope(envelope, season) {
+  return Boolean(
+    envelope
+    && typeof envelope === 'object'
+    && typeof envelope.schema_version === 'string'
+    && envelope.schema_version.startsWith(TRANSITION_PROFILE_SCHEMA_PREFIX)
+    && envelope.season === season
+    && Array.isArray(envelope.rows),
+  );
+}
+
 // Returns a path string for supplements that exist for the given season,
 // or null when the file is known not to exist. Callers should skip null paths.
 export function rookieDisplaySupplementPaths(season) {

--- a/lib/rookies/rookieDataContract.js
+++ b/lib/rookies/rookieDataContract.js
@@ -28,10 +28,11 @@ export function rookieTransitionProfilePath(season) {
     : null;
 }
 
-// Expected transition-profile schema family. A minor-version bump within the
-// v0.2 line stays compatible; a different major/minor is treated as unloadable
-// so the card fails closed rather than reading an unexpected envelope shape.
-export const TRANSITION_PROFILE_SCHEMA_PREFIX = 'rookie-transition-profile-v0.2';
+// Expected transition-profile schema family: the exact v0.2 line with any patch
+// component (v0.2.<n>). Bounded at the version delimiter so look-alikes such as
+// v0.20.0 or a malformed v0.2-invalid suffix do not match and instead fail
+// closed rather than being read as an unexpected envelope shape.
+export const TRANSITION_PROFILE_SCHEMA_PATTERN = /^rookie-transition-profile-v0\.2\.\d+$/;
 
 // Minimal envelope validation before an artifact is treated as loaded:
 // expected schema family, matching season, and a rows array.
@@ -40,7 +41,7 @@ export function isValidTransitionProfileEnvelope(envelope, season) {
     envelope
     && typeof envelope === 'object'
     && typeof envelope.schema_version === 'string'
-    && envelope.schema_version.startsWith(TRANSITION_PROFILE_SCHEMA_PREFIX)
+    && TRANSITION_PROFILE_SCHEMA_PATTERN.test(envelope.schema_version)
     && envelope.season === season
     && Array.isArray(envelope.rows),
   );

--- a/tests/card-disclosure-wiring.test.mjs
+++ b/tests/card-disclosure-wiring.test.mjs
@@ -270,42 +270,73 @@ test('transition envelope validation: accepts a well-formed envelope, rejects dr
 });
 
 // Governed-outcome invariant validation (mapper fails closed on malformed data).
-function loadedCardWithOutcome(outcomeValue, provenance = { source_name: 'NBC Sports', source_url: 'https://example.test' }) {
+const VALID_OUTCOME = Object.freeze({ status: 'drafted', nfl_team: 'NYJ', draft_round: 1, overall_pick: 30, is_udfa: false, source_status: 'external_verified' });
+const VALID_PROVENANCE = Object.freeze({ source_name: 'NBC Sports', source_url: 'https://example.test/tracker', confidence_band: 'HIGH' });
+function cardForOutcome(value, provenance = VALID_PROVENANCE) {
   return mapRookieToCard({
     alphaPlayer: { player_id: 'wr-inv', position: 'WR', scores: { rookie_alpha_0_100: 55.0 } },
-    transitionProfileRow: { player_id: 'wr-inv', official_postdraft_outcome: { value: outcomeValue, provenance } },
+    transitionProfileRow: { player_id: 'wr-inv', official_postdraft_outcome: { value, provenance } },
     transitionProfileStatus: 'loaded',
     rank: 14,
   });
 }
+const outcomeStatus = (value, provenance) => cardForOutcome(value, provenance).officialOutcome.status;
 
 test('governed outcome: a well-formed drafted outcome is authoritative', () => {
-  const card = loadedCardWithOutcome({ status: 'drafted', nfl_team: 'NYJ', draft_round: 1, overall_pick: 30, is_udfa: false });
+  const card = cardForOutcome(VALID_OUTCOME);
   assert.equal(card.officialOutcome.status, 'drafted');
   assert.equal(card.identity.nflTeam, 'NYJ');
   assert.equal(card.draft.provenanceSource, 'transition_profile');
 });
 
 test('governed outcome: a well-formed udfa_signed outcome is authoritative', () => {
-  const card = loadedCardWithOutcome({ status: 'udfa_signed', nfl_team: 'PHI', draft_round: null, overall_pick: null, is_udfa: true });
+  const card = cardForOutcome({ status: 'udfa_signed', nfl_team: 'PHI', draft_round: null, overall_pick: null, is_udfa: true, source_status: 'external_verified' });
   assert.equal(card.officialOutcome.status, 'udfa_signed');
   assert.equal(card.officialOutcome.isUdfa, true);
   assert.equal(card.draft.overallPick, null);
 });
 
-test('governed outcome: invalid contents fail closed as unavailable', () => {
-  // drafted without round/pick
-  assert.equal(loadedCardWithOutcome({ status: 'drafted', nfl_team: 'NYJ', is_udfa: false }).officialOutcome.status, 'unavailable');
-  // drafted but flagged UDFA (inconsistent)
-  assert.equal(loadedCardWithOutcome({ status: 'drafted', nfl_team: 'NYJ', draft_round: 1, overall_pick: 30, is_udfa: true }).officialOutcome.status, 'unavailable');
-  // udfa_signed carrying a pick (inconsistent)
-  assert.equal(loadedCardWithOutcome({ status: 'udfa_signed', nfl_team: 'PHI', draft_round: 1, overall_pick: 30, is_udfa: true }).officialOutcome.status, 'unavailable');
-  // unrecognized status
-  assert.equal(loadedCardWithOutcome({ status: 'mystery', nfl_team: 'NYJ', draft_round: 1, overall_pick: 30, is_udfa: false }).officialOutcome.status, 'unavailable');
-  // empty value object
-  assert.equal(loadedCardWithOutcome({}).officialOutcome.status, 'unavailable');
-  // missing provenance source
-  assert.equal(loadedCardWithOutcome({ status: 'drafted', nfl_team: 'NYJ', draft_round: 1, overall_pick: 30, is_udfa: false }, {}).officialOutcome.status, 'unavailable');
+test('governed outcome: each invalid condition fails closed as unavailable', () => {
+  // source_status not externally verified
+  assert.equal(outcomeStatus({ ...VALID_OUTCOME, source_status: 'seeded' }), 'unavailable');
+  assert.equal(outcomeStatus({ ...VALID_OUTCOME, source_status: undefined }), 'unavailable');
+  // drafted flagged UDFA (inconsistent)
+  assert.equal(outcomeStatus({ ...VALID_OUTCOME, is_udfa: true }), 'unavailable');
+  // drafted missing round / pick
+  assert.equal(outcomeStatus({ ...VALID_OUTCOME, draft_round: null }), 'unavailable');
+  assert.equal(outcomeStatus({ ...VALID_OUTCOME, overall_pick: null }), 'unavailable');
+  // non-integer round / pick
+  assert.equal(outcomeStatus({ ...VALID_OUTCOME, draft_round: 1.5 }), 'unavailable');
+  assert.equal(outcomeStatus({ ...VALID_OUTCOME, overall_pick: '30' }), 'unavailable');
+  // missing team identity
+  assert.equal(outcomeStatus({ ...VALID_OUTCOME, nfl_team: '' }), 'unavailable');
+  // udfa_signed carrying round/pick (inconsistent)
+  assert.equal(outcomeStatus({ status: 'udfa_signed', nfl_team: 'PHI', draft_round: 1, overall_pick: 30, is_udfa: true, source_status: 'external_verified' }), 'unavailable');
+  // udfa_signed not flagged UDFA
+  assert.equal(outcomeStatus({ status: 'udfa_signed', nfl_team: 'PHI', draft_round: null, overall_pick: null, is_udfa: false, source_status: 'external_verified' }), 'unavailable');
+  // unrecognized status / empty value
+  assert.equal(outcomeStatus({ ...VALID_OUTCOME, status: 'mystery' }), 'unavailable');
+  assert.equal(outcomeStatus({}), 'unavailable');
+  // provenance: missing url, missing name, missing confidence band
+  assert.equal(outcomeStatus(VALID_OUTCOME, { source_name: 'NBC', confidence_band: 'HIGH' }), 'unavailable');
+  assert.equal(outcomeStatus(VALID_OUTCOME, { source_url: 'https://x.test', confidence_band: 'HIGH' }), 'unavailable');
+  assert.equal(outcomeStatus(VALID_OUTCOME, { source_name: 'NBC', source_url: 'https://x.test' }), 'unavailable');
+  assert.equal(outcomeStatus(VALID_OUTCOME, null), 'unavailable');
+});
+
+test('unknown transition status fails closed with no supplement fallback', () => {
+  const card = mapRookieToCard({
+    alphaPlayer: { player_id: 'wr-unknown-status', position: 'WR', scores: { rookie_alpha_0_100: 55.0 } },
+    // Draft-results supplement present, but the status is not 'not_expected'.
+    draftResultRow: { player_id: 'wr-unknown-status', nfl_team: 'NYJ', draft_round: 1, overall_pick: 30, is_udfa: false },
+    transitionProfileStatus: 'some_unexpected_value',
+    rank: 14,
+  });
+  assert.equal(card.officialOutcome.status, 'unavailable');
+  assert.equal(card.officialOutcome.reason, 'governed_status_unknown');
+  assert.equal(card.identity.nflTeam, null);
+  assert.equal(card.draft.hasDraftOutcome, false);
+  assert.equal(card.draft.provenanceSource, null);
 });
 
 test('athletic label helper: RAS_PARTIAL is a partial composite on every surface', () => {

--- a/tests/card-disclosure-wiring.test.mjs
+++ b/tests/card-disclosure-wiring.test.mjs
@@ -196,6 +196,22 @@ test('historical fallback: draft-results supplement supplies facts when no trans
   assert.equal(card.draft.provenanceSource, 'draft_results_supplement');
 });
 
+test('governed load failure fails closed: no ungoverned substitution of official facts', () => {
+  const card = mapRookieToCard({
+    alphaPlayer: { player_id: 'wr-2026-loadfail', position: 'WR', scores: { rookie_alpha_0_100: 58.0 } },
+    // Draft-results supplement is present, but the governed profile failed to load.
+    draftResultRow: { player_id: 'wr-2026-loadfail', nfl_team: 'NYJ', draft_round: 1, overall_pick: 30, is_udfa: false },
+    transitionProfileRow: null,
+    transitionProfileStatus: 'load_failed',
+    rank: 14,
+  });
+  assert.equal(card.officialOutcome.status, 'unavailable');
+  assert.equal(card.officialOutcome.reason, 'governed_source_load_failed');
+  assert.equal(card.identity.nflTeam, null); // ungoverned team not shown as official
+  assert.equal(card.draft.hasDraftOutcome, false);
+  assert.equal(card.draft.provenanceSource, null);
+});
+
 test('COMBINE_FALLBACK athletic source is also labeled as a partial composite', () => {
   const card = mapRookieToCard({
     alphaPlayer: { player_id: 'wr-combine', position: 'WR', scores: { athletic_score_0_100: 55, athletic_source: 'COMBINE_FALLBACK' } },

--- a/tests/card-disclosure-wiring.test.mjs
+++ b/tests/card-disclosure-wiring.test.mjs
@@ -1,11 +1,15 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
 
 import { mapRookieToCard } from '../lib/rookies/mapRookieToCard.js';
 import { renderPprProjection } from '../components/rookies/renderPprProjection.js';
 import { normalizeRookieIdentity } from '../lib/rookies/normalizeRookieIdentity.js';
 
 const baseAlphaPlayer = { player_id: 'wr-data-gap-test', position: 'WR' };
+
+const readJson = (relPath) => JSON.parse(fs.readFileSync(new URL(relPath, import.meta.url), 'utf8'));
+const keyById = (rows) => new Map((rows ?? []).map((r) => [String(r.player_id ?? '').toLowerCase(), r]));
 
 test('mapRookieToCard preserves PPR data_gap_flag / data_gap_note metadata', () => {
   const card = mapRookieToCard({
@@ -80,4 +84,121 @@ test('renderPprProjection adds the grade-band caveat for insufficient-evidence c
 test('WR role label is a neutral receiver profile, not perimeter-specific', () => {
   const identity = normalizeRookieIdentity({ alphaPlayer: { position: 'WR' } });
   assert.equal(identity.roleLabel, 'Receiver profile');
+});
+
+// ── Phase 1A: card temporal-integrity contract ──────────────────────────────
+
+// Golden trace: Omar Cooper Jr. built from the real promoted 2026 artifacts.
+function buildOmarCard() {
+  const predraft = readJson('../exports/promoted/rookie-alpha/2026_rookie_alpha_predraft_v0.json');
+  const ppr = keyById(readJson('../data/processed/2026_ppr_projections.json'));
+  const draft = keyById(readJson('../data/processed/2026_draft_results.json'));
+  const transition = keyById(readJson('../exports/promoted/rookie-transition-profile/2026_rookie_transition_profile_v0.json').rows);
+  const omar = predraft.players.find((p) => p.player_id === 'wr-omar-cooper-jr');
+  assert.ok(omar, 'Omar must exist in the promoted pre-draft export');
+  return mapRookieToCard({
+    alphaPlayer: omar,
+    pprRow: ppr.get('wr-omar-cooper-jr'),
+    draftResultRow: draft.get('wr-omar-cooper-jr') ?? null,
+    transitionProfileRow: transition.get('wr-omar-cooper-jr') ?? null,
+    alphaModel: predraft.model,
+    alphaGeneratedAt: predraft.generated_at,
+    rank: omar.rookie_alpha_rank,
+  });
+}
+
+test('golden Omar: NFL identity + draft facts come from the governed transition profile', () => {
+  const card = buildOmarCard();
+  assert.equal(card.identity.nflTeam, 'NYJ');
+  assert.equal(card.officialOutcome.status, 'drafted');
+  assert.equal(card.officialOutcome.nflTeam, 'NYJ');
+  assert.equal(card.officialOutcome.draftRound, 1);
+  assert.equal(card.officialOutcome.overallPick, 30);
+  assert.equal(card.draft.provenanceSource, 'transition_profile');
+  assert.ok(card.officialOutcome.provenance.sourceUrl, 'official outcome must carry a source URL');
+});
+
+test('golden Omar: pre-draft Alpha is a frozen, dated baseline with model version', () => {
+  const card = buildOmarCard();
+  assert.equal(card.preDraftBaseline.grade, card.summary.rookieGrade);
+  assert.match(card.preDraftBaseline.modelVersion, /^rookie-alpha-predraft-v/);
+  assert.match(card.preDraftBaseline.generatedAt, /^\d{4}-\d{2}-\d{2}/);
+});
+
+test('golden Omar: no competing post-draft grade is computed', () => {
+  const card = buildOmarCard();
+  assert.equal(card.postDraftGrade, null);
+  assert.equal(card.postDraftStatus, 'not_yet_published');
+  const scoreLabels = card.scores.map((s) => s.label);
+  assert.ok(!scoreLabels.includes('Post-Draft Adjusted Grade'));
+  assert.ok(!scoreLabels.includes('Delta'));
+  // The governed post-draft artifact value (65.2) must not leak onto the card.
+  assert.ok(!card.scores.some((s) => s.value === 65.2));
+});
+
+test('golden Omar: partial athletic evidence is labeled as a partial composite', () => {
+  const card = buildOmarCard();
+  assert.equal(card.athleticSource, 'RAS_PARTIAL');
+  assert.equal(card.metrics[0].label, 'ATH (partial)');
+});
+
+test('golden Omar: Alpha-derived PPR fails closed when the embedded snapshot is stale', () => {
+  const card = buildOmarCard();
+  assert.equal(card.pprProjection.stale, true);
+  assert.equal(card.pprProjection.median, null);
+  const html = renderPprProjection(card.pprProjection, card);
+  assert.match(html, /ppr-stale-warning/);
+  assert.doesNotMatch(html, /ppr-range-median-marker/);
+});
+
+test('PPR renders normally when the embedded Alpha matches the current promoted Alpha', () => {
+  const card = mapRookieToCard({
+    alphaPlayer: { player_id: 'wr-match', position: 'WR', scores: { rookie_alpha_0_100: 58.0712 } },
+    pprRow: { player_id: 'wr-match', rookie_alpha_0_100: 58.1, ppr_floor: 70, ppr_median: 115, ppr_ceiling: 165, projection_band: 'Starter' },
+  });
+  assert.equal(card.pprProjection.stale, false);
+  assert.equal(card.pprProjection.median, 115);
+  assert.match(renderPprProjection(card.pprProjection, card), /ppr-range-median-marker/);
+});
+
+test('PPR fails closed when the projection row carries no embedded Alpha to verify', () => {
+  const card = mapRookieToCard({
+    alphaPlayer: { player_id: 'wr-noalpha', position: 'WR', scores: { rookie_alpha_0_100: 58.0712 } },
+    pprRow: { player_id: 'wr-noalpha', ppr_floor: 70, ppr_median: 115, ppr_ceiling: 165, projection_band: 'Starter' },
+  });
+  assert.equal(card.pprProjection.stale, true);
+  assert.equal(card.pprProjection.median, null);
+});
+
+test('missing data: no transition profile and no draft result → no official outcome, no invented grade', () => {
+  const card = mapRookieToCard({
+    alphaPlayer: { player_id: 'wr-undrafted-unknown', position: 'WR', scores: { rookie_alpha_0_100: 42.0 } },
+    rank: 40,
+  });
+  assert.equal(card.officialOutcome, null);
+  assert.equal(card.identity.nflTeam, null);
+  assert.equal(card.draft.hasDraftOutcome, false);
+  assert.equal(card.draft.provenanceSource, null);
+  assert.equal(card.postDraftGrade, null);
+  assert.equal(card.postDraftStatus, 'not_yet_published');
+});
+
+test('historical fallback: draft-results supplement supplies facts when no transition profile exists', () => {
+  const card = mapRookieToCard({
+    alphaPlayer: { player_id: 'wr-2024-vet', position: 'WR', scores: { rookie_alpha_0_100: 60.0 } },
+    draftResultRow: { player_id: 'wr-2024-vet', nfl_team: 'KC', draft_round: 2, overall_pick: 50, is_udfa: false },
+    rank: 10,
+  });
+  assert.equal(card.officialOutcome, null); // no governed provenance for pre-2026 classes
+  assert.equal(card.identity.nflTeam, 'KC');
+  assert.equal(card.draft.draftRound, 2);
+  assert.equal(card.draft.overallPick, 50);
+  assert.equal(card.draft.provenanceSource, 'draft_results_supplement');
+});
+
+test('COMBINE_FALLBACK athletic source is also labeled as a partial composite', () => {
+  const card = mapRookieToCard({
+    alphaPlayer: { player_id: 'wr-combine', position: 'WR', scores: { athletic_score_0_100: 55, athletic_source: 'COMBINE_FALLBACK' } },
+  });
+  assert.equal(card.metrics[0].label, 'ATH (partial)');
 });

--- a/tests/card-disclosure-wiring.test.mjs
+++ b/tests/card-disclosure-wiring.test.mjs
@@ -5,6 +5,8 @@ import fs from 'node:fs';
 import { mapRookieToCard } from '../lib/rookies/mapRookieToCard.js';
 import { renderPprProjection } from '../components/rookies/renderPprProjection.js';
 import { normalizeRookieIdentity } from '../lib/rookies/normalizeRookieIdentity.js';
+import { isValidTransitionProfileEnvelope } from '../lib/rookies/rookieDataContract.js';
+import { athleticMetricLabel, athleticChipLabel } from '../lib/rookies/athleticLabel.js';
 
 const baseAlphaPlayer = { player_id: 'wr-data-gap-test', position: 'WR' };
 
@@ -101,6 +103,7 @@ function buildOmarCard() {
     pprRow: ppr.get('wr-omar-cooper-jr'),
     draftResultRow: draft.get('wr-omar-cooper-jr') ?? null,
     transitionProfileRow: transition.get('wr-omar-cooper-jr') ?? null,
+    transitionProfileStatus: 'loaded',
     alphaModel: predraft.model,
     alphaGeneratedAt: predraft.generated_at,
     rank: omar.rookie_alpha_rank,
@@ -173,6 +176,7 @@ test('PPR fails closed when the projection row carries no embedded Alpha to veri
 test('missing data: no transition profile and no draft result → no official outcome, no invented grade', () => {
   const card = mapRookieToCard({
     alphaPlayer: { player_id: 'wr-undrafted-unknown', position: 'WR', scores: { rookie_alpha_0_100: 42.0 } },
+    transitionProfileStatus: 'not_expected',
     rank: 40,
   });
   assert.equal(card.officialOutcome, null);
@@ -183,10 +187,11 @@ test('missing data: no transition profile and no draft result → no official ou
   assert.equal(card.postDraftStatus, 'not_yet_published');
 });
 
-test('historical fallback: draft-results supplement supplies facts when no transition profile exists', () => {
+test('historical fallback: draft-results supplement supplies facts only for not_expected classes', () => {
   const card = mapRookieToCard({
     alphaPlayer: { player_id: 'wr-2024-vet', position: 'WR', scores: { rookie_alpha_0_100: 60.0 } },
     draftResultRow: { player_id: 'wr-2024-vet', nfl_team: 'KC', draft_round: 2, overall_pick: 50, is_udfa: false },
+    transitionProfileStatus: 'not_expected',
     rank: 10,
   });
   assert.equal(card.officialOutcome, null); // no governed provenance for pre-2026 classes
@@ -194,6 +199,37 @@ test('historical fallback: draft-results supplement supplies facts when no trans
   assert.equal(card.draft.draftRound, 2);
   assert.equal(card.draft.overallPick, 50);
   assert.equal(card.draft.provenanceSource, 'draft_results_supplement');
+});
+
+test('loaded profile, player row missing → fail closed as unavailable, no supplement fallback', () => {
+  const card = mapRookieToCard({
+    alphaPlayer: { player_id: 'wr-2026-norow', position: 'WR', scores: { rookie_alpha_0_100: 55.0 } },
+    // Draft-results supplement present, but the player is absent from a loaded governed profile.
+    draftResultRow: { player_id: 'wr-2026-norow', nfl_team: 'NYJ', draft_round: 1, overall_pick: 30, is_udfa: false },
+    transitionProfileRow: null,
+    transitionProfileStatus: 'loaded',
+    rank: 14,
+  });
+  assert.equal(card.officialOutcome.status, 'unavailable');
+  assert.equal(card.officialOutcome.reason, 'governed_outcome_missing');
+  assert.equal(card.identity.nflTeam, null);
+  assert.equal(card.draft.hasDraftOutcome, false);
+  assert.equal(card.draft.provenanceSource, null);
+});
+
+test('loaded profile, malformed player outcome → fail closed as unavailable', () => {
+  const card = mapRookieToCard({
+    alphaPlayer: { player_id: 'wr-2026-malformed', position: 'WR', scores: { rookie_alpha_0_100: 55.0 } },
+    draftResultRow: { player_id: 'wr-2026-malformed', nfl_team: 'NYJ', draft_round: 1, overall_pick: 30, is_udfa: false },
+    // Row exists but official_postdraft_outcome is malformed (no value object).
+    transitionProfileRow: { player_id: 'wr-2026-malformed', official_postdraft_outcome: { provenance: {} } },
+    transitionProfileStatus: 'loaded',
+    rank: 14,
+  });
+  assert.equal(card.officialOutcome.status, 'unavailable');
+  assert.equal(card.officialOutcome.reason, 'governed_outcome_missing');
+  assert.equal(card.identity.nflTeam, null);
+  assert.equal(card.draft.provenanceSource, null);
 });
 
 test('governed load failure fails closed: no ungoverned substitution of official facts', () => {
@@ -217,4 +253,24 @@ test('COMBINE_FALLBACK athletic source is also labeled as a partial composite', 
     alphaPlayer: { player_id: 'wr-combine', position: 'WR', scores: { athletic_score_0_100: 55, athletic_source: 'COMBINE_FALLBACK' } },
   });
   assert.equal(card.metrics[0].label, 'ATH (partial)');
+});
+
+test('transition envelope validation: accepts a well-formed envelope, rejects drift', () => {
+  const good = { schema_version: 'rookie-transition-profile-v0.2.0', season: 2026, rows: [] };
+  assert.equal(isValidTransitionProfileEnvelope(good, 2026), true);
+  assert.equal(isValidTransitionProfileEnvelope({ ...good, schema_version: 'rookie-transition-profile-v0.1.0' }, 2026), false);
+  assert.equal(isValidTransitionProfileEnvelope({ ...good, season: 2025 }, 2026), false);
+  assert.equal(isValidTransitionProfileEnvelope({ schema_version: 'rookie-transition-profile-v0.2.0', season: 2026 }, 2026), false);
+  assert.equal(isValidTransitionProfileEnvelope(null, 2026), false);
+});
+
+test('athletic label helper: RAS_PARTIAL is a partial composite on every surface', () => {
+  // Shared source of truth used by card, board, and compare.
+  assert.equal(athleticMetricLabel('RAS_PARTIAL'), 'ATH (partial)');
+  assert.equal(athleticMetricLabel('COMBINE_FALLBACK'), 'ATH (partial)');
+  assert.equal(athleticMetricLabel('SPORQ'), 'ATH (SPORQ)');
+  assert.equal(athleticMetricLabel('RAS'), 'RAS');
+  assert.equal(athleticChipLabel('RAS_PARTIAL'), 'ATH*'); // board chip, previously mislabeled 'RAS'
+  assert.equal(athleticChipLabel('SPORQ'), 'SPORQ');
+  assert.equal(athleticChipLabel('RAS'), 'RAS');
 });

--- a/tests/card-disclosure-wiring.test.mjs
+++ b/tests/card-disclosure-wiring.test.mjs
@@ -293,7 +293,7 @@ test('governed outcome: a well-formed drafted outcome is authoritative', () => {
 });
 
 test('governed outcome: a well-formed udfa_signed outcome is authoritative', () => {
-  const card = cardForOutcome({ status: 'udfa_signed', nfl_team: 'PHI', draft_round: null, overall_pick: null, is_udfa: true, source_status: 'external_verified' });
+  const card = cardForOutcome({ status: 'udfa_signed', nfl_team: 'PHI', draft_round: null, overall_pick: null, is_udfa: true, source_status: 'external_verified', upstream_provenance_status: null });
   assert.equal(card.officialOutcome.status, 'udfa_signed');
   assert.equal(card.officialOutcome.isUdfa, true);
   assert.equal(card.draft.overallPick, null);
@@ -324,6 +324,8 @@ test('governed outcome: each invalid condition fails closed as unavailable', () 
   // unverified / non-official provenance must not cross the boundary
   assert.equal(outcomeStatus({ ...VALID_OUTCOME, upstream_provenance_status: 'needs_verification' }), 'unavailable');
   assert.equal(outcomeStatus(VALID_OUTCOME, { ...VALID_PROVENANCE, source_type: 'market_derived_proxy' }), 'unavailable');
+  // upstream status omitted entirely (undefined) fails closed — not treated as explicit null
+  assert.equal(outcomeStatus({ ...VALID_OUTCOME, upstream_provenance_status: undefined }), 'unavailable');
   // unrecognized status / empty value
   assert.equal(outcomeStatus({ ...VALID_OUTCOME, status: 'mystery' }), 'unavailable');
   assert.equal(outcomeStatus({}), 'unavailable');

--- a/tests/card-disclosure-wiring.test.mjs
+++ b/tests/card-disclosure-wiring.test.mjs
@@ -258,10 +258,54 @@ test('COMBINE_FALLBACK athletic source is also labeled as a partial composite', 
 test('transition envelope validation: accepts a well-formed envelope, rejects drift', () => {
   const good = { schema_version: 'rookie-transition-profile-v0.2.0', season: 2026, rows: [] };
   assert.equal(isValidTransitionProfileEnvelope(good, 2026), true);
+  assert.equal(isValidTransitionProfileEnvelope({ ...good, schema_version: 'rookie-transition-profile-v0.2.7' }, 2026), true);
   assert.equal(isValidTransitionProfileEnvelope({ ...good, schema_version: 'rookie-transition-profile-v0.1.0' }, 2026), false);
   assert.equal(isValidTransitionProfileEnvelope({ ...good, season: 2025 }, 2026), false);
   assert.equal(isValidTransitionProfileEnvelope({ schema_version: 'rookie-transition-profile-v0.2.0', season: 2026 }, 2026), false);
   assert.equal(isValidTransitionProfileEnvelope(null, 2026), false);
+  // Bounded at the version delimiter — look-alike families must not match.
+  assert.equal(isValidTransitionProfileEnvelope({ ...good, schema_version: 'rookie-transition-profile-v0.20.0' }, 2026), false);
+  assert.equal(isValidTransitionProfileEnvelope({ ...good, schema_version: 'rookie-transition-profile-v0.2-invalid' }, 2026), false);
+  assert.equal(isValidTransitionProfileEnvelope({ ...good, schema_version: 'rookie-transition-profile-v0.2' }, 2026), false);
+});
+
+// Governed-outcome invariant validation (mapper fails closed on malformed data).
+function loadedCardWithOutcome(outcomeValue, provenance = { source_name: 'NBC Sports', source_url: 'https://example.test' }) {
+  return mapRookieToCard({
+    alphaPlayer: { player_id: 'wr-inv', position: 'WR', scores: { rookie_alpha_0_100: 55.0 } },
+    transitionProfileRow: { player_id: 'wr-inv', official_postdraft_outcome: { value: outcomeValue, provenance } },
+    transitionProfileStatus: 'loaded',
+    rank: 14,
+  });
+}
+
+test('governed outcome: a well-formed drafted outcome is authoritative', () => {
+  const card = loadedCardWithOutcome({ status: 'drafted', nfl_team: 'NYJ', draft_round: 1, overall_pick: 30, is_udfa: false });
+  assert.equal(card.officialOutcome.status, 'drafted');
+  assert.equal(card.identity.nflTeam, 'NYJ');
+  assert.equal(card.draft.provenanceSource, 'transition_profile');
+});
+
+test('governed outcome: a well-formed udfa_signed outcome is authoritative', () => {
+  const card = loadedCardWithOutcome({ status: 'udfa_signed', nfl_team: 'PHI', draft_round: null, overall_pick: null, is_udfa: true });
+  assert.equal(card.officialOutcome.status, 'udfa_signed');
+  assert.equal(card.officialOutcome.isUdfa, true);
+  assert.equal(card.draft.overallPick, null);
+});
+
+test('governed outcome: invalid contents fail closed as unavailable', () => {
+  // drafted without round/pick
+  assert.equal(loadedCardWithOutcome({ status: 'drafted', nfl_team: 'NYJ', is_udfa: false }).officialOutcome.status, 'unavailable');
+  // drafted but flagged UDFA (inconsistent)
+  assert.equal(loadedCardWithOutcome({ status: 'drafted', nfl_team: 'NYJ', draft_round: 1, overall_pick: 30, is_udfa: true }).officialOutcome.status, 'unavailable');
+  // udfa_signed carrying a pick (inconsistent)
+  assert.equal(loadedCardWithOutcome({ status: 'udfa_signed', nfl_team: 'PHI', draft_round: 1, overall_pick: 30, is_udfa: true }).officialOutcome.status, 'unavailable');
+  // unrecognized status
+  assert.equal(loadedCardWithOutcome({ status: 'mystery', nfl_team: 'NYJ', draft_round: 1, overall_pick: 30, is_udfa: false }).officialOutcome.status, 'unavailable');
+  // empty value object
+  assert.equal(loadedCardWithOutcome({}).officialOutcome.status, 'unavailable');
+  // missing provenance source
+  assert.equal(loadedCardWithOutcome({ status: 'drafted', nfl_team: 'NYJ', draft_round: 1, overall_pick: 30, is_udfa: false }, {}).officialOutcome.status, 'unavailable');
 });
 
 test('athletic label helper: RAS_PARTIAL is a partial composite on every surface', () => {

--- a/tests/card-disclosure-wiring.test.mjs
+++ b/tests/card-disclosure-wiring.test.mjs
@@ -95,7 +95,8 @@ function buildOmarCard() {
   const predraft = readJson('../exports/promoted/rookie-alpha/2026_rookie_alpha_predraft_v0.json');
   const ppr = keyById(readJson('../data/processed/2026_ppr_projections.json'));
   const draft = keyById(readJson('../data/processed/2026_draft_results.json'));
-  const transition = keyById(readJson('../exports/promoted/rookie-transition-profile/2026_rookie_transition_profile_v0.json').rows);
+  const transitionEnv = readJson('../exports/promoted/rookie-transition-profile/2026_rookie_transition_profile_v0.json');
+  const transition = keyById(transitionEnv.rows);
   const omar = predraft.players.find((p) => p.player_id === 'wr-omar-cooper-jr');
   assert.ok(omar, 'Omar must exist in the promoted pre-draft export');
   return mapRookieToCard({
@@ -104,6 +105,7 @@ function buildOmarCard() {
     draftResultRow: draft.get('wr-omar-cooper-jr') ?? null,
     transitionProfileRow: transition.get('wr-omar-cooper-jr') ?? null,
     transitionProfileStatus: 'loaded',
+    transitionProfileVersion: transitionEnv.schema_version,
     alphaModel: predraft.model,
     alphaGeneratedAt: predraft.generated_at,
     rank: omar.rookie_alpha_rank,
@@ -119,6 +121,7 @@ test('golden Omar: NFL identity + draft facts come from the governed transition 
   assert.equal(card.officialOutcome.overallPick, 30);
   assert.equal(card.draft.provenanceSource, 'transition_profile');
   assert.ok(card.officialOutcome.provenance.sourceUrl, 'official outcome must carry a source URL');
+  assert.equal(card.officialOutcome.schemaVersion, 'rookie-transition-profile-v0.2.0');
 });
 
 test('golden Omar: pre-draft Alpha is a frozen, dated baseline with model version', () => {
@@ -270,8 +273,8 @@ test('transition envelope validation: accepts a well-formed envelope, rejects dr
 });
 
 // Governed-outcome invariant validation (mapper fails closed on malformed data).
-const VALID_OUTCOME = Object.freeze({ status: 'drafted', nfl_team: 'NYJ', draft_round: 1, overall_pick: 30, is_udfa: false, source_status: 'external_verified' });
-const VALID_PROVENANCE = Object.freeze({ source_name: 'NBC Sports', source_url: 'https://example.test/tracker', confidence_band: 'HIGH' });
+const VALID_OUTCOME = Object.freeze({ status: 'drafted', nfl_team: 'NYJ', draft_round: 1, overall_pick: 30, is_udfa: false, source_status: 'external_verified', upstream_provenance_status: 'source_verified' });
+const VALID_PROVENANCE = Object.freeze({ source_type: 'official_draft_result', source_name: 'NBC Sports', source_url: 'https://example.test/tracker', confidence_band: 'HIGH' });
 function cardForOutcome(value, provenance = VALID_PROVENANCE) {
   return mapRookieToCard({
     alphaPlayer: { player_id: 'wr-inv', position: 'WR', scores: { rookie_alpha_0_100: 55.0 } },
@@ -314,14 +317,38 @@ test('governed outcome: each invalid condition fails closed as unavailable', () 
   assert.equal(outcomeStatus({ status: 'udfa_signed', nfl_team: 'PHI', draft_round: 1, overall_pick: 30, is_udfa: true, source_status: 'external_verified' }), 'unavailable');
   // udfa_signed not flagged UDFA
   assert.equal(outcomeStatus({ status: 'udfa_signed', nfl_team: 'PHI', draft_round: null, overall_pick: null, is_udfa: false, source_status: 'external_verified' }), 'unavailable');
+  // is_udfa must be an explicit boolean for drafted (not omitted / null / string)
+  assert.equal(outcomeStatus({ ...VALID_OUTCOME, is_udfa: undefined }), 'unavailable');
+  assert.equal(outcomeStatus({ ...VALID_OUTCOME, is_udfa: null }), 'unavailable');
+  assert.equal(outcomeStatus({ ...VALID_OUTCOME, is_udfa: 'false' }), 'unavailable');
+  // unverified / non-official provenance must not cross the boundary
+  assert.equal(outcomeStatus({ ...VALID_OUTCOME, upstream_provenance_status: 'needs_verification' }), 'unavailable');
+  assert.equal(outcomeStatus(VALID_OUTCOME, { ...VALID_PROVENANCE, source_type: 'market_derived_proxy' }), 'unavailable');
   // unrecognized status / empty value
   assert.equal(outcomeStatus({ ...VALID_OUTCOME, status: 'mystery' }), 'unavailable');
   assert.equal(outcomeStatus({}), 'unavailable');
-  // provenance: missing url, missing name, missing confidence band
-  assert.equal(outcomeStatus(VALID_OUTCOME, { source_name: 'NBC', confidence_band: 'HIGH' }), 'unavailable');
-  assert.equal(outcomeStatus(VALID_OUTCOME, { source_url: 'https://x.test', confidence_band: 'HIGH' }), 'unavailable');
-  assert.equal(outcomeStatus(VALID_OUTCOME, { source_name: 'NBC', source_url: 'https://x.test' }), 'unavailable');
+  // provenance: missing url, missing name, missing confidence band, missing source_type
+  assert.equal(outcomeStatus(VALID_OUTCOME, { ...VALID_PROVENANCE, source_url: undefined }), 'unavailable');
+  assert.equal(outcomeStatus(VALID_OUTCOME, { ...VALID_PROVENANCE, source_name: undefined }), 'unavailable');
+  assert.equal(outcomeStatus(VALID_OUTCOME, { ...VALID_PROVENANCE, confidence_band: undefined }), 'unavailable');
+  assert.equal(outcomeStatus(VALID_OUTCOME, { source_name: 'NBC', source_url: 'https://x.test', confidence_band: 'HIGH' }), 'unavailable'); // no source_type
   assert.equal(outcomeStatus(VALID_OUTCOME, null), 'unavailable');
+});
+
+test('governed outcome: a null upstream_provenance_status is accepted (udfa-signed row)', () => {
+  const card = cardForOutcome({ status: 'udfa_signed', nfl_team: 'PHI', draft_round: null, overall_pick: null, is_udfa: true, source_status: 'external_verified', upstream_provenance_status: null });
+  assert.equal(card.officialOutcome.status, 'udfa_signed');
+});
+
+test('governed outcome: the loaded schema_version is threaded onto the outcome (not hard-coded)', () => {
+  const card = mapRookieToCard({
+    alphaPlayer: { player_id: 'wr-ver', position: 'WR', scores: { rookie_alpha_0_100: 55.0 } },
+    transitionProfileRow: { player_id: 'wr-ver', official_postdraft_outcome: { value: VALID_OUTCOME, provenance: VALID_PROVENANCE } },
+    transitionProfileStatus: 'loaded',
+    transitionProfileVersion: 'rookie-transition-profile-v0.2.7',
+    rank: 14,
+  });
+  assert.equal(card.officialOutcome.schemaVersion, 'rookie-transition-profile-v0.2.7');
 });
 
 test('unknown transition status fails closed with no supplement fallback', () => {


### PR DESCRIPTION
Implements **Phase 1A** of #272 against a freshly pinned `main` (`2ef92fa`). Card-consumption layer only — no Rookie Alpha formula/weight changes, no penalty changes, no artifact regeneration, no narrative work, no stat reconciliation, no tracker/Forecast/FORGE/Devy activation.

## What changed

**Data path (`lib/rookies/`)**
- `rookieDataContract.js`: add `rookieTransitionProfilePath` (2026+ only) and `isValidTransitionProfileEnvelope` (schema-family/season/rows validation, anchored so look-alike versions fail closed).
- `getRookieCardData.js`: load the governed transition profile, validate the envelope, key by `player_id`, and thread the pre-draft model version + `generated_at` plus a per-season `transitionProfileStatus` and the loaded `schema_version` to the mapper.
- `mapRookieToCard.js`: **remove `applyPostDraftAdjustments`** — no post-draft grade is computed in browser code. Derive official NFL team/round/pick **and per-field provenance from the governed transition profile**. **Fail closed** on governance: the draft-results supplement fills facts only for `transitionProfileStatus === 'not_expected'` (pre-2026); a loaded profile with a missing/malformed outcome, a load failure, or any unknown status renders `unavailable`. `readOfficialOutcome` enforces promoted-artifact invariants (`external_verified` + `source_type: official_draft_result` + verified upstream, explicit `is_udfa` boolean, integer round/pick, required team + provenance fields). Emit a frozen `preDraftBaseline`. Label `RAS_PARTIAL`/`COMBINE_FALLBACK` as a partial athletic composite. **Fail closed** on the Alpha-derived PPR projection when its embedded Alpha snapshot no longer matches the current promoted Alpha.
- `athleticLabel.js` (new): single source of truth for athletic-source labels across card/board/compare.

**Render surfaces (`components/rookies/`)**
- `RookieCard.js`: hero shows the frozen, dated baseline and “Post-draft grade not yet published”; new **Official NFL Outcome** panel with sourced provenance and the actual loaded schema version (reason-aware unavailable copy); partial-athletic disclosure; suppress empty position-rank and Projection Comps modules.
- `renderPprProjection.js`: withhold floor/median/ceiling behind a stale-snapshot notice.
- `RookieBoardRow.js` / `buildRookieBoardRows.js` / `RookieCompareView.js`: re-tier on pre-draft Alpha, show “Post-draft grade not yet published”, withhold stale PPR, and correct `RAS_PARTIAL` labeling (compare derives each player's label independently) — the mapper is shared, so all three stay coherent.

## Golden trace — Omar Cooper Jr.
- Hero Alpha **58.1**, labeled `Frozen · rookie-alpha-predraft-v0.5.0 · generated 2026-06-14`.
- Official NFL Outcome: **NYJ · Round 1 · Pick 30**, linked NBC Sports source, HIGH confidence.
- **No** competing post-draft grade (invented 62.1 and governed 65.2 both absent).
- `RAS_PARTIAL` → **ATH (partial)** + composite caveat; empty position-rank and Projection Comps suppressed.
- PPR withheld (embedded 61.3 ≠ current 58.07).

## Review hardening (rounds 2–6, from @codex feedback)
- Withhold stale PPR in the compare side-by-side chart (not just the header note).
- Fail closed when the governed transition profile fails to load or is malformed, rather than substituting the ungoverned supplement.
- Restrict supplement fallback strictly to `not_expected`; unknown statuses fail closed.
- Enforce full governed-outcome invariants (explicit `is_udfa`, official + verified provenance) and anchor schema-family matching at the version delimiter.
- Render the actual loaded transition-profile schema version instead of a hard-coded string.
- Correct `RAS_PARTIAL` disclosure on board + compare via a shared, tested label helper.

## Tests / verification
- Golden-trace Omar + missing/optional-data + fail-closed governance + invariant-rejection + envelope-validation + schema-version cases in the canonical card-disclosure suite — **27/27 pass**; `test:runtime-smoke` green. All 48 promoted 2026 governed rows validate with 0 false rejects.
- Player/board/compare rendered in the pre-installed Chromium (card + compare confirmed this session; board via the same shared imports).

## Notes / residual risk
- `lib/rookies/postDraftAdjustments.js` is now **orphaned** (no importers). Left in place for a reviewer/Phase-2 governance decision rather than deleted.
- Not addressed here (later phases): narrative rewrite / #271 overlap (Phase 2); 69/937 vs 70/961 reconciliation and the `screen_yard_share` eligibility audit (Phase 3, model-governance-walled).
- **Deployment gate:** production remains pinned to `ef2fd83` (content-verified; Railway SHA still to be confirmed in the Railway dashboard). This PR is **not** merged or deployed — human review only. (This test-count metadata correction does not imply approval to merge or deploy.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KN4eTyFVMi6w8YFYyprVV4