### PR TITLE
Remediate 2023 input-integrity candidates

### DIFF
--- a/data/candidate/2023_input_integrity/v0.1.0/college_production_corrections.json
+++ b/data/candidate/2023_input_integrity/v0.1.0/college_production_corrections.json
@@ -1,0 +1,44 @@
+{
+  "artifact": "2023_college_production_corrections_candidate_v0",
+  "schema_version": "tiber-rookies.2023-input-integrity.production-candidate.v0.1.0",
+  "status": "candidate_only",
+  "issue": "Prometheus-Frameworks/TIBER-Rookies#285",
+  "model_facing": false,
+  "promotion_authorized": false,
+  "historical_cutoff": "2023-04-26T23:59:59Z",
+  "source_seed": {
+    "path": "data/processed/2023_college_production.json",
+    "git_commit": "524bc549940926792aff24e4fb109d5e30122697",
+    "sha256": "0960bb72b28a32d1a616b1f73c52e362744910400318b337cb06e9a221b7f9cc"
+  },
+  "records": [
+    {
+      "player_id": "wr-puka-nacua",
+      "player_name": "Puka Nacua",
+      "position": "WR",
+      "school": "BYU",
+      "class_year": 2023,
+      "source_season": 2022,
+      "stat_scope": "single_season_receiving",
+      "games": 9,
+      "receptions": 48,
+      "receiving_yards": 625,
+      "receiving_tds": 5,
+      "rushing_attempts": 25,
+      "rushing_yards": 209,
+      "rushing_tds": 5,
+      "production_score_0_100": null,
+      "production_score_status": "needs_verification",
+      "correction_note": "The archived 1594 yards / 10 TD claim is not a valid 2022 receiving line. Ten matches Nacua's five receiving plus five rushing touchdowns, but 1594 does not reconcile to his 2022 receiving, scrimmage, BYU-career receiving, or full college-career receiving totals. The unlabeled value is therefore unsupported, not relabeled as an aggregate. Re-scoring is outside issue #285.",
+      "source_ref": {
+        "source_name": "BYU Athletics — BYU Football 2022 Season Review",
+        "source_url": "https://byucougars.com/news/2023/01/12/byu-football-2022-season-review",
+        "published_on": "2023-01-11",
+        "source_status": "verified_public_source",
+        "retrieved_on": "2026-08-04",
+        "corroborating_source_name": "cfbstats.com — Puka Nacua 2022 player statistics",
+        "corroborating_source_url": "https://cfbstats.com/2022/player/77/1106480/index.html"
+      }
+    }
+  ]
+}

--- a/data/candidate/2023_input_integrity/v0.1.0/combine_results_corrections.json
+++ b/data/candidate/2023_input_integrity/v0.1.0/combine_results_corrections.json
@@ -1,0 +1,70 @@
+{
+  "artifact": "2023_combine_results_corrections_candidate_v0",
+  "schema_version": "tiber-rookies.2023-input-integrity.combine-candidate.v0.1.0",
+  "status": "candidate_only",
+  "issue": "Prometheus-Frameworks/TIBER-Rookies#285",
+  "model_facing": false,
+  "promotion_authorized": false,
+  "historical_cutoff": "2023-04-26T23:59:59Z",
+  "source_seed": {
+    "path": "data/raw/2023_combine_results.json",
+    "git_commit": "524bc549940926792aff24e4fb109d5e30122697",
+    "sha256": "35cbc98df75767ef9592b64b2e4f8351b2c02af8be4e69c9646b1ee039c2aa9f"
+  },
+  "records": [
+    {
+      "player_id": "wr-puka-nacua",
+      "player_name": "Puka Nacua",
+      "position": "WR",
+      "event_type": "nfl_combine",
+      "event_year": 2023,
+      "height_in": 74,
+      "weight_lb": 201,
+      "testing_status": "attended_no_scored_testing",
+      "forty": null,
+      "vertical": null,
+      "broad": null,
+      "three_cone": null,
+      "shuttle": null,
+      "bench": null,
+      "correction_note": "The source seed mixed non-combine values into an official-combine row. Nacua attended, but a contemporaneous report says he completed no scored drills; the nflverse release contains measurements but no standard athletic-test values. This candidate keeps every scored combine test null.",
+      "source_ref": {
+        "source_name": "nflverse combine public release",
+        "source_url": "https://github.com/nflverse/nflverse-data/releases/download/combine/combine.csv",
+        "source_asset_sha256": "5648886b1bb9de8a0c42b05ee7b1d9cbe58897676caaa2f6a4a3d3c9228235bb",
+        "source_row_identity": "season=2023;player_name=Puka Nacua;pfr_id=NacuPu00",
+        "corroborating_source_url": "https://gephardtdaily.com/sports/10-players-with-utah-ties-among-pro-prospects-invited-to-2023-nfl-scouting-combine/",
+        "corroborating_source_note": "Published 2023-03-06; reports that Nacua attended but did not compete in any scored drills.",
+        "source_status": "verified_public_source",
+        "retrieved_on": "2026-08-04"
+      }
+    },
+    {
+      "player_id": "wr-zay-flowers",
+      "player_name": "Zay Flowers",
+      "position": "WR",
+      "event_type": "nfl_combine",
+      "event_year": 2023,
+      "height_in": 69,
+      "weight_lb": 182,
+      "testing_status": "tested_partial",
+      "forty": 4.42,
+      "vertical": 35.5,
+      "broad": 127,
+      "three_cone": null,
+      "shuttle": null,
+      "bench": null,
+      "correction_note": "The source seed's 41.0-inch vertical and 129-inch broad jump conflict with both the nflverse combine row and the repo SPORQ row. The candidate uses the mutually agreeing 35.5/127 values.",
+      "source_ref": {
+        "source_name": "nflverse combine public release",
+        "source_url": "https://github.com/nflverse/nflverse-data/releases/download/combine/combine.csv",
+        "source_asset_sha256": "5648886b1bb9de8a0c42b05ee7b1d9cbe58897676caaa2f6a4a3d3c9228235bb",
+        "source_row_identity": "season=2023;player_name=Zay Flowers;pfr_id=FlowZa00",
+        "corroborating_repo_path": "data/historical/sporq_historical.json",
+        "corroborating_source_url": "https://www.baltimoreravens.com/news/jaxon-smith-njigba-zay-flowers-jalin-hyatt-wide-receiver-prospects-combine",
+        "source_status": "verified_public_source",
+        "retrieved_on": "2026-08-04"
+      }
+    }
+  ]
+}

--- a/data/candidate/2023_input_integrity/v0.1.0/manifest.json
+++ b/data/candidate/2023_input_integrity/v0.1.0/manifest.json
@@ -1,0 +1,74 @@
+{
+  "artifact": "2023_input_integrity_candidate_manifest_v0",
+  "schema_version": "tiber-rookies.2023-input-integrity-manifest.v0.1.0",
+  "status": "candidate_only",
+  "issue": "Prometheus-Frameworks/TIBER-Rookies#285",
+  "prepared_on": "2026-08-04",
+  "base_git_commit": "524bc549940926792aff24e4fb109d5e30122697",
+  "promotion_authorized": false,
+  "promoted_artifacts_regenerated": false,
+  "scope": "Five confirmed 2023 input-integrity findings only; no full-class rebuild.",
+  "candidate_files": [
+    {
+      "path": "data/candidate/2023_input_integrity/v0.1.0/college_production_corrections.json",
+      "sha256": "abb08f023bbfaccf6fe7d7b7dd5993b37ae7e2c510c479ac0ebdb48e29b332fb"
+    },
+    {
+      "path": "data/candidate/2023_input_integrity/v0.1.0/combine_results_corrections.json",
+      "sha256": "7c656660c8ab6a65b2b301400613139ee43df88bbd16d82171aaa8efecccd063"
+    },
+    {
+      "path": "data/candidate/2023_input_integrity/v0.1.0/nfl_outcome_regular_season_inputs.json",
+      "sha256": "1e704570863cc5e67741d1e791af99a2f392ff9034703388a0576a9f00f426b3"
+    },
+    {
+      "path": "data/candidate/2023_input_integrity/v0.1.0/pro_day_results_candidate.json",
+      "sha256": "11bca71bfb55c04feba4aadd92b825aa1ab0061215644949fcb06ba7bf5974e7"
+    },
+    {
+      "path": "data/candidate/2023_input_integrity/v0.1.0/prospect_context_corrections.json",
+      "sha256": "e06ba66c2637150b96286a1339ea6a0b0620b154900adafc89367e51d7e05b1c"
+    }
+  ],
+  "preserved_source_files": [
+    {
+      "path": "data/raw/2023_combine_results.json",
+      "sha256": "35cbc98df75767ef9592b64b2e4f8351b2c02af8be4e69c9646b1ee039c2aa9f"
+    },
+    {
+      "path": "data/processed/2023_college_production.json",
+      "sha256": "0960bb72b28a32d1a616b1f73c52e362744910400318b337cb06e9a221b7f9cc"
+    },
+    {
+      "path": "data/processed/2023_prospect_context.json",
+      "sha256": "8e2406b690c79c04a7d5d30078d877edf8f6f35fb79d7636a089d66805e8acad"
+    },
+    {
+      "path": "exports/promoted/rookie-alpha/2023_manifest.json",
+      "sha256": "761ae24780aab0a165d7c0027893d75c731f97788e738f44747c4228e8beec8c"
+    },
+    {
+      "path": "exports/promoted/rookie-alpha/2023_rookie_alpha_predraft_v0.csv",
+      "sha256": "51c4cf4a388819a233778cc749f0578e426bdd6bd74ed1ea58748065c8d157fc"
+    },
+    {
+      "path": "exports/promoted/rookie-alpha/2023_rookie_alpha_predraft_v0.json",
+      "sha256": "a37d5ca72409b0c18b1fd28d315d5192068df6702be28b392409e848a06590b6"
+    },
+    {
+      "path": "exports/promoted/nfl-fantasy-outcomes/player_year_ppr_outcomes_v1.csv",
+      "sha256": "0e60c176c421022da8e85c66822b1b86e7e1555a07200d7f108ca4fb1654b279"
+    },
+    {
+      "path": "exports/promoted/nfl-fantasy-outcomes/player_year_ppr_outcomes_v1.json",
+      "sha256": "eaf5044e89738eb0ea7300c1e313f4978d22fa956627bf19c460febec01a6d54"
+    }
+  ],
+  "migration_boundary": {
+    "candidate_overlay_only": true,
+    "original_seed_overwrite_allowed": false,
+    "promoted_export_write_allowed": false,
+    "production_score_recalculation_in_scope": false,
+    "full_2023_class_rebuild_in_scope": false
+  }
+}

