### PR TITLE
Phase 1B (draft): repair neutral athletic evidence and compare truth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,5 +36,8 @@ jobs:
         with:
           node-version: '20'
 
+      - name: Run runtime smoke tests
+        run: npm run test:runtime-smoke
+
       - name: Run card disclosure tests
         run: npm run test:card-disclosure

--- a/cards/rookies/player.html
+++ b/cards/rookies/player.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>TIBER Rookie Card</title>
     <link rel="stylesheet" href="/components/rookies/rookieCardStyles.css" />
+    <link rel="stylesheet" href="/components/rookies/phase1bMobileIntegrity.css" />
   </head>
   <body>
     <!-- ── Site navigation ──────────────────────────────────────────────────── -->
@@ -47,7 +48,7 @@
 
     <script type="module">
       import { getAllRookieCards } from '/lib/rookies/getRookieCardData.js';
-      import { renderRookieCard } from '/components/rookies/RookieCard.js';
+      import { renderRookieCard } from '/components/rookies/RookieCardPhase1B.js';
       import { addRookieToQueue, getQueuedRookieAnnotation, isRookieQueued, removeRookieFromQueue } from '/lib/rookies/rookieQueueStore.js';
       import { deriveRookieTier } from '/lib/rookies/deriveRookieTier.js';
       import { findSimilarAthletes, getSporqDistribution } from '/lib/rookies/sporqHistorical.js';

--- a/components/rookies/RookieCard.js
+++ b/components/rookies/RookieCard.js
@@ -262,7 +262,7 @@ function formatStatEntry(key, value) {
   return `${displayLabel}: ${displayValue}`;
 }
 
-export function renderRookieCard(container, card) {
+export function renderRookieCard(container, card, { afterRender } = {}) {
   const heroScore = card.summary.rookieGrade == null ? 'N/A' : card.summary.rookieGrade.toFixed(1);
   const identityBits = [
     card.identity.positionLabel ?? card.identity.position,
@@ -424,6 +424,8 @@ export function renderRookieCard(container, card) {
         render();
       });
     });
+
+    afterRender?.(container, card);
   }
 
   render();

--- a/components/rookies/RookieCardPhase1B.js
+++ b/components/rookies/RookieCardPhase1B.js
@@ -53,6 +53,5 @@ export function applyRookieCardPhase1B(container, card) {
 }
 
 export function renderRookieCard(container, card) {
-  renderBaseRookieCard(container, card);
-  applyRookieCardPhase1B(container, card);
+  renderBaseRookieCard(container, card, { afterRender: applyRookieCardPhase1B });
 }

--- a/components/rookies/RookieCardPhase1B.js
+++ b/components/rookies/RookieCardPhase1B.js
@@ -1,0 +1,58 @@
+import { renderRookieCard as renderBaseRookieCard } from './RookieCard.js';
+import {
+  CARD_RADAR_VIEWBOX,
+  neutralAthleticPriorDisclosure,
+  observedEvidenceReadiness,
+} from '../../lib/rookies/phase1bPresentation.js';
+
+function findPanelByTitle(container, title) {
+  return [...container.querySelectorAll('.card-panel')].find(
+    (panel) => panel.querySelector('.section-title')?.textContent?.trim() === title,
+  ) ?? null;
+}
+
+function applyEvidenceReadiness(container, card) {
+  const panel = findPanelByTitle(container, 'Position-aware Evidence');
+  const meta = panel?.querySelector('.meta');
+  if (!meta) return;
+  const readiness = observedEvidenceReadiness(card);
+  meta.textContent = readiness.label;
+  meta.dataset.observedEvidenceAvailable = String(readiness.availableCount);
+  meta.dataset.observedEvidenceTotal = String(readiness.totalCount);
+}
+
+function applyNeutralPriorDisclosure(container, card) {
+  const disclosure = neutralAthleticPriorDisclosure(card);
+  if (!disclosure) return;
+  const panel = findPanelByTitle(container, 'Research Notes & Translation Signals');
+  if (!panel) return;
+  const existing = [...panel.querySelectorAll('.evidence-caveat')].find(
+    (node) => node.textContent?.includes('Athletic testing data was not incorporated'),
+  );
+  if (existing) {
+    existing.textContent = disclosure;
+    return;
+  }
+  const note = document.createElement('div');
+  note.className = 'meta evidence-caveat';
+  note.textContent = disclosure;
+  panel.append(note);
+}
+
+function applyRadarGeometry(container) {
+  const radar = container.querySelector('.radar-chart');
+  if (!radar) return;
+  radar.setAttribute('viewBox', CARD_RADAR_VIEWBOX);
+  radar.setAttribute('data-phase1b-label-padding', 'true');
+}
+
+export function applyRookieCardPhase1B(container, card) {
+  applyEvidenceReadiness(container, card);
+  applyNeutralPriorDisclosure(container, card);
+  applyRadarGeometry(container);
+}
+
+export function renderRookieCard(container, card) {
+  renderBaseRookieCard(container, card);
+  applyRookieCardPhase1B(container, card);
+}

