### PR TITLE
Remove unsourced gunshot claim from Travis Hunter 2025 card (#271)

### DIFF
--- a/data/processed/2025_prospect_context.json
+++ b/data/processed/2025_prospect_context.json
@@ -170,10 +170,8 @@
       "elite_production",
       "two_way_player"
     ],
-    "context_flags": [
-      "severe_injury_recovery"
-    ],
-    "evidence_summary": "2024 Heisman winner (2-way; WR+CB). First true impact at 19 as Colorado freshman; recovered from gunshot injury in 2023. Dual-role usage at NFL level unlikely \u2014 evaluated purely as WR.",
+    "context_flags": [],
+    "evidence_summary": "2024 Heisman winner (2-way; WR+CB). First true impact at 19 as Colorado freshman. Dual-role usage at NFL level unlikely \u2014 evaluated purely as WR.",
     "context_source": "manual_historical_seed",
     "exceptional_metrics": []
   },

--- a/exports/promoted/rookie-alpha/2025_manifest.json
+++ b/exports/promoted/rookie-alpha/2025_manifest.json
@@ -1,8 +1,8 @@
 {
   "season": 2025,
   "model_version": "rookie-alpha-predraft-v0.5.0",
-  "generated_at": "2026-05-11T16:44:35+00:00",
-  "run_id": "rookie-alpha-2025-2026-05-11T16:44:35+00:00",
+  "generated_at": "2026-07-25T13:14:24+00:00",
+  "run_id": "rookie-alpha-2025-2026-07-25T13:14:24+00:00",
   "input_files": [
     {
       "path": "data/raw/2025_combine_results.json",
@@ -21,7 +21,7 @@
     },
     {
       "path": "data/processed/2025_prospect_context.json",
-      "sha256": "0ff1620308cfc6ca6a0194c3b7ea0a98da7db2a5db263a77b57b41e45082d662",
+      "sha256": "d0baef201055a0c976b654be6d43bfb0af9eb08b173648d99eda7e6f37c13231",
       "row_count": 67
     },
     {
@@ -47,7 +47,7 @@
   "output_files": [
     {
       "path": "exports/promoted/rookie-alpha/2025_rookie_alpha_predraft_v0.json",
-      "sha256": "03b616147e41b2cd9943348dd8c6ad5cf5f77d0f74ce55062ad69501637863d0"
+      "sha256": "eac4ce0e76c8a1f85a8ba9bf97c461f6be61ac78399d33307c2c4fe1086af4f6"
     },
     {
       "path": "exports/promoted/rookie-alpha/2025_rookie_alpha_predraft_v0.csv",
@@ -57,8 +57,8 @@
   "export_metadata": {
     "season": 2025,
     "model_version": "rookie-alpha-predraft-v0.5.0",
-    "generated_at": "2026-05-11T16:44:35+00:00",
-    "run_id": "rookie-alpha-2025-2026-05-11T16:44:35+00:00",
+    "generated_at": "2026-07-25T13:14:24+00:00",
+    "run_id": "rookie-alpha-2025-2026-07-25T13:14:24+00:00",
     "coverage_summary": {
       "players_total": 67,
       "players_with_any_missing_input": 0,

--- a/exports/promoted/rookie-alpha/2025_rookie_alpha_predraft_v0.json
+++ b/exports/promoted/rookie-alpha/2025_rookie_alpha_predraft_v0.json
@@ -11,8 +11,8 @@
       "age_at_entry_supported": false
     }
   },
-  "generated_at": "2026-05-11T16:44:35+00:00",
-  "run_id": "rookie-alpha-2025-2026-05-11T16:44:35+00:00",
+  "generated_at": "2026-07-25T13:14:24+00:00",
+  "run_id": "rookie-alpha-2025-2026-07-25T13:14:24+00:00",
   "season": 2025,
   "coverage_summary": {
     "players_total": 67,
@@ -760,7 +760,7 @@
         "translation_flags": [
           "young_breakout"
         ],
-        "evidence_summary": "2024 Heisman winner (2-way; WR+CB). First true impact at 19 as Colorado freshman; recovered from gunshot injury in 2023. Dual-role usage at NFL level unlikely \u2014 evaluated purely as WR.",
+        "evidence_summary": "2024 Heisman winner (2-way; WR+CB). First true impact at 19 as Colorado freshman. Dual-role usage at NFL level unlikely \u2014 evaluated purely as WR.",
         "context_source": "manual_historical_seed"
       },
       "rookie_alpha_rank": 8,

--- a/tests/test_no_unsourced_violence_claims.py
+++ b/tests/test_no_unsourced_violence_claims.py
@@ -1,0 +1,58 @@
+"""Incident-specific regression for TIBER-Rookies#271.
+
+The 2025 Travis Hunter source and promoted Rookie Alpha export carried the
+unsupported claim "recovered from gunshot injury in 2023" plus an unsourced
+``severe_injury_recovery`` context flag. This test prevents that exact incident
+from recurring without establishing a repository-wide content policy.
+"""
+
+import json
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PLAYER_ID = "wr-travis-hunter"
+REJECTED_CLAIM = "recovered from gunshot injury in 2023"
+REJECTED_CONTEXT_FLAG = "severe_injury_recovery"
+SOURCE_PATH = REPO_ROOT / "data" / "processed" / "2025_prospect_context.json"
+PROMOTED_PATH = (
+    REPO_ROOT
+    / "exports"
+    / "promoted"
+    / "rookie-alpha"
+    / "2025_rookie_alpha_predraft_v0.json"
+)
+
+
+def _source_row() -> dict:
+    rows = json.loads(SOURCE_PATH.read_text(encoding="utf-8"))
+    return next(row for row in rows if row.get("player_id") == PLAYER_ID)
+
+
+def _promoted_player() -> dict:
+    payload = json.loads(PROMOTED_PATH.read_text(encoding="utf-8"))
+    return next(
+        player for player in payload["players"] if player.get("player_id") == PLAYER_ID
+    )
+
+
+class TravisHunterClaimRegressionTests(unittest.TestCase):
+    def test_source_does_not_contain_rejected_claim(self) -> None:
+        summary = (_source_row().get("evidence_summary") or "").lower()
+        self.assertNotIn(REJECTED_CLAIM, summary)
+
+    def test_source_does_not_contain_rejected_context_flag(self) -> None:
+        flags = _source_row().get("context_flags") or []
+        self.assertNotIn(REJECTED_CONTEXT_FLAG, flags)
+
+    def test_promoted_summary_matches_corrected_source(self) -> None:
+        source_summary = _source_row().get("evidence_summary") or ""
+        promoted_summary = (
+            (_promoted_player().get("evidence") or {}).get("evidence_summary") or ""
+        )
+        self.assertNotIn(REJECTED_CLAIM, promoted_summary.lower())
+        self.assertEqual(promoted_summary, source_summary)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Bounded content correction for the blocker reported in **#271** and re-confirmed still live in the weekly Devy Scout ledger (**#278**).

**Pinned starting state:** TIBER-Rookies `main` @ `11acc8bd7bff15f66253b72ba617336d8aff5839` (2026-07-24T17:56:58-04:00) — the head both #271 (2026-07-18) and this run inspected; no commit touched the affected files in between.

`evidence_summary` for Travis Hunter (`wr-travis-hunter`, 2025 class) read:

> "2024 Heisman winner (2-way; WR+CB). First true impact at 19 as Colorado freshman; **recovered from gunshot injury in 2023**. Dual-role usage at NFL level unlikely — evaluated purely as WR."

sourced only to `context_source: "manual_historical_seed"`, which has no `source_url`. Per `AGENTS.md` §5 (never fabricate player facts; preserve provenance) and the fix #271 already proposed, the claim is removed rather than replaced with different biographical/medical content. The accompanying `context_flags: ["severe_injury_recovery"]` — also unsourced, and rendered verbatim as a card badge by `RookieCard.js` / `RookieCompareView.js` when present — is dropped for the same reason.

## What changed

- `data/processed/2025_prospect_context.json` — Travis Hunter's `evidence_summary` and `context_flags` only (2 fields, 1 of 67 entries).
- `exports/promoted/rookie-alpha/2025_rookie_alpha_predraft_v0.json` + `2025_manifest.json` — regenerated via the established path (`python3 scripts/compute_rookie_alpha.py --season 2025`, same one used for the prior #254 fix) from the corrected source. `scripts/validate_promoted_export.py` passes against the refreshed manifest hashes.
- `tests/test_no_unsourced_violence_claims.py` (new) — incident-specific regression guarding against this exact recurrence:
  - checks only Travis Hunter's 2025 source and promoted entries for the rejected claim and source-only `context_flag`;
  - verifies the promoted summary remains synchronized with the corrected source;
  - explicitly does not establish a repository-wide content ban or provenance policy.

## What did not change (verified)

Programmatically diffed all 67 players' `scores`, `context`, and `evidence` (minus the two Travis Hunter fields above) between the prior committed export and the regenerated one: **zero differences**. Top-level `model`/`coverage_summary`/`source_files_used` unchanged. The CSV output is byte-identical (it never carried `evidence_summary`). No rankings, scores, the `#235` Devy pulse detector, or Calvin Russell's Devy-lane entry were touched — none of those files are in this diff.

```
$ git diff --stat
 data/processed/2025_prospect_context.json          |  6 +-
 exports/promoted/rookie-alpha/2025_manifest.json   | 12 +--
 exports/promoted/rookie-alpha/2025_rookie_alpha_predraft_v0.json | 6 +-
 tests/test_no_unsourced_violence_claims.py         | 58 ++++++
```

## Verification

- `python3 -m pytest tests -q` → 456 passed (453 pre-existing + 3 new).
- `npm run test:card-disclosure` → 6/6 pass.
- `python3 scripts/validate_promoted_export.py --export-json exports/promoted/rookie-alpha/2025_rookie_alpha_predraft_v0.json --manifest exports/promoted/rookie-alpha/2025_manifest.json` → `VALIDATION PASSED`.
- **Live cross-repo check:** ran TIBER-Fantasy's actual `RookieArtifactClient.loadPromotedRookieArtifact(2025)` against this corrected file (sibling checkout, `../TIBER-Rookies/exports/promoted/rookie-alpha`, the exact default `DEFAULT_PROMOTED_ARTIFACT_PATH` in `rookieArtifactClient.ts`) — the raw payload it reads into memory no longer contains "gunshot" and carries the corrected text.

## Separate finding: is Fantasy's direct file read intentional or a bypass?

Asked to report on this without redesigning it — **it is an intentional, documented, governed contract, not a bypass**, but with one gap worth operator attention:

- `docs/runbooks/ROOKIE_PROMOTED_HANDOFF.md` and `server/modules/externalModels/MODULE.md` (TIBER-Fantasy) explicitly document this as a deliberate read-only artifact handoff — "no runtime coupling to TIBER-Rookies routes" — following the repo's standard client → adapter → service → route pattern used for all promoted-lab integrations.
- **Correction to my earlier assessment:** I initially verified only `RookieArtifactClient` (the raw file-read layer) and reported the claim as reaching a "live consumer surface." Tracing the full path shows that's overstated. `rookieArtifactAdapter.ts`'s `mapRow()` builds the served `TiberRookieRow` from an explicit field allowlist (`profile_summary`, `identity_note`, `board_summary`, plus numeric scores) that does **not** include `evidence_summary` or `evidence.*` at all. `rookieArtifactService.ts` and `rookiesPromotedRoutes.ts` only ever serve that mapped, filtered row — never the raw client payload. A repo-wide grep of TIBER-Fantasy confirms zero other references to `evidence_summary`. **So today, this specific field never reaches any TIBER-Fantasy API response or UI**, contrary to what I initially reported.
- **The actual gap:** the client layer still reads the entire raw promoted file into process memory, unfiltered, before the adapter narrows it. Nothing in the governed contract's documentation states that `evidence_summary` is deliberately excluded for hygiene reasons — it's simply not on the current field allowlist. That's a difference between "governed by design" and "safe by accident of the current allowlist." Any future change that widens the mapped fields (e.g., to surface research notes on a card) would need to either exclude `evidence_summary`/`context_flags` outright or gate them through the same provenance policy TIBER-Rookies applies on its own cards. No code change proposed here — flagging for an operator decision on whether the contract should say this explicitly.

## Links

- Fixes the blocker in #271 (17 accompanying warnings in that issue are out of scope for this bounded correction).
- Evidence and this PR are cross-referenced in the weekly Devy Scout ledger, #278.

## Not in scope for this PR

Rankings/scores, the `#235` Devy pulse detector/runbook, Calvin Russell's Devy seed entry, the other 17 warnings in #271, and any TIBER-Fantasy code change (including the adapter-allowlist gap noted above) are explicitly untouched. **No production deployment is included in this PR.**


---
_Generated by [Claude Code](https://claude.ai/code/session_01DF29r2AoW2UT5QEaYR48Xv)_