--- a/data/candidate/2023_input_integrity/v0.1.0/nfl_outcome_regular_season_inputs.json
+++ b/data/candidate/2023_input_integrity/v0.1.0/nfl_outcome_regular_season_inputs.json
@@ -1,0 +1,101 @@
+{
+  "artifact": "2023_nfl_outcome_regular_season_inputs_candidate_v0",
+  "schema_version": "tiber-rookies.2023-input-integrity.nfl-outcome-input-candidate.v0.1.0",
+  "status": "candidate_only",
+  "issue": "Prometheus-Frameworks/TIBER-Rookies#285",
+  "model_facing": false,
+  "promotion_authorized": false,
+  "scope_note": "Source-input rows for the six 2023-drafted skill players whose promoted rookie-season rows exceed 17 games. This is not a regenerated outcome export and is not full-class coverage.",
+  "source_promoted_artifact_read_only": {
+    "path": "exports/promoted/nfl-fantasy-outcomes/player_year_ppr_outcomes_v1.json",
+    "git_commit": "524bc549940926792aff24e4fb109d5e30122697",
+    "sha256": "eaf5044e89738eb0ea7300c1e313f4978d22fa956627bf19c460febec01a6d54"
+  },
+  "source_ref": {
+    "source_name": "nflverse stats_player regular-season public release",
+    "source_url": "https://github.com/nflverse/nflverse-data/releases/download/stats_player/stats_player_reg_2023.csv.gz",
+    "source_asset_sha256": "3bd9d361c060612a36f13a282e13effe633689b1fabac35c6c5b28dfc7283c60",
+    "source_status": "verified_public_source",
+    "retrieved_on": "2026-08-04"
+  },
+  "records": [
+    {
+      "player_id": "00-0039052",
+      "player_name": "T.Palmer",
+      "position": "WR",
+      "season": 2023,
+      "season_type": "REG",
+      "games": 17,
+      "receptions": 39,
+      "receiving_yards": 385,
+      "receiving_tds": 3,
+      "rushing_yards": 22,
+      "rushing_tds": 0
+    },
+    {
+      "player_id": "00-0039064",
+      "player_name": "Z.Flowers",
+      "position": "WR",
+      "season": 2023,
+      "season_type": "REG",
+      "games": 16,
+      "receptions": 77,
+      "receiving_yards": 858,
+      "receiving_tds": 5,
+      "rushing_yards": 56,
+      "rushing_tds": 1
+    },
+    {
+      "player_id": "00-0039065",
+      "player_name": "S.LaPorta",
+      "position": "TE",
+      "season": 2023,
+      "season_type": "REG",
+      "games": 17,
+      "receptions": 86,
+      "receiving_yards": 889,
+      "receiving_tds": 10,
+      "rushing_yards": 4,
+      "rushing_tds": 0
+    },
+    {
+      "player_id": "00-0039067",
+      "player_name": "R.Rice",
+      "position": "WR",
+      "season": 2023,
+      "season_type": "REG",
+      "games": 16,
+      "receptions": 79,
+      "receiving_yards": 938,
+      "receiving_tds": 7,
+      "rushing_yards": -3,
+      "rushing_tds": 0
+    },
+    {
+      "player_id": "00-0039075",
+      "player_name": "P.Nacua",
+      "position": "WR",
+      "season": 2023,
+      "season_type": "REG",
+      "games": 17,
+      "receptions": 105,
+      "receiving_yards": 1486,
+      "receiving_tds": 6,
+      "rushing_yards": 89,
+      "rushing_tds": 0
+    },
+    {
+      "player_id": "00-0039139",
+      "player_name": "J.Gibbs",
+      "position": "RB",
+      "season": 2023,
+      "season_type": "REG",
+      "games": 15,
+      "receptions": 52,
+      "receiving_yards": 316,
+      "receiving_tds": 1,
+      "rushing_yards": 945,
+      "rushing_tds": 10
+    }
+  ]
+}

--- a/data/candidate/2023_input_integrity/v0.1.0/pro_day_results_candidate.json
+++ b/data/candidate/2023_input_integrity/v0.1.0/pro_day_results_candidate.json
@@ -1,0 +1,36 @@
+{
+  "artifact": "2023_pro_day_results_candidate_v0",
+  "schema_version": "tiber-rookies.2023-input-integrity.pro-day-candidate.v0.1.0",
+  "status": "candidate_only",
+  "issue": "Prometheus-Frameworks/TIBER-Rookies#285",
+  "model_facing": false,
+  "promotion_authorized": false,
+  "historical_cutoff": "2023-04-26T23:59:59Z",
+  "records": [
+    {
+      "player_id": "wr-puka-nacua",
+      "player_name": "Puka Nacua",
+      "position": "WR",
+      "event_type": "pro_day",
+      "event_date": "2023-03-24",
+      "measurement_status": "public_report_unofficial_timing",
+      "height_in": 73.25,
+      "weight_lb": 206,
+      "forty": 4.55,
+      "vertical": 33.0,
+      "broad": 121,
+      "three_cone": 7.3,
+      "shuttle": 4.36,
+      "bench": 15,
+      "candidate_note": "Kept in a separate pro-day candidate so these numbers can never be labeled as combine testing. The archived seed's 4.57/36.5/122 line does not match this single published pro-day result set and is not reclassified wholesale.",
+      "source_ref": {
+        "source_name": "KSL Sports — BYU Pro Day 2023 results",
+        "source_url": "https://sports.ksl.com/ncaa/byu/byu-pro-day-2023-jaren-hall-puka-nacua-results-nfl-draft/499843",
+        "published_on": "2023-03-24",
+        "source_status": "verified_public_source",
+        "official_event_confirmation_url": "https://byucougars.com/news/2023/03/24/hayes-brooks-highlight-byus-2023-nfl-pro-day",
+        "retrieved_on": "2026-08-04"
+      }
+    }
+  ]
+}

--- a/data/candidate/2023_input_integrity/v0.1.0/prospect_context_corrections.json
+++ b/data/candidate/2023_input_integrity/v0.1.0/prospect_context_corrections.json
@@ -1,0 +1,73 @@
+{
+  "artifact": "2023_prospect_context_corrections_candidate_v0",
+  "schema_version": "tiber-rookies.2023-input-integrity.context-candidate.v0.1.0",
+  "status": "candidate_only",
+  "issue": "Prometheus-Frameworks/TIBER-Rookies#285",
+  "model_facing": false,
+  "promotion_authorized": false,
+  "historical_cutoff": "2023-04-26T23:59:59Z",
+  "source_seed": {
+    "path": "data/processed/2023_prospect_context.json",
+    "git_commit": "524bc549940926792aff24e4fb109d5e30122697",
+    "sha256": "8e2406b690c79c04a7d5d30078d877edf8f6f35fb79d7636a089d66805e8acad"
+  },
+  "records": [
+    {
+      "player_id": "wr-puka-nacua",
+      "player_name": "Puka Nacua",
+      "position": "WR",
+      "school": "BYU",
+      "class_year": 2023,
+      "legacy_evidence_summary_action": "replace_entire_value",
+      "candidate_evidence_facts": {
+        "source_season": 2022,
+        "stat_scope": "single_season_receiving_and_rushing_components",
+        "games": 9,
+        "receptions": 48,
+        "receiving_yards": 625,
+        "receiving_tds": 5,
+        "rushing_attempts": 25,
+        "rushing_yards": 209,
+        "rushing_tds": 5
+      },
+      "candidate_evidence_summary": "BYU senior wide receiver; in nine games in 2022, 48 receptions for 625 yards and five receiving touchdowns, plus 25 carries for 209 yards and five rushing touchdowns.",
+      "correction_note": "The legacy evidence summary repeats the unsupported 1,594-yard aggregate and includes draft capital and NFL rookie production that occurred after the historical cutoff. The candidate replaces the entire summary with explicitly scoped, cutoff-safe 2022 facts.",
+      "source_ref": {
+        "source_name": "BYU Athletics — BYU Football 2022 Season Review",
+        "source_url": "https://byucougars.com/news/2023/01/12/byu-football-2022-season-review",
+        "published_on": "2023-01-11",
+        "source_status": "verified_public_source",
+        "retrieved_on": "2026-08-04"
+      }
+    },
+    {
+      "player_id": "wr-zay-flowers",
+      "player_name": "Zay Flowers",
+      "position": "WR",
+      "school": "Boston College",
+      "class_year": 2023,
+      "class_standing": "senior",
+      "college_seasons_played": [
+        2019,
+        2020,
+        2021,
+        2022
+      ],
+      "early_declare_flag": false,
+      "evidence_tags_remove": [
+        "early_declare"
+      ],
+      "candidate_evidence_summary": "Boston College senior wide receiver; 78 receptions, 1,077 receiving yards, and 12 receiving touchdowns in 2022.",
+      "correction_note": "Boston College identified Flowers as a senior throughout the 2022 season. A four-season senior is not an early declare under this candidate's class-year semantics.",
+      "source_ref": {
+        "source_name": "Boston College Athletics — Flowers Picks Up AP All-America Honor",
+        "source_url": "https://bceagles.com/news/2022/12/12/football-flowers-picks-up-ap-all-america-honor",
+        "published_on": "2022-12-12",
+        "source_status": "verified_public_source",
+        "corroborating_source_name": "Boston College Athletics — Flowers Tabbed Season Golden Helmet Winner",
+        "corroborating_source_url": "https://bceagles.com/news/2022/11/28/football-flowers-tabbed-season-golden-helmet-winner",
+        "retrieved_on": "2026-08-04"
+      }
+    }
+  ]
+}

