### PR TITLE
fix: pin TIBER-Rookies Railway build to Node

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,0 @@
-def main():
-    print("Hello from repl-nix-workspace!")
-
-
-if __name__ == "__main__":
-    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,0 @@
-[project]
-name = "repl-nix-workspace"
-version = "0.1.0"
-description = "Add your description here"
-requires-python = ">=3.12"
-dependencies = []

--- a/railpack.json
+++ b/railpack.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://schema.railpack.com",
+  "provider": "node"
+}


### PR DESCRIPTION
## Summary

Repair Railway builder detection for the standalone TIBER-Rookies service without changing application behavior.

- remove the unused Replit placeholder `main.py`
- remove the empty placeholder `pyproject.toml`
- add `railpack.json` with an explicit Node provider

The last healthy production commit (`9b87d5d`) used the same `railway.json` start command (`npm start`) and `/health` check but did not contain the Python detection markers. Current Railway builds select Python 3.13 and then fail because `npm` is unavailable.

Failed deployment evidence: https://railway.com/project/51990b6b-a0ca-4515-97fb-a2bd9bc4c57b/service/3470a892-de3e-47f7-bdcf-8a749ec8692f?id=f2841759-c0c3-4cdb-972a-1b35872495e4#details

## Validation

- `npm run test:runtime-smoke` — 1/1 passed
- `npm run test:card-disclosure` — 6/6 passed
- deployment JSON parses successfully
- branch is exactly one commit ahead of `11acc8bd7bff15f66253b72ba617336d8aff5839`
- diff is limited to `main.py`, `pyproject.toml`, and `railpack.json`

## Release gate

Draft only. Do not merge directly to `main` yet. Production currently runs `9b87d5d`, while `main` is 81 commits ahead of that deployed SHA. Because Railway autodeploy is enabled and Wait for CI is disabled, merging would immediately attempt to release the accumulated production drift as well as this fix.

Before merge, validate this exact branch SHA in a non-production Railway environment/service, confirm Railpack selects Node and installs npm, then verify `/health`, root redirect, board, player detail, and compare routes.