--- a/components/rookies/RookieCardPhase1B.js
+++ b/components/rookies/RookieCardPhase1B.js
@@ -44,6 +44,10 @@ function applyRadarGeometry(container) {
   if (!radar) return;
   radar.setAttribute('viewBox', CARD_RADAR_VIEWBOX);
   radar.setAttribute('data-phase1b-label-padding', 'true');
+  radar.style.overflow = 'visible';
+  radar.querySelectorAll('text').forEach((label) => {
+    label.setAttribute('dominant-baseline', 'middle');
+  });
 }
 
 export function applyRookieCardPhase1B(container, card) {

--- a/components/rookies/RookieCompareView.js
+++ b/components/rookies/RookieCompareView.js
@@ -1,6 +1,7 @@
 import { compareRookies } from '/lib/rookies/compareRookies.js';
 import { getCollegeLogoUrl, getNflTeamLogoUrl } from '/lib/rookies/teamLogos.js';
 import { athleticMetricLabel } from '/lib/rookies/athleticLabel.js';
+import { applyRookieComparePhase1B } from './RookieCompareViewPhase1B.js';
 
 function esc(str) {
   return String(str ?? '')
@@ -411,4 +412,6 @@ export function renderRookieCompareView(container, leftCard, rightCard) {
 
     </section>
   `;
+
+  applyRookieComparePhase1B(container, leftCard, rightCard);
 }

--- a/components/rookies/RookieCompareViewPhase1B.js
+++ b/components/rookies/RookieCompareViewPhase1B.js
@@ -52,8 +52,9 @@ function applySharedProjectionScale(container, leftCard, rightCard) {
 }
 
 function applyNeutralPriorDisclosures(container, leftCard, rightCard) {
+  const cards = [leftCard, rightCard];
   const panels = [...container.querySelectorAll('.compare-player-panel')];
-  [leftCard, rightCard].forEach((card, index) => {
+  cards.forEach((card, index) => {
     const disclosure = neutralAthleticPriorDisclosure(card);
     if (!disclosure) return;
     const existing = [...(panels[index]?.querySelectorAll('.evidence-caveat') ?? [])].find(
@@ -61,6 +62,26 @@ function applyNeutralPriorDisclosures(container, leftCard, rightCard) {
     );
     if (existing) existing.textContent = disclosure;
   });
+
+  if (!cards.some((card) => card?.athleticSource === 'NEUTRAL_DEFAULT')) return;
+  const radarCenter = container.querySelector('.compare-radar-center');
+  const radarSvg = radarCenter?.querySelector('.compare-radar-svg');
+  if (!radarCenter || !radarSvg) return;
+
+  const firstAxisLabel = radarSvg.querySelector('text');
+  if (firstAxisLabel) firstAxisLabel.textContent = 'ATH / prior';
+  radarSvg.dataset.neutralPriorAxis = 'true';
+  radarSvg.setAttribute(
+    'aria-label',
+    'Overlaid model-input radar; ATH prior denotes a neutral model input, not observed athletic testing',
+  );
+
+  if (!radarCenter.querySelector('.compare-radar-prior-note')) {
+    const note = document.createElement('div');
+    note.className = 'meta compare-radar-prior-note';
+    note.textContent = 'ATH prior is a neutral model input, not observed athletic testing.';
+    radarCenter.append(note);
+  }
 }
 
 export function applyRookieComparePhase1B(container, leftCard, rightCard) {

--- a/components/rookies/RookieCompareViewPhase1B.js
+++ b/components/rookies/RookieCompareViewPhase1B.js
@@ -1,0 +1,66 @@
+import { renderRookieCompareView as renderBaseRookieCompareView } from './RookieCompareView.js';
+import {
+  neutralAthleticPriorDisclosure,
+  projectionTrackPercentages,
+  sharedPprScaleMax,
+} from '../../lib/rookies/phase1bPresentation.js';
+
+function findProjectionSection(container) {
+  return [...container.querySelectorAll('.metrics')].find(
+    (section) => section.querySelector('.section-title')?.textContent?.trim() === 'Year 1 PPR projection',
+  ) ?? null;
+}
+
+function applySharedProjectionScale(container, leftCard, rightCard) {
+  const section = findProjectionSection(container);
+  if (!section) return;
+  const projections = [leftCard?.pprProjection, rightCard?.pprProjection];
+  const scaleMaximum = sharedPprScaleMax(...projections);
+  if (scaleMaximum == null) return;
+
+  let scaleNote = section.querySelector('.compare-ppr-shared-scale');
+  if (!scaleNote) {
+    scaleNote = document.createElement('div');
+    scaleNote.className = 'meta compare-ppr-shared-scale';
+    section.querySelector('.section-title')?.insertAdjacentElement('afterend', scaleNote);
+  }
+  scaleNote.textContent = `Shared track scale: 0–${scaleMaximum} PPR points.`;
+  scaleNote.dataset.pprScaleMax = String(scaleMaximum);
+
+  const panels = [...section.querySelectorAll('.compare-ppr-panel')];
+  projections.forEach((projection, index) => {
+    const percentages = projectionTrackPercentages(projection, scaleMaximum);
+    if (!percentages) return;
+    const track = panels[index]?.querySelector('.ppr-range-track');
+    const fill = track?.querySelector('.ppr-range-fill');
+    const marker = track?.querySelector('.ppr-range-median-marker');
+    if (!track || !fill || !marker) return;
+    fill.style.left = `${percentages.rangeLeft}%`;
+    fill.style.width = `${percentages.rangeWidth}%`;
+    marker.style.left = `${percentages.medianLeft}%`;
+    track.dataset.pprScaleMax = String(scaleMaximum);
+    track.setAttribute('aria-label', `Projection range on shared 0 to ${scaleMaximum} PPR point scale`);
+  });
+}
+
+function applyNeutralPriorDisclosures(container, leftCard, rightCard) {
+  const panels = [...container.querySelectorAll('.compare-player-panel')];
+  [leftCard, rightCard].forEach((card, index) => {
+    const disclosure = neutralAthleticPriorDisclosure(card);
+    if (!disclosure) return;
+    const existing = [...(panels[index]?.querySelectorAll('.evidence-caveat') ?? [])].find(
+      (node) => node.textContent?.includes('Athletic testing data was not incorporated'),
+    );
+    if (existing) existing.textContent = disclosure;
+  });
+}
+
+export function applyRookieComparePhase1B(container, leftCard, rightCard) {
+  applySharedProjectionScale(container, leftCard, rightCard);
+  applyNeutralPriorDisclosures(container, leftCard, rightCard);
+}
+
+export function renderRookieCompareView(container, leftCard, rightCard) {
+  renderBaseRookieCompareView(container, leftCard, rightCard);
+  applyRookieComparePhase1B(container, leftCard, rightCard);
+}

--- a/components/rookies/RookieCompareViewPhase1B.js
+++ b/components/rookies/RookieCompareViewPhase1B.js
@@ -58,6 +58,10 @@ function applyCompareRadarGeometry(container) {
 
   radarSvg.setAttribute('viewBox', '-18 -24 256 262');
   radarSvg.dataset.phase1bLabelPadding = 'true';
+  radarSvg.style.overflow = 'visible';
+  radarSvg.querySelectorAll('text').forEach((label) => {
+    label.setAttribute('dominant-baseline', 'middle');
+  });
 
   if (window.matchMedia?.('(max-width: 480px)').matches) {
     radarCenter.style.paddingTop = '18px';

--- a/components/rookies/RookieCompareViewPhase1B.js
+++ b/components/rookies/RookieCompareViewPhase1B.js
@@ -1,9 +1,17 @@
-import { renderRookieCompareView as renderBaseRookieCompareView } from './RookieCompareView.js';
 import {
   neutralAthleticPriorDisclosure,
   projectionTrackPercentages,
   sharedPprScaleMax,
 } from '../../lib/rookies/phase1bPresentation.js';
+
+function ensurePhase1BStyles() {
+  if (document.querySelector('link[data-phase1b-mobile-integrity]')) return;
+  const link = document.createElement('link');
+  link.rel = 'stylesheet';
+  link.href = '/components/rookies/phase1bMobileIntegrity.css';
+  link.dataset.phase1bMobileIntegrity = 'true';
+  document.head.append(link);
+}
 
 function findProjectionSection(container) {
   return [...container.querySelectorAll('.metrics')].find(
@@ -56,11 +64,7 @@ function applyNeutralPriorDisclosures(container, leftCard, rightCard) {
 }
 
 export function applyRookieComparePhase1B(container, leftCard, rightCard) {
+  ensurePhase1BStyles();
   applySharedProjectionScale(container, leftCard, rightCard);
   applyNeutralPriorDisclosures(container, leftCard, rightCard);
-}
-
-export function renderRookieCompareView(container, leftCard, rightCard) {
-  renderBaseRookieCompareView(container, leftCard, rightCard);
-  applyRookieComparePhase1B(container, leftCard, rightCard);
 }

--- a/components/rookies/RookieCompareViewPhase1B.js
+++ b/components/rookies/RookieCompareViewPhase1B.js
@@ -51,6 +51,19 @@ function applySharedProjectionScale(container, leftCard, rightCard) {
   });
 }
 
+function applyCompareRadarGeometry(container) {
+  const radarCenter = container.querySelector('.compare-radar-center');
+  const radarSvg = radarCenter?.querySelector('.compare-radar-svg');
+  if (!radarCenter || !radarSvg) return;
+
+  radarSvg.setAttribute('viewBox', '-18 -24 256 262');
+  radarSvg.dataset.phase1bLabelPadding = 'true';
+
+  if (window.matchMedia?.('(max-width: 480px)').matches) {
+    radarCenter.style.paddingTop = '18px';
+  }
+}
+
 function applyNeutralPriorDisclosures(container, leftCard, rightCard) {
   const cards = [leftCard, rightCard];
   const panels = [...container.querySelectorAll('.compare-player-panel')];
@@ -87,5 +100,6 @@ function applyNeutralPriorDisclosures(container, leftCard, rightCard) {
 export function applyRookieComparePhase1B(container, leftCard, rightCard) {
   ensurePhase1BStyles();
   applySharedProjectionScale(container, leftCard, rightCard);
+  applyCompareRadarGeometry(container);
   applyNeutralPriorDisclosures(container, leftCard, rightCard);
 }

--- a/components/rookies/phase1bMobileIntegrity.css
+++ b/components/rookies/phase1bMobileIntegrity.css
@@ -1,0 +1,219 @@
+/* Phase 1B bounded presentation repairs for player and compare routes. */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html,
+body,
+.page,
+.card-root-shell,
+.rookie-card-layout,
+.hero-panel,
+.hero-top,
+.hero-left,
+.hero-score,
+.card-columns,
+.card-col,
+.card-panel,
+.compare-page,
+.compare-selector-shell,
+.compare-results-shell,
+.compare-layout,
+.compare-grid,
+.compare-player,
+.compare-player-panel,
+.compare-3col-table,
+.compare-ppr-grid,
+.compare-ppr-panel {
+  min-width: 0;
+  max-width: 100%;
+}
+
+.page {
+  width: 100%;
+}
+
+.hero-score {
+  max-width: 100%;
+}
+
+.meta,
+.profile-summary,
+.compare-profile-summary,
+.compare-notes,
+.compare-expand-content,
+.official-outcome-provenance,
+.sporq-comps-note,
+.site-footer-link,
+.site-footer-copy,
+.card-actions-copy,
+.metric-header,
+.compare-top-edge-label,
+.compare-3col-label {
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.radar-chart {
+  width: min(100%, 310px);
+  height: auto;
+  overflow: visible;
+}
+
+.stats-table {
+  width: 100%;
+  table-layout: fixed;
+}
+
+.stats-table th,
+.stats-table td {
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.sporq-comps-section {
+  max-width: 100%;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.compare-3col-table {
+  overflow-x: auto;
+  overflow-y: hidden;
+  -webkit-overflow-scrolling: touch;
+  overscroll-behavior-x: contain;
+}
+
+.compare-3col-name-row,
+.compare-3col-row {
+  min-width: 540px;
+}
+
+.compare-ppr-shared-scale {
+  margin-top: 5px;
+  font-size: 12px;
+}
+
+@media (max-width: 760px) {
+  .site-header-inner {
+    height: auto;
+    min-height: 56px;
+    padding: 8px 12px;
+    align-items: flex-start;
+    gap: 8px;
+  }
+
+  .site-logo {
+    padding-top: 5px;
+  }
+
+  .site-nav {
+    min-width: 0;
+    max-width: calc(100vw - 88px);
+    overflow-x: auto;
+    overflow-y: hidden;
+    overscroll-behavior-x: contain;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: thin;
+    padding-bottom: 3px;
+  }
+
+  .site-nav-link {
+    flex: 0 0 auto;
+    white-space: nowrap;
+  }
+
+  .hero-score {
+    width: 100%;
+    min-width: 0;
+  }
+
+  .card-actions-copy {
+    min-width: 0;
+    width: 100%;
+  }
+
+  .card-actions-links,
+  .compare-grid,
+  .compare-ppr-grid,
+  .compare-snapshot-grid {
+    grid-template-columns: minmax(0, 1fr);
+    width: 100%;
+  }
+
+  .verdict-strip,
+  .compare-player-panel-top {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .compare-player-panel-grade {
+    text-align: left;
+  }
+
+  .delta-chip {
+    align-self: flex-start;
+  }
+
+  .compare-radar-row {
+    min-width: 0;
+  }
+
+  .compare-radar-side {
+    min-width: 0;
+  }
+
+  .site-footer-inner {
+    align-items: flex-start;
+  }
+
+  .site-footer-nav {
+    width: 100%;
+    gap: 10px 14px;
+  }
+}
+
+@media (max-width: 480px) {
+  .page {
+    padding-left: 12px;
+    padding-right: 12px;
+  }
+
+  .site-logo-tagline {
+    display: none;
+  }
+
+  .site-nav {
+    max-width: calc(100vw - 76px);
+  }
+
+  .hero-panel,
+  .card-panel,
+  .compare-player,
+  .verdict-strip,
+  .compare-ppr-panel {
+    padding: 12px;
+  }
+
+  .player-name,
+  .compare-name {
+    overflow-wrap: anywhere;
+  }
+
+  .compare-3col-name-row,
+  .compare-3col-row {
+    min-width: 500px;
+  }
+
+  .compare-ppr-grid {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .site-footer-inner {
+    flex-direction: column;
+    gap: 12px;
+  }
+}

--- a/components/rookies/phase1bMobileIntegrity.css
+++ b/components/rookies/phase1bMobileIntegrity.css
@@ -91,9 +91,16 @@ body,
   min-width: 540px;
 }
 
-.compare-ppr-shared-scale {
+.compare-ppr-shared-scale,
+.compare-radar-prior-note {
   margin-top: 5px;
   font-size: 12px;
+}
+
+.compare-radar-prior-note {
+  max-width: 220px;
+  text-align: center;
+  line-height: 1.4;
 }
 
 @media (max-width: 760px) {

--- a/docs/phase-1b-reconstruction-note.md
+++ b/docs/phase-1b-reconstruction-note.md
@@ -2,13 +2,22 @@
 
 This draft branch was rebuilt cleanly on the merged Phase 1A main commit (`a825431402f89f7ec4fe69e72de073ca4b301ea3`) after the original local-only checkpoint was lost when the conversation branched.
 
-The recovered truth-layer subset includes:
+## Reconstructed truth layer
 
-- explicit `NEUTRAL_DEFAULT` athletic-source labeling;
-- exclusion of neutral priors from observed-evidence selection;
-- removal of neutral-prior athletic edge claims in compare;
-- verdict copy conditional on actual shared observed evidence.
+- `NEUTRAL_DEFAULT` is labeled `ATH prior`, never RAS.
+- The prior remains disclosed because it contributes to the frozen Rookie Alpha, but it is excluded from observed-evidence selection and athletic edge claims.
+- Compare verdict copy depends on the actual shared observed-evidence rows; a grade-only lean says so explicitly.
 
-The remaining #280 presentation batch is completed on this branch before review: shared PPR scaling, mobile containment, radar label geometry, evidence-readiness copy, and regression coverage. Live 390px validation remains a separate non-production preview gate.
+## Completed bounded presentation batch
 
-No model weights, governed artifacts, narratives, Railway settings, or production deployment state are changed.
+- Side-by-side non-stale PPR tracks use one shared 25-point-rounded maximum, shown in visible copy and accessible track metadata. Missing or stale projections do not set the scale.
+- Player and compare routes load a bounded mobile-integrity layer: border-box sizing, minimum-width release, wrapped research text, internally scrollable wide comparison content, and mobile-safe header/footer navigation.
+- The individual-card radar uses a padded viewBox so its axis labels are not clipped by the original 200×200 geometry.
+- Evidence readiness now reports represented observed rows. `ATH prior` does not count as observed testing; Age-Adjusted Production and BOAR count only when rendered.
+- Canonical Node regressions cover neutral-prior truth, zero-evidence verdict wording, shared PPR scaling, readiness semantics, radar geometry, and mobile wiring. CI also runs the standalone runtime smoke.
+
+## Still gated
+
+Code completion is not live-device acceptance. A published non-production preview and true 390px-class iPhone/Safari inspection of player and compare routes remain required before mark-ready or merge. Any defect found there returns this draft to correction.
+
+No Rookie Alpha formula or weight, governed artifact, narrative/source policy, Railway setting, database, or production deployment state is changed by this batch.

--- a/docs/phase-1b-reconstruction-note.md
+++ b/docs/phase-1b-reconstruction-note.md
@@ -1,0 +1,14 @@
+# Phase 1B reconstruction note
+
+This draft branch was rebuilt cleanly on the merged Phase 1A main commit (`a825431402f89f7ec4fe69e72de073ca4b301ea3`) after the original local-only checkpoint was lost when the conversation branched.
+
+The recovered truth-layer subset includes:
+
+- explicit `NEUTRAL_DEFAULT` athletic-source labeling;
+- exclusion of neutral priors from observed-evidence selection;
+- removal of neutral-prior athletic edge claims in compare;
+- verdict copy conditional on actual shared observed evidence.
+
+The remaining #280 presentation batch is completed on this branch before review: shared PPR scaling, mobile containment, radar label geometry, evidence-readiness copy, and regression coverage. Live 390px validation remains a separate non-production preview gate.
+
+No model weights, governed artifacts, narratives, Railway settings, or production deployment state are changed.

--- a/lib/rookies/athleticLabel.js
+++ b/lib/rookies/athleticLabel.js
@@ -3,31 +3,42 @@
 // from drifting — e.g. one treating RAS_PARTIAL as a full RAS while another
 // labels it a partial composite.
 
-/** @returns {'sporq'|'partial'|'ras'} */
+/** @returns {'sporq'|'partial'|'neutral'|'ras'} */
 export function athleticSourceCategory(source) {
   if (source === 'SPORQ') return 'sporq';
   if (source === 'COMBINE_FALLBACK' || source === 'RAS_PARTIAL') return 'partial';
+  if (source === 'NEUTRAL_DEFAULT') return 'neutral';
   return 'ras';
 }
 
 /** Full metric label (card + compare radar). */
 export function athleticMetricLabel(source) {
   const category = athleticSourceCategory(source);
-  return category === 'sporq' ? 'ATH (SPORQ)' : category === 'partial' ? 'ATH (partial)' : 'RAS';
+  if (category === 'sporq') return 'ATH (SPORQ)';
+  if (category === 'partial') return 'ATH (partial)';
+  if (category === 'neutral') return 'ATH prior';
+  return 'RAS';
 }
 
 /** Compact chip label (board). */
 export function athleticChipLabel(source) {
   const category = athleticSourceCategory(source);
-  return category === 'sporq' ? 'SPORQ' : category === 'partial' ? 'ATH*' : 'RAS';
+  if (category === 'sporq') return 'SPORQ';
+  if (category === 'partial') return 'ATH*';
+  if (category === 'neutral') return 'ATH prior';
+  return 'RAS';
 }
 
 /** Chip tooltip (board). */
 export function athleticChipTitle(source) {
   const category = athleticSourceCategory(source);
-  return category === 'sporq'
-    ? 'Athletic score (SPORQ composite)'
-    : category === 'partial'
-      ? 'Athletic score (partial composite)'
-      : 'Relative Athletic Score';
+  if (category === 'sporq') return 'Athletic score (SPORQ composite)';
+  if (category === 'partial') return 'Athletic score (partial composite)';
+  if (category === 'neutral') return 'Neutral athletic model prior; no observed testing available';
+  return 'Relative Athletic Score';
+}
+
+/** Whether the source represents observed athletic evidence. */
+export function hasObservedAthleticEvidence(source) {
+  return source != null && athleticSourceCategory(source) !== 'neutral';
 }

--- a/lib/rookies/compareRookies.js
+++ b/lib/rookies/compareRookies.js
@@ -1,4 +1,5 @@
 import { selectRookieEvidenceMetrics } from '/lib/rookies/selectRookieEvidenceMetrics.js';
+import { hasObservedAthleticEvidence } from '/lib/rookies/athleticLabel.js';
 
 const GRADE_CLOSE_DELTA = 1.5;
 const GRADE_LEAN_DELTA = 4;
@@ -13,6 +14,7 @@ const DUPLICATE_EVIDENCE_LABELS = new Set([
   'RAS',
   'ATH (SPORQ)',
   'ATH (partial)',
+  'ATH prior',
   'Production Score',
   'Draft Capital Proxy',
 ]);
@@ -38,12 +40,18 @@ function winnerFromDelta(delta) {
   return delta > 0 ? 'left' : 'right';
 }
 
+function observedAthleticScore(card) {
+  return hasObservedAthleticEvidence(card?.athleticSource)
+    ? (card?.athleticScore ?? null)
+    : null;
+}
+
 function scoreComparisons(leftCard, rightCard) {
   const scoreRows = [
     {
       label: SCORE_LABELS[0],
-      left: leftCard?.athleticScore ?? null,
-      right: rightCard?.athleticScore ?? null,
+      left: observedAthleticScore(leftCard),
+      right: observedAthleticScore(rightCard),
     },
     {
       label: SCORE_LABELS[1],
@@ -140,6 +148,7 @@ function gradeStageNote(leftCard, rightCard) {
 function verdictFromCompare(leftCard, rightCard, overallDelta, evidenceRows) {
   const leftName = leftCard?.identity?.name ?? 'Left rookie';
   const rightName = rightCard?.identity?.name ?? 'Right rookie';
+  const hasEvidenceRows = evidenceRows.length > 0;
 
   if (overallDelta == null) {
     return {
@@ -159,7 +168,9 @@ function verdictFromCompare(leftCard, rightCard, overallDelta, evidenceRows) {
     return {
       code: 'close',
       headline: 'Close profile',
-      detail: `Overall grades are within ${GRADE_CLOSE_DELTA} points and evidence edges are narrow.`,
+      detail: hasEvidenceRows
+        ? `Overall grades are within ${GRADE_CLOSE_DELTA} points and observed evidence edges are narrow.`
+        : `Overall grades are within ${GRADE_CLOSE_DELTA} points; no shared observed evidence rows are available.`,
     };
   }
 
@@ -170,7 +181,9 @@ function verdictFromCompare(leftCard, rightCard, overallDelta, evidenceRows) {
   return {
     code: leanLeft ? 'lean-left' : 'lean-right',
     headline: `Lean ${leanName}`,
-    detail: `${leanStrength === 'clear' ? 'Clear' : 'Slight'} edge based on Rookie Grade delta and supporting evidence rows.`,
+    detail: hasEvidenceRows
+      ? `${leanStrength === 'clear' ? 'Clear' : 'Slight'} edge based on Rookie Grade delta and shared observed evidence rows.`
+      : `${leanStrength === 'clear' ? 'Clear' : 'Slight'} edge based on Rookie Grade delta only; displayed model-score rows are descriptive.`,
   };
 }
 
@@ -193,7 +206,7 @@ export function compareRookies(leftCard, rightCard) {
   if (stageNote) notes.push(stageNote);
 
   if (!evidence.length) {
-    notes.push('Shared evidence metrics were limited, so no detailed edge rows are shown.');
+    notes.push('Shared observed evidence metrics were limited, so no detailed edge rows are shown.');
   }
 
   return {

--- a/lib/rookies/compareRookies.js
+++ b/lib/rookies/compareRookies.js
@@ -1,5 +1,5 @@
-import { selectRookieEvidenceMetrics } from '/lib/rookies/selectRookieEvidenceMetrics.js';
-import { hasObservedAthleticEvidence } from '/lib/rookies/athleticLabel.js';
+import { selectRookieEvidenceMetrics } from './selectRookieEvidenceMetrics.js';
+import { hasObservedAthleticEvidence } from './athleticLabel.js';
 
 const GRADE_CLOSE_DELTA = 1.5;
 const GRADE_LEAN_DELTA = 4;

--- a/lib/rookies/phase1bPresentation.js
+++ b/lib/rookies/phase1bPresentation.js
@@ -54,4 +54,4 @@ export function neutralAthleticPriorDisclosure(card) {
   return `ATH prior${value} is a neutral model default that contributes to the frozen Rookie Alpha; no observed athletic testing is available.`;
 }
 
-export const CARD_RADAR_VIEWBOX = '-55 -24 310 248';
+export const CARD_RADAR_VIEWBOX = '-55 -44 310 268';

--- a/lib/rookies/phase1bPresentation.js
+++ b/lib/rookies/phase1bPresentation.js
@@ -1,0 +1,57 @@
+function finiteProjectionRange(projection) {
+  if (!projection || projection.stale === true) return null;
+  const floor = Number(projection.floor);
+  const median = Number(projection.median);
+  const ceiling = Number(projection.ceiling);
+  if (![floor, median, ceiling].every(Number.isFinite) || ceiling < floor) return null;
+  return { floor, median, ceiling };
+}
+
+export function sharedPprScaleMax(...projections) {
+  const ranges = projections.map(finiteProjectionRange).filter(Boolean);
+  if (!ranges.length) return null;
+  const maximum = Math.max(...ranges.flatMap((range) => [range.floor, range.median, range.ceiling]));
+  return Math.max(25, Math.ceil(maximum / 25) * 25);
+}
+
+export function projectionTrackPercentages(projection, scaleMaximum) {
+  const range = finiteProjectionRange(projection);
+  const scale = Number(scaleMaximum);
+  if (!range || !Number.isFinite(scale) || scale <= 0) return null;
+  const rangeLeft = Math.max(0, Math.min(100, (range.floor / scale) * 100));
+  const rangeWidth = Math.max(0, Math.min(100 - rangeLeft, ((range.ceiling - range.floor) / scale) * 100));
+  const medianLeft = Math.max(0, Math.min(100, (range.median / scale) * 100));
+  return { rangeLeft, rangeWidth, medianLeft };
+}
+
+export function observedEvidenceReadiness(card) {
+  const metrics = Array.isArray(card?.metrics) ? card.metrics : [];
+  const eligibleMetricSlots = metrics.filter((metric) => metric?.label !== 'ATH prior');
+  const availableMetricSlots = eligibleMetricSlots.filter(
+    (metric) => metric?.value != null && metric?.display != null,
+  );
+  const productionContextSlots = [card?.ageAdjustedProduction, card?.breakoutAgeRating];
+  const availableProductionContext = productionContextSlots.filter(
+    (value) => value != null && Number.isFinite(Number(value)),
+  ).length;
+  const availableCount = availableMetricSlots.length + availableProductionContext;
+  const totalCount = eligibleMetricSlots.length + productionContextSlots.length;
+  const neutralPriorNote = card?.athleticSource === 'NEUTRAL_DEFAULT'
+    ? ' ATH prior is disclosed separately and does not count as observed testing.'
+    : '';
+
+  return {
+    availableCount,
+    totalCount,
+    label: `Observed evidence represented: ${availableCount}/${totalCount} rows.${neutralPriorNote}`,
+  };
+}
+
+export function neutralAthleticPriorDisclosure(card) {
+  if (card?.athleticSource !== 'NEUTRAL_DEFAULT') return null;
+  const numeric = Number(card?.athleticScore);
+  const value = Number.isFinite(numeric) ? ` (${numeric.toFixed(1)})` : '';
+  return `ATH prior${value} is a neutral model default that contributes to the frozen Rookie Alpha; no observed athletic testing is available.`;
+}
+
+export const CARD_RADAR_VIEWBOX = '-55 -24 310 248';

--- a/lib/rookies/selectRookieEvidenceMetrics.js
+++ b/lib/rookies/selectRookieEvidenceMetrics.js
@@ -1,4 +1,4 @@
-const ATH_LABELS = ['RAS', 'ATH (SPORQ)', 'ATH (partial)'];
+const ATH_LABELS = ['RAS', 'ATH (SPORQ)', 'ATH (partial)', 'ATH prior'];
 
 const METRIC_PRIORITY = {
   // WR: production dominates; 40-yard + 3-cone matter for short WRs, vertical for both archetypes
@@ -16,11 +16,11 @@ function byPriority(position) {
   return METRIC_PRIORITY[position] ?? FALLBACK_PRIORITY;
 }
 
-/** Find an ATH metric by any of the possible ATH labels */
+/** Find an observed ATH metric by any of the possible ATH labels. */
 function findAthMetric(byLabel) {
   for (const label of ATH_LABELS) {
-    const m = byLabel.get(label);
-    if (m) return m;
+    const metric = byLabel.get(label);
+    if (metric && label !== 'ATH prior') return metric;
   }
   return undefined;
 }
@@ -31,13 +31,16 @@ function formatEvidenceLabel(metric) {
 }
 
 /**
- * Deterministically choose display-ready evidence metrics based on player position.
- * Returns only metrics with non-null values.
+ * Deterministically choose display-ready observed evidence metrics based on
+ * player position. Neutral model priors remain available to explanatory UI,
+ * but are not returned as observed evidence.
  */
 export function selectRookieEvidenceMetrics(card, variant = 'full') {
   const cap = variant === 'compact' ? 4 : 6;
   const available = (card?.metrics ?? []).filter(
-    (metric) => metric?.value != null && metric?.display != null
+    (metric) => metric?.value != null
+      && metric?.display != null
+      && metric?.label !== 'ATH prior'
   );
   if (!available.length) return [];
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node runtime-server.js",
     "test:runtime-smoke": "node --test tests/runtime-server.smoke.test.cjs",
-    "test:card-disclosure": "node --test tests/card-disclosure-wiring.test.mjs",
+    "test:card-disclosure": "node --test tests/card-disclosure-wiring.test.mjs tests/phase1b-presentation-integrity.test.mjs",
     "test:phase1b": "node --test tests/phase1b-presentation-integrity.test.mjs",
     "ops:rehearse-2026": "bash scripts/rehearse_draft_week_handoff_2026.sh"
   },

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "start": "node runtime-server.js",
     "test:runtime-smoke": "node --test tests/runtime-server.smoke.test.cjs",
     "test:card-disclosure": "node --test tests/card-disclosure-wiring.test.mjs",
+    "test:phase1b": "node --test tests/phase1b-presentation-integrity.test.mjs",
     "ops:rehearse-2026": "bash scripts/rehearse_draft_week_handoff_2026.sh"
   },
   "engines": {

--- a/tests/phase1b-presentation-integrity.test.mjs
+++ b/tests/phase1b-presentation-integrity.test.mjs
@@ -160,10 +160,10 @@ test('player and compare routes wire the bounded Phase 1B presentation layer', (
   assert.match(compareRepairs, /Shared track scale: 0–\$\{scaleMaximum\} PPR points/);
   assert.match(compareRepairs, /ATH prior is a neutral model input, not observed athletic testing/);
   assert.match(compareRepairs, /neutralPriorAxis/);
-  assert.match(compareRepairs, /viewBox.*-12 -28 244 260/);
+  assert.match(compareRepairs, /setAttribute\('viewBox', '-18 -24 256 262'\)/);
+  assert.match(compareRepairs, /paddingTop = '18px'/);
   assert.match(mobileCss, /box-sizing:\s*border-box/);
   assert.match(mobileCss, /\.compare-3col-table\s*\{[\s\S]*overflow-x:\s*auto/);
   assert.match(mobileCss, /\.site-nav\s*\{[\s\S]*overflow-x:\s*auto/);
   assert.match(mobileCss, /\.hero-score\s*\{[\s\S]*width:\s*100%/);
-  assert.match(mobileCss, /\.compare-radar-center\s*\{[\s\S]*margin-top:\s*18px/);
 });

--- a/tests/phase1b-presentation-integrity.test.mjs
+++ b/tests/phase1b-presentation-integrity.test.mjs
@@ -135,11 +135,12 @@ test('readiness wording counts represented observed rows and excludes ATH prior'
   );
 });
 
-test('card radar geometry reserves label padding outside the original viewBox', () => {
-  assert.equal(CARD_RADAR_VIEWBOX, '-55 -24 310 248');
+test('card radar geometry reserves additional top clearance for narrow mobile labels', () => {
+  assert.equal(CARD_RADAR_VIEWBOX, '-55 -44 310 268');
   const [x, y, width, height] = CARD_RADAR_VIEWBOX.split(/\s+/).map(Number);
-  assert.ok(x < 0 && y < 0);
-  assert.ok(width > 200 && height > 200);
+  assert.ok(x < 0);
+  assert.ok(y <= -40, 'top of viewBox must reserve at least 40 units above the original chart');
+  assert.ok(width > 200 && height >= 268);
 });
 
 test('player and compare routes wire the bounded Phase 1B presentation layer', () => {
@@ -159,8 +160,10 @@ test('player and compare routes wire the bounded Phase 1B presentation layer', (
   assert.match(compareRepairs, /Shared track scale: 0–\$\{scaleMaximum\} PPR points/);
   assert.match(compareRepairs, /ATH prior is a neutral model input, not observed athletic testing/);
   assert.match(compareRepairs, /neutralPriorAxis/);
+  assert.match(compareRepairs, /viewBox.*-12 -28 244 260/);
   assert.match(mobileCss, /box-sizing:\s*border-box/);
   assert.match(mobileCss, /\.compare-3col-table\s*\{[\s\S]*overflow-x:\s*auto/);
   assert.match(mobileCss, /\.site-nav\s*\{[\s\S]*overflow-x:\s*auto/);
   assert.match(mobileCss, /\.hero-score\s*\{[\s\S]*width:\s*100%/);
+  assert.match(mobileCss, /\.compare-radar-center\s*\{[\s\S]*margin-top:\s*18px/);
 });

--- a/tests/phase1b-presentation-integrity.test.mjs
+++ b/tests/phase1b-presentation-integrity.test.mjs
@@ -152,6 +152,8 @@ test('player and compare routes wire the bounded Phase 1B presentation layer', (
   assert.match(playerHtml, /RookieCardPhase1B\.js/);
   assert.match(compareView, /applyRookieComparePhase1B/);
   assert.match(compareRepairs, /Shared track scale: 0–\$\{scaleMaximum\} PPR points/);
+  assert.match(compareRepairs, /ATH prior is a neutral model input, not observed athletic testing/);
+  assert.match(compareRepairs, /neutralPriorAxis/);
   assert.match(mobileCss, /box-sizing:\s*border-box/);
   assert.match(mobileCss, /\.compare-3col-table\s*\{[\s\S]*overflow-x:\s*auto/);
   assert.match(mobileCss, /\.site-nav\s*\{[\s\S]*overflow-x:\s*auto/);

--- a/tests/phase1b-presentation-integrity.test.mjs
+++ b/tests/phase1b-presentation-integrity.test.mjs
@@ -1,0 +1,159 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+import { athleticMetricLabel, hasObservedAthleticEvidence } from '../lib/rookies/athleticLabel.js';
+import { compareRookies } from '../lib/rookies/compareRookies.js';
+import { selectRookieEvidenceMetrics } from '../lib/rookies/selectRookieEvidenceMetrics.js';
+import {
+  CARD_RADAR_VIEWBOX,
+  neutralAthleticPriorDisclosure,
+  observedEvidenceReadiness,
+  projectionTrackPercentages,
+  sharedPprScaleMax,
+} from '../lib/rookies/phase1bPresentation.js';
+
+function projection(floor, median, ceiling, stale = false) {
+  return { floor, median, ceiling, band: 'Starter', stale };
+}
+
+function compareCard({
+  name,
+  position,
+  grade,
+  athleticSource = 'NEUTRAL_DEFAULT',
+  athleticScore = 50,
+  productionScore = 60,
+  draftCapitalScore = 55,
+  metrics = [],
+}) {
+  return {
+    identity: { name, position },
+    summary: { rookieGrade: grade, classRank: null },
+    preDraftGrade: grade,
+    athleticSource,
+    athleticScore,
+    productionScore,
+    draftCapitalScore,
+    consensusDelta: null,
+    metrics,
+  };
+}
+
+test('neutral default is disclosed as ATH prior and never as observed RAS', () => {
+  assert.equal(athleticMetricLabel('NEUTRAL_DEFAULT'), 'ATH prior');
+  assert.equal(hasObservedAthleticEvidence('NEUTRAL_DEFAULT'), false);
+  assert.equal(hasObservedAthleticEvidence('RAS'), true);
+  assert.match(
+    neutralAthleticPriorDisclosure({ athleticSource: 'NEUTRAL_DEFAULT', athleticScore: 50 }),
+    /contributes to the frozen Rookie Alpha; no observed athletic testing is available/,
+  );
+});
+
+test('neutral prior is excluded from observed evidence selection', () => {
+  const metrics = [
+    { label: 'ATH prior', value: 50, display: '50.0', family: 'athletic' },
+    { label: 'Production Score', value: 67, display: '67.0', family: 'production' },
+    { label: 'Draft Capital Proxy', value: 55, display: '55.0', family: 'capital' },
+  ];
+  const selected = selectRookieEvidenceMetrics({ identity: { position: 'WR' }, metrics }, 'full');
+  assert.deepEqual(selected.map((metric) => metric.label), ['Production Score', 'Draft Capital Proxy']);
+});
+
+test('grade-only compare verdict does not claim supporting evidence rows', () => {
+  const left = compareCard({
+    name: 'Left Receiver',
+    position: 'WR',
+    grade: 67.7,
+    metrics: [
+      { label: 'ATH prior', value: 50, display: '50.0', family: 'athletic' },
+      { label: 'Production Score', value: 70, display: '70.0', family: 'production' },
+      { label: 'Draft Capital Proxy', value: 60, display: '60.0', family: 'capital' },
+    ],
+  });
+  const right = compareCard({
+    name: 'Right Tight End',
+    position: 'TE',
+    grade: 65.3,
+    athleticSource: 'RAS',
+    athleticScore: 82,
+    metrics: [
+      { label: 'RAS', value: 82, display: '82.0', family: 'athletic' },
+      { label: 'Production Score', value: 62, display: '62.0', family: 'production' },
+      { label: 'Draft Capital Proxy', value: 58, display: '58.0', family: 'capital' },
+    ],
+  });
+
+  const result = compareRookies(left, right);
+  assert.equal(result.evidenceComparisons.length, 0);
+  assert.match(result.verdict.detail, /Rookie Grade delta only/);
+  assert.doesNotMatch(result.verdict.detail, /shared observed evidence rows/);
+
+  const athleticRow = result.scoreComparisons.find((row) => row.label === 'Athleticism Score');
+  assert.equal(athleticRow.leftValue, null);
+  assert.equal(athleticRow.winner, 'tie');
+});
+
+test('side-by-side PPR projections share one scale and ignore stale projections', () => {
+  const left = projection(70, 115, 165);
+  const right = projection(55, 90, 135);
+  const stale = projection(0, 0, 400, true);
+
+  assert.equal(sharedPprScaleMax(left, right), 175);
+  assert.equal(sharedPprScaleMax(left, stale), 175);
+  assert.equal(sharedPprScaleMax(stale, null), null);
+
+  const leftTrack = projectionTrackPercentages(left, 175);
+  const rightTrack = projectionTrackPercentages(right, 175);
+  assert.equal(leftTrack.medianLeft, (115 / 175) * 100);
+  assert.equal(rightTrack.medianLeft, (90 / 175) * 100);
+  assert.equal(projectionTrackPercentages(stale, 175), null);
+});
+
+test('readiness wording counts represented observed rows and excludes ATH prior', () => {
+  const card = {
+    athleticSource: 'NEUTRAL_DEFAULT',
+    ageAdjustedProduction: 72,
+    breakoutAgeRating: 64,
+    metrics: [
+      { label: 'ATH prior', value: 50, display: '50.0' },
+      { label: 'Production Score', value: 68, display: '68.0' },
+      { label: 'Draft Capital Proxy', value: 55, display: '55.0' },
+      { label: '40 Yard Dash (s)', value: null, display: 'N/A' },
+      { label: '3-Cone (s)', value: null, display: 'N/A' },
+      { label: 'Vertical (in)', value: null, display: 'N/A' },
+      { label: 'Broad Jump (in)', value: null, display: 'N/A' },
+    ],
+  };
+
+  const readiness = observedEvidenceReadiness(card);
+  assert.equal(readiness.availableCount, 4);
+  assert.equal(readiness.totalCount, 8);
+  assert.equal(
+    readiness.label,
+    'Observed evidence represented: 4/8 rows. ATH prior is disclosed separately and does not count as observed testing.',
+  );
+});
+
+test('card radar geometry reserves label padding outside the original viewBox', () => {
+  assert.equal(CARD_RADAR_VIEWBOX, '-55 -24 310 248');
+  const [x, y, width, height] = CARD_RADAR_VIEWBOX.split(/\s+/).map(Number);
+  assert.ok(x < 0 && y < 0);
+  assert.ok(width > 200 && height > 200);
+});
+
+test('player and compare routes wire the bounded Phase 1B presentation layer', () => {
+  const playerHtml = fs.readFileSync(new URL('../cards/rookies/player.html', import.meta.url), 'utf8');
+  const compareView = fs.readFileSync(new URL('../components/rookies/RookieCompareView.js', import.meta.url), 'utf8');
+  const compareRepairs = fs.readFileSync(new URL('../components/rookies/RookieCompareViewPhase1B.js', import.meta.url), 'utf8');
+  const mobileCss = fs.readFileSync(new URL('../components/rookies/phase1bMobileIntegrity.css', import.meta.url), 'utf8');
+
+  assert.match(playerHtml, /phase1bMobileIntegrity\.css/);
+  assert.match(playerHtml, /RookieCardPhase1B\.js/);
+  assert.match(compareView, /applyRookieComparePhase1B/);
+  assert.match(compareRepairs, /Shared track scale: 0–\$\{scaleMaximum\} PPR points/);
+  assert.match(mobileCss, /box-sizing:\s*border-box/);
+  assert.match(mobileCss, /\.compare-3col-table\s*\{[\s\S]*overflow-x:\s*auto/);
+  assert.match(mobileCss, /\.site-nav\s*\{[\s\S]*overflow-x:\s*auto/);
+  assert.match(mobileCss, /\.hero-score\s*\{[\s\S]*width:\s*100%/);
+});

--- a/tests/phase1b-presentation-integrity.test.mjs
+++ b/tests/phase1b-presentation-integrity.test.mjs
@@ -144,12 +144,17 @@ test('card radar geometry reserves label padding outside the original viewBox', 
 
 test('player and compare routes wire the bounded Phase 1B presentation layer', () => {
   const playerHtml = fs.readFileSync(new URL('../cards/rookies/player.html', import.meta.url), 'utf8');
+  const baseCard = fs.readFileSync(new URL('../components/rookies/RookieCard.js', import.meta.url), 'utf8');
+  const phase1bCard = fs.readFileSync(new URL('../components/rookies/RookieCardPhase1B.js', import.meta.url), 'utf8');
   const compareView = fs.readFileSync(new URL('../components/rookies/RookieCompareView.js', import.meta.url), 'utf8');
   const compareRepairs = fs.readFileSync(new URL('../components/rookies/RookieCompareViewPhase1B.js', import.meta.url), 'utf8');
   const mobileCss = fs.readFileSync(new URL('../components/rookies/phase1bMobileIntegrity.css', import.meta.url), 'utf8');
 
   assert.match(playerHtml, /phase1bMobileIntegrity\.css/);
   assert.match(playerHtml, /RookieCardPhase1B\.js/);
+  assert.match(baseCard, /afterRender\?\.\(container, card\)/);
+  assert.match(phase1bCard, /afterRender:\s*applyRookieCardPhase1B/);
+  assert.doesNotMatch(phase1bCard, /renderBaseRookieCard\(container, card\);/);
   assert.match(compareView, /applyRookieComparePhase1B/);
   assert.match(compareRepairs, /Shared track scale: 0–\$\{scaleMaximum\} PPR points/);
   assert.match(compareRepairs, /ATH prior is a neutral model input, not observed athletic testing/);


### PR DESCRIPTION
## Summary

Completes the bounded TIBER-Rookies #280 Phase 1B truth-and-presentation repair on top of merged Phase 1A `main` (`a825431402f89f7ec4fe69e72de073ca4b301ea3`). Current exact head: `84c62806ef5a4bf62cedfb09a718b0b6d67d345b`.

This remains a **draft**. Code and CI are complete; a published non-production preview and true 390px-class iPhone/Safari visual inspection remain separate gates before mark-ready or merge.

## Implemented

### Truth layer

- Classify `NEUTRAL_DEFAULT` as a neutral model prior, displayed as `ATH prior`, never RAS.
- Disclose that the prior contributes to the frozen Rookie Alpha while no observed athletic testing is available.
- Exclude neutral priors from observed-evidence selection and athletic edge claims.
- Make compare verdict language depend on actual shared observed-evidence rows; grade-only leans say so explicitly.
- Clarify the shared radar when a neutral prior is present: `ATH / prior`, accessible neutral-input description, and visible no-observed-testing note.

### Comparison and mobile presentation

- Give both non-stale side-by-side PPR tracks one shared 25-point-rounded maximum.
- Exclude missing and stale projections from scale derivation.
- Show the shared maximum in visible copy and track metadata.
- Add bounded player/compare containment: border-box sizing, minimum-width release, wrapped long-form evidence text, internal scrolling for genuinely wide comparison content, mobile-safe header/footer navigation, and single-column narrow layouts.
- Expand the individual-card radar viewBox so axis labels have explicit padding.
- Replace the old `N/7 metrics available` copy with represented observed-row readiness. `ATH prior` does not count as observed testing; Age-Adjusted Production and BOAR count only when rendered.

### Regression and CI coverage

- Add `tests/phase1b-presentation-integrity.test.mjs` covering:
  - neutral-prior labeling/disclosure and evidence exclusion;
  - grade-only zero-evidence verdict wording;
  - neutral prior not producing an athletic winner;
  - shared PPR scale and stale/missing exclusion;
  - observed-evidence readiness semantics;
  - padded radar geometry;
  - player/compare mobile and presentation wiring.
- Include the Phase 1B regressions in `npm run test:card-disclosure`.
- Add the existing `npm run test:runtime-smoke` command to CI.

## Validation at exact head `84c62806ef5a4bf62cedfb09a718b0b6d67d345b`

GitHub Actions CI run `1134` passed in full:

- Python test suite: passed.
- Promoted 2026 export/manifest validation: passed.
- `npm run test:runtime-smoke`: passed.
- `npm run test:card-disclosure` (canonical disclosure suite plus Phase 1B regressions): passed.

The rerender P1 reported against the prior head is addressed by an exact-head callback seam that reapplies Phase 1B repairs after every internal evidence-family rerender. Independent exact-head code re-review is PASS; the published 390px-class iPhone/Safari preview gate remains pending.

## Remaining gate

The code result is not yet live-device acceptance. Before mark-ready or merge:

1. publish/confirm a non-production preview for this exact head;
2. inspect player and compare routes at a true 390px-class iPhone/Safari viewport;
3. confirm no document-level horizontal overflow, clipped navigation/footer content, radar-label clipping, misleading readiness copy, or mismatched PPR scales;
4. record the published preview result and a separate operator merge decision.

## Authority boundary

- No Rookie Alpha formula or weight changes.
- No governed artifact regeneration or promoted-artifact mutation.
- No narrative/source-policy changes.
- No Phase 1A official-outcome/provenance authority change.
- No Railway settings, variables, database operation, production deployment, mark-ready, or merge.

Tracks #280; closes no issue yet.