--- a/data/fixtures/archived/2023_input_integrity/README.md
+++ b/data/fixtures/archived/2023_input_integrity/README.md
@@ -1,0 +1,14 @@
+# Archived 2023 contaminated seed rows
+
+This directory preserves the exact defect-bearing rows identified by
+[TIBER-Rookies #285](https://github.com/Prometheus-Frameworks/TIBER-Rookies/issues/285).
+They are fixtures of what previously ran, not facts to consume.
+
+The complete seed files remain byte-for-byte unchanged at their original
+paths. `contaminated_seed_rows_v0.json` copies only the rows implicated by the
+five confirmed findings and pins the source commit and file hashes. Candidate
+corrections live separately under
+`data/candidate/2023_input_integrity/v0.1.0/`.
+
+Do not use these archived rows for scoring, reconstruction, regeneration, or
+promotion. Their purpose is correction lineage and regression evidence.

--- a/data/fixtures/archived/2023_input_integrity/contaminated_seed_rows_v0.json
+++ b/data/fixtures/archived/2023_input_integrity/contaminated_seed_rows_v0.json
@@ -1,0 +1,117 @@
+{
+  "artifact": "archived_contaminated_2023_seed_rows_v0",
+  "status": "archived_fixture_non_authoritative",
+  "issue": "Prometheus-Frameworks/TIBER-Rookies#285",
+  "archived_on": "2026-08-04",
+  "source_git_commit": "524bc549940926792aff24e4fb109d5e30122697",
+  "lineage_note": "Exact copies of the defect-bearing rows as they existed when prior promoted artifacts were produced. The complete source files remain untouched at their original paths; this fixture makes the correction lineage reviewable without treating contaminated values as current truth.",
+  "must_not_be_used_for": [
+    "model_input",
+    "artifact_regeneration",
+    "fact_source",
+    "promotion"
+  ],
+  "source_files": [
+    {
+      "path": "data/raw/2023_combine_results.json",
+      "sha256": "35cbc98df75767ef9592b64b2e4f8351b2c02af8be4e69c9646b1ee039c2aa9f"
+    },
+    {
+      "path": "data/processed/2023_college_production.json",
+      "sha256": "0960bb72b28a32d1a616b1f73c52e362744910400318b337cb06e9a221b7f9cc"
+    },
+    {
+      "path": "data/processed/2023_prospect_context.json",
+      "sha256": "8e2406b690c79c04a7d5d30078d877edf8f6f35fb79d7636a089d66805e8acad"
+    }
+  ],
+  "archived_rows": {
+    "combine_results": [
+      {
+        "player_id": "wr-zay-flowers",
+        "player_name": "Zay Flowers",
+        "position": "WR",
+        "height_in": 68,
+        "weight_lb": 182,
+        "forty": 4.42,
+        "forty_source": "NFL combine 2023 (official)",
+        "vertical": 41.0,
+        "broad": 129,
+        "three_cone": null,
+        "three_cone_source": null,
+        "ras_source": "nfl_combine_2023"
+      },
+      {
+        "player_id": "wr-puka-nacua",
+        "player_name": "Puka Nacua",
+        "position": "WR",
+        "height_in": 72,
+        "weight_lb": 205,
+        "forty": 4.57,
+        "forty_source": "NFL combine 2023 (official)",
+        "vertical": 36.5,
+        "broad": 122,
+        "three_cone": null,
+        "three_cone_source": null,
+        "ras_source": "nfl_combine_2023"
+      }
+    ],
+    "college_production": [
+      {
+        "player_id": "wr-puka-nacua",
+        "player_name": "Puka Nacua",
+        "position": "WR",
+        "school": "BYU",
+        "class_year": 2023,
+        "production_score_0_100": 62.0,
+        "production_score_source": "manual_historical_seed (2022: 1594 yds/10 TDs BYU; senior BOA 22; non-P4; high volume but conference discount; elite efficiency archetype — 105 catches NFL rookie year as R5 pick)"
+      }
+    ],
+    "prospect_context": [
+      {
+        "player_id": "wr-puka-nacua",
+        "player_name": "Puka Nacua",
+        "position": "WR",
+        "school": "BYU",
+        "class_year": 2023,
+        "historical_anchor_flag": false,
+        "early_declare_flag": false,
+        "breakout_age": 22,
+        "age_at_first_impact_season": 22,
+        "young_breakout_flag": false,
+        "career_yards_per_route_run": 2.65,
+        "best_season_yprr": 2.65,
+        "evidence_tags": [
+          "elite_efficiency_tier",
+          "multi_season_efficiency",
+          "inside_out_versatility"
+        ],
+        "context_flags": [],
+        "evidence_summary": "Pick #177 to Rams (R5). BYU WR — 1594 yds/10 TDs in 2022. Senior; non-P4; BOA 22 all work against him in this model. But: elite YPRR (2.65), 105 catches as NFL rookie — the extreme late-round efficiency calibration anchor. Model will score him low due to capital + age; that tension is the point.",
+        "context_source": "manual_historical_seed_2023",
+        "exceptional_metrics": []
+      },
+      {
+        "player_id": "wr-zay-flowers",
+        "player_name": "Zay Flowers",
+        "position": "WR",
+        "school": "Boston College",
+        "class_year": 2023,
+        "historical_anchor_flag": false,
+        "early_declare_flag": true,
+        "breakout_age": 21,
+        "age_at_first_impact_season": 21,
+        "young_breakout_flag": false,
+        "evidence_tags": [
+          "early_declare",
+          "elite_efficiency_tier",
+          "yac_signal"
+        ],
+        "context_flags": [],
+        "evidence_summary": "Pick #22 to Baltimore. BC WR — 78 rec/1077 yds/12 TDs in 2022 (ACC non-P4 elite). Elite YPRR efficiency. Non-P4 conference discount on production score. Pro Bowl 2023 (first year). Validates that production quality > conference prestige.",
+        "context_source": "manual_historical_seed_2023",
+        "exceptional_metrics": []
+      }
+    ]
+  }
+}

--- a/docs/audits/2023-input-integrity-remediation.json
+++ b/docs/audits/2023-input-integrity-remediation.json
@@ -1,0 +1,221 @@
+{
+  "artifact": "2023_input_integrity_source_audit_v0",
+  "issue": "Prometheus-Frameworks/TIBER-Rookies#285",
+  "audit_date": "2026-08-04",
+  "base_git_commit": "524bc549940926792aff24e4fb109d5e30122697",
+  "status": "candidate_remediation_prepared_operator_review_required",
+  "findings": [
+    {
+      "finding_id": "2023-INPUT-001",
+      "subject": "Puka Nacua combine/pro-day conflation",
+      "status": "confirmed",
+      "legacy_path": "data/raw/2023_combine_results.json",
+      "legacy_claim": {
+        "event_type": "NFL combine 2023 (official)",
+        "height_in": 72,
+        "weight_lb": 205,
+        "forty": 4.57,
+        "vertical": 36.5,
+        "broad": 122
+      },
+      "verified_result": {
+        "combine_height_in": 74,
+        "combine_weight_lb": 201,
+        "combine_testing_status": "attended_no_scored_testing",
+        "combine_forty": null,
+        "combine_vertical": null,
+        "combine_broad": null,
+        "separate_pro_day_public_report": {
+          "forty": 4.55,
+          "vertical": 33.0,
+          "broad": 121,
+          "measurement_status": "public_report_unofficial_timing"
+        }
+      },
+      "conclusion": "The legacy tuple is neither an official combine line nor one coherent verified 2023 pro-day line. The 4.57 forty and 36.5 vertical also match an ESPN Class-of-2019 recruiting-combine profile, which is a strong cross-year-conflation clue but not proven lineage because the seed cites no URL and its 122 broad is absent there. Combine tests are null in the candidate; sourced pro-day values remain in a separate candidate artifact.",
+      "sources": [
+        "https://github.com/nflverse/nflverse-data/releases/download/combine/combine.csv",
+        "data/historical/sporq_historical.json",
+        "https://gephardtdaily.com/sports/10-players-with-utah-ties-among-pro-prospects-invited-to-2023-nfl-scouting-combine/",
+        "https://sports.ksl.com/ncaa/byu/byu-pro-day-2023-jaren-hall-puka-nacua-results-nfl-draft/499843",
+        "https://byucougars.com/news/2023/03/24/hayes-brooks-highlight-byus-2023-nfl-pro-day",
+        "https://www.espn.com/college-sports/football/recruiting/player/combine/_/id/227660/puka-nacua/1000"
+      ],
+      "candidate_paths": [
+        "data/candidate/2023_input_integrity/v0.1.0/combine_results_corrections.json",
+        "data/candidate/2023_input_integrity/v0.1.0/pro_day_results_candidate.json"
+      ]
+    },
+    {
+      "finding_id": "2023-INPUT-002",
+      "subject": "Zay Flowers combine vertical/broad conflict",
+      "status": "confirmed",
+      "legacy_path": "data/raw/2023_combine_results.json",
+      "legacy_claim": {
+        "height_in": 68,
+        "vertical": 41.0,
+        "broad": 129
+      },
+      "verified_result": {
+        "height_in": 69,
+        "weight_lb": 182,
+        "forty": 4.42,
+        "vertical": 35.5,
+        "broad": 127
+      },
+      "conclusion": "nflverse and the repo SPORQ row agree on 35.5/127 and a 69-inch height. The candidate adopts the agreeing values.",
+      "sources": [
+        "https://github.com/nflverse/nflverse-data/releases/download/combine/combine.csv",
+        "https://www.baltimoreravens.com/news/jaxon-smith-njigba-zay-flowers-jalin-hyatt-wide-receiver-prospects-combine",
+        "data/historical/sporq_historical.json"
+      ],
+      "candidate_paths": [
+        "data/candidate/2023_input_integrity/v0.1.0/combine_results_corrections.json"
+      ]
+    },
+    {
+      "finding_id": "2023-INPUT-003",
+      "subject": "Puka Nacua 2022 production scope ambiguity",
+      "status": "confirmed_unreconciled_aggregate",
+      "legacy_path": "data/processed/2023_college_production.json",
+      "additional_legacy_path": "data/processed/2023_prospect_context.json",
+      "legacy_claim": "2022: 1594 yds/10 TDs BYU",
+      "verified_result": {
+        "stat_scope": "single_season_receiving",
+        "season": 2022,
+        "games": 9,
+        "receptions": 48,
+        "receiving_yards": 625,
+        "receiving_tds": 5,
+        "rushing_attempts": 25,
+        "rushing_yards": 209,
+        "rushing_tds": 5,
+        "all_purpose_yards": 834,
+        "total_touchdowns": 10
+      },
+      "conclusion": "Ten can be explained only as receiving plus rushing touchdowns. The 1,594-yard value matches no named official 2022 or career aggregate checked, so it remains unsupported rather than being relabeled. The same claim appears in Puka's prospect-context summary together with post-cutoff draft capital and rookie production. The contaminated production score is null pending separately authorized re-scoring, and the candidate context replaces the entire hindsight-bearing summary.",
+      "sources": [
+        "https://byucougars.com/news/2023/01/12/byu-football-2022-season-review",
+        "https://cfbstats.com/2022/player/77/1106480/index.html",
+        "https://byucougars.com/sports/football/roster/player/puka-nacua"
+      ],
+      "candidate_paths": [
+        "data/candidate/2023_input_integrity/v0.1.0/college_production_corrections.json",
+        "data/candidate/2023_input_integrity/v0.1.0/prospect_context_corrections.json"
+      ]
+    },
+    {
+      "finding_id": "2023-INPUT-004",
+      "subject": "Zay Flowers early-declare classification",
+      "status": "confirmed_under_candidate_semantics",
+      "legacy_path": "data/processed/2023_prospect_context.json",
+      "legacy_claim": {
+        "early_declare_flag": true,
+        "evidence_tag": "early_declare"
+      },
+      "verified_result": {
+        "class_standing": "senior",
+        "college_seasons_played": [
+          2019,
+          2020,
+          2021,
+          2022
+        ],
+        "early_declare_flag": false
+      },
+      "semantics_note": "Candidate semantics define early declare as entering before the player's senior/fourth played season. COVID-era remaining eligibility does not turn a completed senior season into an early declare.",
+      "sources": [
+        "https://bceagles.com/news/2022/12/12/football-flowers-picks-up-ap-all-america-honor",
+        "https://bceagles.com/news/2022/11/28/football-flowers-tabbed-season-golden-helmet-winner"
+      ],
+      "candidate_paths": [
+        "data/candidate/2023_input_integrity/v0.1.0/prospect_context_corrections.json"
+      ]
+    },
+    {
+      "finding_id": "2023-INPUT-005",
+      "subject": "NFL regular/postseason outcome mixing",
+      "status": "confirmed",
+      "legacy_path": "exports/promoted/nfl-fantasy-outcomes/player_year_ppr_outcomes_v1.json",
+      "root_cause": "The legacy weekly nflverse input carries season_type, but build_player_outcome_rows previously aggregated every weekly row before distinguishing REG from POST.",
+      "minimum_confirmed_impact": {
+        "nfl_season_2023_rows_with_games_over_17": 35,
+        "draft_class_2023_rookie_rows_with_games_over_17": 6,
+        "draft_class_2023_rookie_players": [
+          "J.Gibbs",
+          "P.Nacua",
+          "R.Rice",
+          "S.LaPorta",
+          "T.Palmer",
+          "Z.Flowers"
+        ],
+        "current_release_draft_class_2023_reg_post_mixed_player_seasons_2023_2024": 31,
+        "current_release_draft_class_2023_player_seasons_2023_2024": 132,
+        "current_release_mixed_share_percent": 23.5,
+        "current_release_input_sha256": "01a8db3ce4f576c51fc46ee329d789b3141d83e81a02323ef49f9744c1e1012e",
+        "current_release_method_note": "Reproduced from the current nflverse legacy player_stats release by filtering to draft_year=2023 identities and seasons 2023-2024. All 31 emitted games and five builder-consumed receiving/rushing fields exactly match current-release REG+POST aggregation; none match REG-only.",
+        "historical_source_version_lineage": "needs_verification because the emitted artifact cites a mutable local download path without source asset hash or release timestamp"
+      },
+      "verified_examples": {
+        "P.Nacua": {
+          "legacy_mixed": "18 games; 114 receptions; 1667 receiving yards; 7 receiving TD",
+          "regular_season_source": "17 games; 105 receptions; 1486 receiving yards; 6 receiving TD"
+        },
+        "Z.Flowers": {
+          "legacy_mixed": "18 games; 86 receptions; 1014 receiving yards; 6 receiving TD",
+          "regular_season_source": "16 games; 77 receptions; 858 receiving yards; 5 receiving TD"
+        }
+      },
+      "conclusion": "Builder input filtering now retains REG, excludes POST, and rejects weekly rows whose season type is absent or unknown. Weekly-mode games remain stat-participation weeks rather than authoritative appearance counts; that separate semantic gap is explicit and unresolved. The promoted outcome artifact remains untouched.",
+      "sources": [
+        "https://github.com/nflverse/nflverse-data/releases/download/player_stats/player_stats.csv.gz",
+        "https://github.com/nflverse/nflverse-data/releases/download/stats_player/stats_player_reg_2023.csv.gz",
+        "scripts/build_nfl_fantasy_outcomes.py"
+      ],
+      "candidate_paths": [
+        "data/candidate/2023_input_integrity/v0.1.0/nfl_outcome_regular_season_inputs.json"
+      ]
+    }
+  ],
+  "affected_artifacts": [
+    {
+      "paths": [
+        "exports/promoted/rookie-alpha/2023_manifest.json",
+        "exports/promoted/rookie-alpha/2023_rookie_alpha_predraft_v0.json",
+        "exports/promoted/rookie-alpha/2023_rookie_alpha_predraft_v0.csv"
+      ],
+      "relationship": "directly built from the contaminated 2023 seed inputs",
+      "action_in_this_change": "preserved_unchanged"
+    },
+    {
+      "paths": [
+        "exports/promoted/rookie-alpha/historical_class_comparison.json",
+        "exports/promoted/rookie-alpha/historical_class_comparison.csv"
+      ],
+      "relationship": "downstream rollup includes the promoted 2023 Rookie Alpha rows",
+      "action_in_this_change": "preserved_unchanged"
+    },
+    {
+      "paths": [
+        "exports/promoted/nfl-fantasy-outcomes/player_year_ppr_outcomes_v1.json",
+        "exports/promoted/nfl-fantasy-outcomes/player_year_ppr_outcomes_v1.csv",
+        "exports/promoted/nfl-fantasy-outcomes/context_flag_outcome_summary_v1.json",
+        "exports/promoted/nfl-fantasy-outcomes/context_flag_outcome_summary_v1.csv"
+      ],
+      "relationship": "direct REG/POST contamination and downstream cohort summary",
+      "action_in_this_change": "preserved_unchanged"
+    },
+    {
+      "paths": [
+        "exports/promoted/rookie-ml-lane/*"
+      ],
+      "relationship": "potential consumer of historical deterministic scores/outcomes; model disposition is parked in issue #286",
+      "action_in_this_change": "not_evaluated_or_modified"
+    }
+  ],
+  "recommendation": {
+    "decision": "historical_2023_promoted_artifact_deprecation_requires_operator_decision",
+    "reason": "The existing promoted files are immutable evidence of prior runs but no longer support an unqualified clean-historical-input claim. An operator should choose limitation record, deprecation, or separately authorized supersession after candidate review.",
+    "promotion_or_deprecation_performed": false
+  }
+}

--- a/docs/audits/2023-input-integrity-remediation.md
+++ b/docs/audits/2023-input-integrity-remediation.md
@@ -1,0 +1,193 @@
+# 2023 input-integrity remediation audit
+
+Issue: [TIBER-Rookies #285](https://github.com/Prometheus-Frameworks/TIBER-Rookies/issues/285)  
+Base: `524bc549940926792aff24e4fb109d5e30122697`  
+Posture: candidate-only; operator review required
+
+## Result
+
+All five reported defects are confirmed. The contaminated source rows remain
+byte-for-byte unchanged and are copied into a non-authoritative archive
+fixture. Corrections are isolated under
+`data/candidate/2023_input_integrity/v0.1.0/`; nothing in
+`exports/promoted/**` was regenerated.
+
+The appropriate handoff decision is:
+
+```text
+historical_2023_promoted_artifact_deprecation_requires_operator_decision
+```
+
+That is a recommendation for review, not a deprecation or promotion action.
+
+## Defect-by-defect source audit
+
+### 1. Puka Nacua combine/pro-day conflation — confirmed
+
+The legacy combine row claims official testing at 4.57 / 36.5 / 122 with a
+72-inch, 205-pound measurement. The [nflverse combine release](https://github.com/nflverse/nflverse-data/releases/download/combine/combine.csv)
+instead records Puka at 6-2, 201 with every athletic test blank; the repo's
+SPORQ row also records all tests null and `dnq: true`.
+[Contemporaneous reporting](https://gephardtdaily.com/sports/10-players-with-utah-ties-among-pro-prospects-invited-to-2023-nfl-scouting-combine/)
+states that he attended but did not compete in any scored drills. The
+candidate therefore uses `attended_no_scored_testing`, not a broader claim
+that he performed no combine activity.
+
+Puka did test at BYU's March 24 pro day, but the published 2023 line is
+different: KSL reported a 4.55 forty, 33-inch vertical, 10-foot-1/121-inch
+broad jump, 7.30 three-cone, 4.36 shuttle, and 15 bench reps. BYU confirms the
+event and Puka's participation. Sources:
+[KSL results](https://sports.ksl.com/ncaa/byu/byu-pro-day-2023-jaren-hall-puka-nacua-results-nfl-draft/499843),
+[BYU event report](https://byucougars.com/news/2023/03/24/hayes-brooks-highlight-byus-2023-nfl-pro-day).
+
+The seed's 4.57 forty and 36.5 vertical also match an
+[ESPN Class-of-2019 recruiting-combine profile](https://www.espn.com/college-sports/football/recruiting/player/combine/_/id/227660/puka-nacua/1000).
+That is a strong cross-year-conflation clue, not proven lineage: the seed has
+no URL, and its 122-inch broad jump is not part of the ESPN result.
+
+Conclusion: the legacy tuple is not one coherent 2023 event record. The
+combine candidate keeps all Puka tests null. A separate, explicitly
+unofficial-timing pro-day candidate carries the sourced KSL line; no pro-day
+number is relabeled as combine testing.
+
+### 2. Zay Flowers vertical/broad conflict — confirmed
+
+The seed says 41.0-inch vertical / 129-inch broad and lists his height as 68
+inches. Both the nflverse combine release and
+`data/historical/sporq_historical.json` give 35.5 / 127 and 69 inches at 182
+pounds. A [Baltimore Ravens combine recap](https://www.baltimoreravens.com/news/jaxon-smith-njigba-zay-flowers-jalin-hyatt-wide-receiver-prospects-combine)
+published before the draft corroborates 35.5 and 10-foot-7/127. The candidate
+uses the agreeing result and retains the 4.42 forty.
+
+### 3. Puka 2022 production ambiguity — confirmed and unreconciled
+
+The college-production seed presents `1594 yds / 10 TDs` as a 2022 line. The
+same unsupported aggregate appears in Puka's prospect-context summary alongside
+post-cutoff draft capital and NFL rookie production. The verified 2022
+receiving line is 48 receptions, 625 yards, and five touchdowns. He also had
+25 carries for 209 yards and five rushing touchdowns in nine games.
+[BYU's January 2023 season review](https://byucougars.com/news/2023/01/12/byu-football-2022-season-review)
+labels the year as 834 all-purpose yards and 10 total touchdowns;
+[cfbstats](https://cfbstats.com/2022/player/77/1106480/index.html) provides the
+same component receiving/rushing lines.
+
+Ten is therefore explainable only after combining receiving and rushing
+touchdowns. `1594` matches none of the checked 2022 receiving, scrimmage,
+all-purpose, BYU-career receiving, or full college-career receiving scopes.
+It is not silently relabeled. The candidate stores granular 2022 facts with
+`stat_scope: single_season_receiving` and leaves
+`production_score_0_100: null` / `needs_verification`; re-scoring is outside
+this issue. The context candidate replaces the entire contaminated summary
+with the same cutoff-safe, explicitly scoped components; it does not preserve
+the draft or rookie hindsight.
+
+### 4. Zay Flowers early-declare flag — confirmed under explicit semantics
+
+Boston College called Flowers a senior during and after the 2022 season:
+[AP All-America release](https://bceagles.com/news/2022/12/12/football-flowers-picks-up-ap-all-america-honor),
+[Golden Helmet release](https://bceagles.com/news/2022/11/28/football-flowers-tabbed-season-golden-helmet-winner).
+He played 2019, 2020, 2021, and 2022.
+
+Candidate semantics define an early declare as entry before the player's
+senior/fourth played season. COVID-era remaining eligibility does not turn a
+completed senior season into an early declare. The candidate sets the flag
+false and explicitly removes the stale `early_declare` evidence tag. It also
+uses a cutoff-safe summary rather than copying the legacy row's post-draft
+Pro Bowl hindsight.
+
+### 5. REG/POST mixing — confirmed
+
+The legacy weekly nflverse path aggregated rows without applying its
+`season_type` field. That reproduces exact regular-plus-postseason totals:
+
+| Player | Promoted mixed row | Regular-season source |
+|---|---|---|
+| Puka Nacua | 18 G, 114-1,667-7 | 17 G, 105-1,486-6 |
+| Zay Flowers | 18 G, 86-1,014-6 | 16 G, 77-858-5 |
+
+The promoted JSON contains 35 NFL-season-2023 rows with more than 17 games;
+six are 2023-drafted skill players (Gibbs, Nacua, Rice, LaPorta, Palmer,
+Flowers). This is a minimum visible count, not a claim that only those rows
+are affected: postseason mixing can also contaminate a player who missed
+regular-season games without pushing `games` above 17.
+
+Replaying the current
+[nflverse legacy release](https://github.com/nflverse/nflverse-data/releases/download/player_stats/player_stats.csv.gz)
+(retrieved 2026-08-04; SHA-256
+`01a8db3ce4f576c51fc46ee329d789b3141d83e81a02323ef49f9744c1e1012e`)
+finds 31 of 132 draft-class-2023 player-seasons in 2023-2024 (23.5%) with
+positive postseason receiving/rushing fields.
+For all 31, the emitted games and five builder-consumed receiving/rushing
+fields exactly match the old algorithm's current-release REG+POST aggregation,
+and none match REG-only. This is a reproducible current-release blast radius,
+not cryptographic proof of the historical input release: the promoted artifact
+cites a mutable local download path but records no source asset hash or release
+timestamp. Historical source-version lineage therefore remains
+`needs_verification`.
+
+Separate from REG/POST mixing, weekly-mode `games` counts stat-participation
+weeks, not an authoritative games-played field. The season filter fixes playoff
+inflation but does not prove complete appearance counts for zero-touch games;
+that semantic gap remains explicit and outside this candidate correction.
+
+The builder now filters weekly rows to `REG` before aggregation, excludes
+`POST`, and fails closed when weekly season type is missing or unknown. The
+six obvious rookie rows are copied from the
+[nflverse regular-season 2023 source](https://github.com/nflverse/nflverse-data/releases/download/stats_player/stats_player_reg_2023.csv.gz)
+as candidate inputs only. No promoted outcome was regenerated.
+
+## Correction lineage and migration boundary
+
+- Archived defect rows:
+  `data/fixtures/archived/2023_input_integrity/contaminated_seed_rows_v0.json`
+- Candidate manifest:
+  `data/candidate/2023_input_integrity/v0.1.0/manifest.json`
+- Machine-readable audit:
+  `docs/audits/2023-input-integrity-remediation.json`
+- Candidate validator:
+  `scripts/validate_2023_input_integrity.py`
+
+The manifest pins all candidate files plus the untouched source/promoted
+files. Candidate files are overlays for review, not drop-in governed inputs.
+They cannot be promoted or used to overwrite the existing seeds under this
+authority.
+
+## Affected-artifact inventory
+
+| Artifact family | Relationship | This PR |
+|---|---|---|
+| `exports/promoted/rookie-alpha/2023_*` | Directly built from the contaminated combine, production, and context seeds | Unchanged |
+| `exports/promoted/rookie-alpha/historical_class_comparison.*` | Includes promoted 2023 Rookie Alpha rows | Unchanged |
+| `exports/promoted/nfl-fantasy-outcomes/player_year_ppr_outcomes_v1.*` | Direct REG/POST contamination | Unchanged |
+| `exports/promoted/nfl-fantasy-outcomes/context_flag_outcome_summary_v1.*` | Downstream outcome summary | Unchanged |
+| `exports/promoted/rookie-ml-lane/*` | Potential consumer of historical scores/outcomes; disposition belongs to parked #286 | Not evaluated or modified |
+
+## Regression gates
+
+`tests/test_validate_2023_input_integrity.py` rejects:
+
+1. combine/pro-day conflation;
+2. aggregate college stats without explicit season/scope semantics;
+3. four-season class-year rows marked early declare;
+4. any `POST` row in the regular-season candidate input.
+
+`tests/test_build_nfl_fantasy_outcomes.py` additionally proves the builder
+excludes postseason rows and refuses ambiguous weekly inputs.
+
+Run:
+
+```bash
+python3 scripts/validate_2023_input_integrity.py
+python3 -m unittest tests.test_validate_2023_input_integrity tests.test_build_nfl_fantasy_outcomes -v
+python3 scripts/validate_promoted_export.py \
+  --export-json exports/promoted/rookie-alpha/2023_rookie_alpha_predraft_v0.json \
+  --manifest exports/promoted/rookie-alpha/2023_manifest.json
+```
+
+## Promotion/deprecation recommendation
+
+Do not overwrite the old seeds or repair promoted files in place. Preserve
+them as the record of prior runs. After operator review, the clean options
+are an explicit limitation/deprecation record or a separately authorized,
+versioned superseding artifact built from reviewed candidates. Model-lane
+disposition remains parked in #286.

--- a/scripts/build_nfl_fantasy_outcomes.py
+++ b/scripts/build_nfl_fantasy_outcomes.py
@@ -40,8 +40,11 @@ NFLVERSE_DRAFT_PICKS_URL = (
 )
 
 POSITIONS = {"WR", "RB", "TE", "QB"}
-WEEKLY_MODE_COLUMNS = {"week", "game_id", "recent_team", "opponent_team"}
+WEEKLY_MODE_COLUMNS = {"week", "game_id"}
 STATS_PLAYER_SEASON_PATTERN = re.compile(r"^stats_player_reg_(\d{4})\.(csv\.gz|csv)$")
+SEASON_TYPE_FIELDS = ("season_type", "seasonType")
+REGULAR_SEASON_TYPES = frozenset({"REG", "REGULAR", "REGULAR_SEASON"})
+POSTSEASON_TYPES = frozenset({"POST", "POSTSEASON", "POST_SEASON"})
 
 FIELDNAMES = [
     "player_id",
@@ -173,6 +176,48 @@ def detect_source_mode(stats_rows: list[dict[str, str]]) -> str:
     return "seasonal_source"
 
 
+def regular_season_stats_rows(stats_rows: list[dict[str, str]]) -> list[dict[str, str]]:
+    """Return regular-season rows and fail closed on ambiguous weekly input.
+
+    The legacy nflverse ``player_stats`` asset can contain both REG and POST
+    game rows.  Aggregating it without an explicit season-type gate silently
+    mixes playoffs into player-season totals.  Season-sliced
+    ``stats_player_reg_*`` inputs are already regular-season summaries and do
+    not need a row-level season type.
+    """
+    if not stats_rows:
+        return []
+
+    source_mode = detect_source_mode(stats_rows)
+    has_season_type_column = any(
+        any(field in row for field in SEASON_TYPE_FIELDS) for row in stats_rows
+    )
+    if not has_season_type_column:
+        if source_mode == "weekly_aggregated":
+            raise ValueError(
+                "weekly stats input must declare season_type so REG and POST cannot be mixed"
+            )
+        return stats_rows
+
+    regular_rows: list[dict[str, str]] = []
+    for index, row in enumerate(stats_rows):
+        raw_value = next(
+            (row.get(field) for field in SEASON_TYPE_FIELDS if field in row),
+            None,
+        )
+        normalized = str(raw_value or "").strip().upper().replace("-", "_").replace(" ", "_")
+        if normalized in REGULAR_SEASON_TYPES:
+            regular_rows.append(row)
+            continue
+        if normalized in POSTSEASON_TYPES:
+            continue
+        raise ValueError(
+            f"stats row {index} has unknown or missing season_type {raw_value!r}; "
+            "refusing ambiguous REG/POST aggregation"
+        )
+    return regular_rows
+
+
 def latest_stats_season(stats_rows: list[dict[str, str]]) -> int:
     return max((to_int(row.get("season"), 0) for row in stats_rows), default=0)
 
@@ -288,6 +333,7 @@ def build_player_outcome_rows(
     draft_rows: list[dict[str, str]],
     source_notes: str,
 ) -> list[dict[str, Any]]:
+    stats_rows = regular_season_stats_rows(stats_rows)
     draft_index = build_draft_index(draft_rows)
     source_mode = detect_source_mode(stats_rows)
     grouped: dict[tuple[str, int], dict[str, Any]] = {}

--- a/scripts/validate_2023_input_integrity.py
+++ b/scripts/validate_2023_input_integrity.py
@@ -1,0 +1,320 @@
+#!/usr/bin/env python3
+"""Validate the issue #285 archived fixtures and candidate corrections.
+
+This validator is intentionally candidate-scoped.  It never mutates seed or
+promoted artifacts and it does not imply promotion authority.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_MANIFEST = Path("data/candidate/2023_input_integrity/v0.1.0/manifest.json")
+DEFAULT_ARCHIVE = Path("data/fixtures/archived/2023_input_integrity/contaminated_seed_rows_v0.json")
+ATHLETIC_FIELDS = ("forty", "vertical", "broad", "three_cone", "shuttle", "bench")
+
+
+def load_json(path: Path) -> Any:
+    with path.open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _records(payload: dict[str, Any], label: str, errors: list[str]) -> list[dict[str, Any]]:
+    records = payload.get("records")
+    if not isinstance(records, list) or not records:
+        errors.append(f"{label}: records must be a non-empty list")
+        return []
+    return records
+
+
+def _source_ref_present(record: dict[str, Any], label: str, errors: list[str]) -> None:
+    source_ref = record.get("source_ref")
+    if not isinstance(source_ref, dict):
+        errors.append(f"{label}: source_ref is required")
+        return
+    if not source_ref.get("source_url"):
+        errors.append(f"{label}: source_ref.source_url is required")
+    if source_ref.get("source_status") not in {"verified_public_source", "governed_in_repo"}:
+        errors.append(f"{label}: source_ref.source_status is not verified")
+
+
+def validate_candidate_documents(
+    combine: dict[str, Any],
+    pro_day: dict[str, Any],
+    production: dict[str, Any],
+    context: dict[str, Any],
+    outcomes: dict[str, Any],
+) -> list[str]:
+    errors: list[str] = []
+
+    for label, payload in (
+        ("combine", combine),
+        ("pro_day", pro_day),
+        ("production", production),
+        ("context", context),
+        ("outcomes", outcomes),
+    ):
+        if payload.get("status") != "candidate_only":
+            errors.append(f"{label}: status must be candidate_only")
+        if payload.get("promotion_authorized") is not False:
+            errors.append(f"{label}: promotion_authorized must be false")
+        if payload.get("model_facing") is not False:
+            errors.append(f"{label}: model_facing must be false")
+
+    combine_records = _records(combine, "combine", errors)
+    combine_by_id = {row.get("player_id"): row for row in combine_records}
+    for index, row in enumerate(combine_records):
+        label = f"combine.records[{index}]"
+        _source_ref_present(row, label, errors)
+        if row.get("event_type") != "nfl_combine":
+            errors.append(f"{label}: event_type must be nfl_combine")
+        if row.get("testing_status") == "attended_no_scored_testing":
+            populated = [field for field in ATHLETIC_FIELDS if row.get(field) is not None]
+            if populated:
+                errors.append(
+                    f"{label}: combine DNP row contains athletic values {populated}; possible pro-day conflation"
+                )
+
+    puka_combine = combine_by_id.get("wr-puka-nacua")
+    if not puka_combine:
+        errors.append("combine: missing Puka Nacua correction row")
+    elif puka_combine.get("testing_status") != "attended_no_scored_testing":
+        errors.append(
+            "combine: Puka Nacua must remain attended_no_scored_testing at the NFL combine"
+        )
+
+    flowers_combine = combine_by_id.get("wr-zay-flowers")
+    if not flowers_combine:
+        errors.append("combine: missing Zay Flowers correction row")
+    elif (flowers_combine.get("vertical"), flowers_combine.get("broad")) != (35.5, 127):
+        errors.append("combine: Zay Flowers must retain verified 35.5 vertical / 127 broad")
+
+    for index, row in enumerate(_records(pro_day, "pro_day", errors)):
+        label = f"pro_day.records[{index}]"
+        _source_ref_present(row, label, errors)
+        if row.get("event_type") != "pro_day":
+            errors.append(f"{label}: event_type must be pro_day")
+        if "combine" in str(row.get("measurement_status", "")).lower():
+            errors.append(f"{label}: pro-day measurement_status must not claim combine provenance")
+
+    production_records = _records(production, "production", errors)
+    production_by_id = {row.get("player_id"): row for row in production_records}
+    for index, row in enumerate(production_records):
+        label = f"production.records[{index}]"
+        _source_ref_present(row, label, errors)
+        if row.get("stat_scope") != "single_season_receiving":
+            errors.append(f"{label}: stat_scope must be single_season_receiving; aggregates are ambiguous")
+        if not isinstance(row.get("source_season"), int):
+            errors.append(f"{label}: integer source_season is required")
+        if row.get("production_score_0_100") is not None:
+            errors.append(f"{label}: contaminated production score must remain null pending re-score authority")
+    puka_production = production_by_id.get("wr-puka-nacua")
+    if not puka_production:
+        errors.append("production: missing Puka Nacua correction row")
+    elif (
+        puka_production.get("source_season"),
+        puka_production.get("receptions"),
+        puka_production.get("receiving_yards"),
+        puka_production.get("receiving_tds"),
+    ) != (2022, 48, 625, 5):
+        errors.append("production: Puka Nacua 2022 receiving line must be 48/625/5")
+
+    context_records = _records(context, "context", errors)
+    context_by_id = {row.get("player_id"): row for row in context_records}
+    for index, row in enumerate(context_records):
+        label = f"context.records[{index}]"
+        _source_ref_present(row, label, errors)
+        seasons = row.get("college_seasons_played")
+        if seasons is None:
+            continue
+        if not isinstance(seasons, list) or not seasons or any(
+            not isinstance(year, int) for year in seasons
+        ):
+            errors.append(f"{label}: college_seasons_played must be a non-empty integer list")
+            continue
+        if len(set(seasons)) >= 4 and row.get("early_declare_flag") is not False:
+            errors.append(f"{label}: four-season player cannot be early_declare under candidate semantics")
+
+    puka_context = context_by_id.get("wr-puka-nacua")
+    if not puka_context:
+        errors.append("context: missing Puka Nacua evidence-summary correction row")
+    else:
+        if puka_context.get("legacy_evidence_summary_action") != "replace_entire_value":
+            errors.append("context: Puka Nacua contaminated evidence summary must be replaced entirely")
+        facts = puka_context.get("candidate_evidence_facts", {})
+        fact_values = (
+            facts.get("source_season"),
+            facts.get("games"),
+            facts.get("receptions"),
+            facts.get("receiving_yards"),
+            facts.get("receiving_tds"),
+            facts.get("rushing_attempts"),
+            facts.get("rushing_yards"),
+            facts.get("rushing_tds"),
+        )
+        if fact_values != (2022, 9, 48, 625, 5, 25, 209, 5):
+            errors.append("context: Puka Nacua evidence facts must use scoped 2022 components")
+        summary = str(puka_context.get("candidate_evidence_summary", "")).lower()
+        forbidden = ("1594", "1,594", "nfl rookie", "pick #177", "rams (r5)")
+        if not summary or any(token in summary for token in forbidden):
+            errors.append("context: Puka Nacua candidate summary retains ambiguous or post-cutoff claims")
+
+    flowers_context = context_by_id.get("wr-zay-flowers")
+    if not flowers_context:
+        errors.append("context: missing Zay Flowers correction row")
+    elif flowers_context.get("early_declare_flag") is not False:
+        errors.append("context: Zay Flowers early_declare_flag must be false")
+    elif "early_declare" not in flowers_context.get("evidence_tags_remove", []):
+        errors.append("context: stale Zay Flowers early_declare tag must be explicitly removed")
+
+    source_ref = outcomes.get("source_ref")
+    if not isinstance(source_ref, dict) or not source_ref.get("source_url"):
+        errors.append("outcomes: shared source_ref.source_url is required")
+    elif "stats_player_reg_2023" not in source_ref["source_url"]:
+        errors.append("outcomes: source must be the season-specific regular-season release")
+    outcome_records = _records(outcomes, "outcomes", errors)
+    for index, row in enumerate(outcome_records):
+        label = f"outcomes.records[{index}]"
+        if row.get("season_type") != "REG":
+            errors.append(f"{label}: season_type must be REG; REG/POST mixing is forbidden")
+        if row.get("season") != 2023:
+            errors.append(f"{label}: season must be 2023")
+        games = row.get("games")
+        if not isinstance(games, int) or not 0 <= games <= 17:
+            errors.append(f"{label}: games must be an integer in regular-season range 0..17")
+
+    return errors
+
+
+def validate_manifest(repo_root: Path, manifest: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    if manifest.get("status") != "candidate_only":
+        errors.append("manifest: status must be candidate_only")
+    if manifest.get("promotion_authorized") is not False:
+        errors.append("manifest: promotion_authorized must be false")
+    if manifest.get("promoted_artifacts_regenerated") is not False:
+        errors.append("manifest: promoted_artifacts_regenerated must be false")
+
+    for field in ("candidate_files", "preserved_source_files"):
+        entries = manifest.get(field)
+        if not isinstance(entries, list) or not entries:
+            errors.append(f"manifest: {field} must be a non-empty list")
+            continue
+        for index, entry in enumerate(entries):
+            relative = entry.get("path")
+            expected = entry.get("sha256")
+            if not relative or not expected:
+                errors.append(f"manifest: {field}[{index}] requires path and sha256")
+                continue
+            if field == "candidate_files" and str(relative).startswith("exports/promoted/"):
+                errors.append(f"manifest: candidate file cannot live under exports/promoted: {relative}")
+            path = repo_root / relative
+            if not path.is_file():
+                errors.append(f"manifest: missing file {relative}")
+                continue
+            actual = sha256_file(path)
+            if actual != expected:
+                errors.append(f"manifest: sha256 mismatch for {relative}: {actual} != {expected}")
+    return errors
+
+
+def validate_archive(repo_root: Path, archive: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    if archive.get("status") != "archived_fixture_non_authoritative":
+        errors.append("archive: status must be archived_fixture_non_authoritative")
+
+    source_files = archive.get("source_files", [])
+    for index, entry in enumerate(source_files):
+        path = repo_root / entry.get("path", "")
+        if not path.is_file():
+            errors.append(f"archive: source_files[{index}] missing {entry.get('path')}")
+            continue
+        actual = sha256_file(path)
+        if actual != entry.get("sha256"):
+            errors.append(f"archive: preserved source changed: {entry.get('path')}")
+
+    comparisons = (
+        ("combine_results", "data/raw/2023_combine_results.json"),
+        ("college_production", "data/processed/2023_college_production.json"),
+        ("prospect_context", "data/processed/2023_prospect_context.json"),
+    )
+    archived_rows = archive.get("archived_rows", {})
+    for key, relative in comparisons:
+        live_rows = load_json(repo_root / relative)
+        live_by_id = {row.get("player_id"): row for row in live_rows}
+        for row in archived_rows.get(key, []):
+            player_id = row.get("player_id")
+            if live_by_id.get(player_id) != row:
+                errors.append(f"archive: {key} row for {player_id} is not an exact source copy")
+    return errors
+
+
+def validate_bundle(repo_root: Path, manifest_path: Path, archive_path: Path) -> list[str]:
+    manifest = load_json(repo_root / manifest_path)
+    archive = load_json(repo_root / archive_path)
+    errors = validate_manifest(repo_root, manifest)
+    errors.extend(validate_archive(repo_root, archive))
+
+    candidate_payloads = {
+        Path(entry["path"]).name: load_json(repo_root / entry["path"])
+        for entry in manifest.get("candidate_files", [])
+    }
+    required = {
+        "combine_results_corrections.json",
+        "pro_day_results_candidate.json",
+        "college_production_corrections.json",
+        "prospect_context_corrections.json",
+        "nfl_outcome_regular_season_inputs.json",
+    }
+    missing = sorted(required - candidate_payloads.keys())
+    if missing:
+        errors.append(f"manifest: missing required candidate payloads: {missing}")
+        return errors
+
+    errors.extend(
+        validate_candidate_documents(
+            candidate_payloads["combine_results_corrections.json"],
+            candidate_payloads["pro_day_results_candidate.json"],
+            candidate_payloads["college_production_corrections.json"],
+            candidate_payloads["prospect_context_corrections.json"],
+            candidate_payloads["nfl_outcome_regular_season_inputs.json"],
+        )
+    )
+    return errors
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Validate issue #285 candidate 2023 input corrections")
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--archive", type=Path, default=DEFAULT_ARCHIVE)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    errors = validate_bundle(REPO_ROOT, args.manifest, args.archive)
+    if errors:
+        print("2023 INPUT INTEGRITY VALIDATION FAILED")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+    print("2023 INPUT INTEGRITY VALIDATION PASSED")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_build_nfl_fantasy_outcomes.py
+++ b/tests/test_build_nfl_fantasy_outcomes.py
@@ -15,6 +15,7 @@ from scripts.build_nfl_fantasy_outcomes import (
     is_stale_source,
     latest_draft_year,
     latest_stats_season,
+    regular_season_stats_rows,
     resolve_stats_rows,
 )
 
@@ -84,6 +85,7 @@ class BuilderJoinTests(unittest.TestCase):
                 "player_name": "Test Receiver",
                 "position": "WR",
                 "season": "2022",
+                "season_type": "REG",
                 "week": "1",
                 "game_id": "2022_01_ATL_NO",
                 "receptions": "3",
@@ -97,6 +99,7 @@ class BuilderJoinTests(unittest.TestCase):
                 "player_name": "Test Receiver",
                 "position": "WR",
                 "season": "2022",
+                "season_type": "REG",
                 "week": "2",
                 "game_id": "2022_02_LAR_ATL",
                 "receptions": "5",
@@ -117,6 +120,113 @@ class BuilderJoinTests(unittest.TestCase):
         self.assertEqual(rows[0]["ppr_points"], 27.0)
         self.assertEqual(rows[0]["ppr_per_game"], 13.5)
         self.assertIn("source_mode=weekly_aggregated", rows[0]["source_notes"])
+
+    def test_weekly_postseason_rows_are_excluded_before_aggregation(self) -> None:
+        draft_rows = [
+            {
+                "gsis_id": "00-001",
+                "player_name": "Test Receiver",
+                "position": "WR",
+                "season": "2023",
+                "round": "1",
+                "pick": "8",
+                "team": "ATL",
+            }
+        ]
+        stats_rows = [
+            {
+                "gsis_id": "00-001",
+                "position": "WR",
+                "season": "2023",
+                "season_type": "REG",
+                "week": "18",
+                "game_id": "2023_18_ATL_NO",
+                "receptions": "5",
+                "receiving_yards": "70",
+                "receiving_tds": "1",
+            },
+            {
+                "gsis_id": "00-001",
+                "position": "WR",
+                "season": "2023",
+                "season_type": "POST",
+                "week": "19",
+                "game_id": "2023_19_ATL_DAL",
+                "receptions": "9",
+                "receiving_yards": "180",
+                "receiving_tds": "2",
+            },
+        ]
+
+        rows = build_player_outcome_rows(stats_rows, draft_rows, source_notes="fixture")
+
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["games"], 1)
+        self.assertEqual(rows[0]["receptions"], 5.0)
+        self.assertEqual(rows[0]["receiving_yards"], 70.0)
+        self.assertEqual(rows[0]["receiving_tds"], 1.0)
+
+    def test_weekly_rows_without_season_type_fail_closed(self) -> None:
+        stats_rows = [
+            {
+                "gsis_id": "00-001",
+                "position": "WR",
+                "season": "2023",
+                "week": "1",
+                "game_id": "2023_01_ATL_NO",
+            }
+        ]
+
+        with self.assertRaisesRegex(ValueError, "must declare season_type"):
+            regular_season_stats_rows(stats_rows)
+
+    def test_weekly_rows_with_unknown_season_type_fail_closed(self) -> None:
+        stats_rows = [
+            {
+                "gsis_id": "00-001",
+                "position": "WR",
+                "season": "2023",
+                "season_type": "UNKNOWN",
+                "week": "1",
+                "game_id": "2023_01_ATL_NO",
+            }
+        ]
+
+        with self.assertRaisesRegex(ValueError, "unknown or missing season_type"):
+            regular_season_stats_rows(stats_rows)
+
+    def test_season_summary_recent_team_preserves_games(self) -> None:
+        draft_rows = [
+            {
+                "gsis_id": "00-001",
+                "player_name": "Test Receiver",
+                "position": "WR",
+                "season": "2023",
+                "round": "1",
+                "pick": "8",
+                "team": "ATL",
+            }
+        ]
+        stats_rows = [
+            {
+                "player_id": "00-001",
+                "player_name": "Test Receiver",
+                "position": "WR",
+                "season": "2023",
+                "season_type": "REG",
+                "recent_team": "ATL",
+                "games": "17",
+                "receptions": "90",
+                "receiving_yards": "1200",
+                "receiving_tds": "8",
+            }
+        ]
+
+        rows = build_player_outcome_rows(stats_rows, draft_rows, source_notes="fixture")
+
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["games"], 17)
+        self.assertIn("source_mode=seasonal_source", rows[0]["source_notes"])
 
 
 class SourceFreshnessTests(unittest.TestCase):

--- a/tests/test_validate_2023_input_integrity.py
+++ b/tests/test_validate_2023_input_integrity.py
@@ -1,0 +1,87 @@
+"""Regression coverage for issue #285 candidate input remediation."""
+
+from __future__ import annotations
+
+import copy
+import json
+import unittest
+from pathlib import Path
+
+from scripts.validate_2023_input_integrity import (
+    DEFAULT_ARCHIVE,
+    DEFAULT_MANIFEST,
+    REPO_ROOT,
+    validate_bundle,
+    validate_candidate_documents,
+)
+
+
+CANDIDATE_DIR = REPO_ROOT / "data/candidate/2023_input_integrity/v0.1.0"
+
+
+def load(name: str) -> dict:
+    return json.loads((CANDIDATE_DIR / name).read_text(encoding="utf-8"))
+
+
+def candidate_documents() -> tuple[dict, dict, dict, dict, dict]:
+    return (
+        load("combine_results_corrections.json"),
+        load("pro_day_results_candidate.json"),
+        load("college_production_corrections.json"),
+        load("prospect_context_corrections.json"),
+        load("nfl_outcome_regular_season_inputs.json"),
+    )
+
+
+class CandidateBundleTests(unittest.TestCase):
+    def test_real_candidate_bundle_and_archive_validate(self) -> None:
+        self.assertEqual(validate_bundle(REPO_ROOT, DEFAULT_MANIFEST, DEFAULT_ARCHIVE), [])
+
+    def test_combine_and_pro_day_conflation_is_rejected(self) -> None:
+        combine, pro_day, production, context, outcomes = map(copy.deepcopy, candidate_documents())
+        puka = next(row for row in combine["records"] if row["player_id"] == "wr-puka-nacua")
+        puka["forty"] = 4.55
+
+        errors = validate_candidate_documents(combine, pro_day, production, context, outcomes)
+
+        self.assertTrue(any("possible pro-day conflation" in error for error in errors))
+
+    def test_aggregate_stat_scope_without_semantics_is_rejected(self) -> None:
+        combine, pro_day, production, context, outcomes = map(copy.deepcopy, candidate_documents())
+        production["records"][0]["stat_scope"] = "aggregate"
+
+        errors = validate_candidate_documents(combine, pro_day, production, context, outcomes)
+
+        self.assertTrue(any("aggregates are ambiguous" in error for error in errors))
+
+    def test_ambiguous_and_post_cutoff_context_summary_is_rejected(self) -> None:
+        combine, pro_day, production, context, outcomes = map(copy.deepcopy, candidate_documents())
+        puka = next(row for row in context["records"] if row["player_id"] == "wr-puka-nacua")
+        puka["candidate_evidence_summary"] = (
+            "BYU WR — 1594 yds/10 TDs in 2022; 105 catches as NFL rookie."
+        )
+
+        errors = validate_candidate_documents(combine, pro_day, production, context, outcomes)
+
+        self.assertTrue(any("ambiguous or post-cutoff" in error for error in errors))
+
+    def test_four_season_player_cannot_be_marked_early_declare(self) -> None:
+        combine, pro_day, production, context, outcomes = map(copy.deepcopy, candidate_documents())
+        flowers = next(row for row in context["records"] if row["player_id"] == "wr-zay-flowers")
+        flowers["early_declare_flag"] = True
+
+        errors = validate_candidate_documents(combine, pro_day, production, context, outcomes)
+
+        self.assertTrue(any("four-season player cannot be early_declare" in error for error in errors))
+
+    def test_postseason_input_is_rejected(self) -> None:
+        combine, pro_day, production, context, outcomes = map(copy.deepcopy, candidate_documents())
+        outcomes["records"][0]["season_type"] = "POST"
+
+        errors = validate_candidate_documents(combine, pro_day, production, context, outcomes)
+
+        self.assertTrue(any("REG/POST mixing is forbidden" in error for error in errors))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Addresses #285.

## Summary

- audits each of the five 2023 input-integrity defects with cutoff-safe source lineage
- preserves exact contaminated rows as archived, non-authoritative fixtures while leaving original seeds byte-for-byte unchanged
- adds versioned candidate-only combine, pro-day, production, context, and regular-season outcome inputs
- filters weekly nflverse rows to `REG` before aggregation and fails closed on missing/unknown season type
- adds regressions for combine/pro-day conflation, aggregate ambiguity and hindsight leakage, class-year semantics, REG/POST mixing, and seasonal-summary game counts
- records the affected promoted-artifact families and leaves deprecation/promotion decisions to the operator

## Boundaries

- no files under `exports/promoted/**` changed or regenerated
- no files under `data/historical/reconstruction_2023/**` changed
- no original 2023 seed was overwritten or deleted
- all candidate artifacts declare `promotion_authorized: false` and `model_facing: false`
- no model-governance or #286 work is included

## Validation

- `python3 scripts/validate_2023_input_integrity.py`
- focused unit suite: 22/22 passed
- 2023 promoted manifest validator passed
- Python compile, JSON parse, and `git diff --check` passed
- protected-path and promoted-export diff gates passed
- full pytest: 464 passed, 2 failed; both failures reproduce unchanged at base commit `524bc549` in existing promoted-export temp-root tests

## Operator review points

- historical promoted-artifact deprecation remains an explicit operator decision
- the historical nflverse source snapshot was not hash-pinned at emission; current-release replay matches REG+POST contamination in 31/132 draft-class-2023 player-seasons, while exact historical source-version lineage remains `needs_verification`
- weekly-mode `games` still means stat-participation weeks rather than authoritative appearances; that separate semantic gap is documented and not silently resolved here
