### PR TITLE
Add draft-fact stubs for unscored 2026 rookies

### DIFF
--- a/cards/rookies/board/index.html
+++ b/cards/rookies/board/index.html
@@ -29,7 +29,7 @@
       <section class="hero-section" aria-label="Page introduction">
         <div class="hero-label">NFL Draft Intelligence · 2022–2026 Classes</div>
         <h1 class="hero-headline">Find and Compare<br>Top <em>NFL Draft Prospects</em></h1>
-        <p class="hero-sub">TIBER grades every rookie using athletic profile, production score, and draft capital — giving you a clear, ranked view of the best bets in each class.</p>
+        <p class="hero-sub">TIBER grades eligible rookies using athletic profile, production score, and draft capital. Source-backed draft-fact stubs keep other drafted players visible without inventing model output.</p>
         <div class="hero-ctas">
           <a class="hero-cta-primary" href="#board-section">Explore the Board</a>
           <a class="hero-cta-secondary" href="/cards/rookies/compare/">Compare Players</a>
@@ -44,7 +44,7 @@
           <div class="step-card">
             <div class="step-number">01</div>
             <div class="step-title">Multi-Signal Grading</div>
-            <p class="step-desc">Each rookie receives a composite Rookie Grade combining athletic testing (SPORQ/combine), college production, and draft capital into a single 0–100 score.</p>
+            <p class="step-desc">Each scored rookie receives a composite Rookie Grade combining athletic testing (SPORQ/combine), college production, and draft capital into a single 0–100 score.</p>
           </div>
           <div class="step-card">
             <div class="step-number">02</div>
@@ -89,7 +89,7 @@
       <!-- ── Board ─────────────────────────────────────────────────────────── -->
       <div id="board-section" style="scroll-margin-top: 72px"></div>
       <div class="section-title" style="margin-top: 4px">TIBER Rookie Board</div>
-      <p class="meta" style="margin-top: 4px">Ranking-first board powered by promoted Rookie Grade artifacts. Use tiers to spot cliffs, then jump to detail or compare.</p>
+      <p class="meta" style="margin-top: 4px">Ranking-first board powered by promoted Rookie Grade artifacts plus source-backed draft-fact stubs. Unscored rows are visible but never ranked or compared.</p>
 
       <section id="board-summary" class="board-summary" style="margin-top: 14px">Loading board summary…</section>
       <div class="board-search-row" style="margin-top: 10px">
@@ -119,6 +119,7 @@
     <script type="module">
       import { getAllRookieCards } from '/lib/rookies/getRookieCardData.js';
       import { buildRookieBoardRows, filterRookieBoard, sortRookieBoard } from '/lib/rookies/buildRookieBoardRows.js';
+      import { get2026RookieStubs, mergeRookieBoardRowsWithStubs } from '/lib/rookies/rookieStubs.js';
       import { groupRookiesByTier } from '/lib/rookies/groupRookiesByTier.js';
       import { getRookieTierRules } from '/lib/rookies/deriveRookieTier.js';
       import { renderRookieBoardControls } from '/components/rookies/RookieBoardControls.js';
@@ -203,11 +204,16 @@
       function renderHeroMetrics(allRows) {
         const heroMetrics = document.getElementById('hero-metrics');
         if (!heroMetrics) return;
+        const scoredCount = allRows.filter((row) => row.alphaStatus !== 'not_scored').length;
         const positions = new Set(allRows.map((r) => r.position).filter(Boolean));
         const classes = new Set(allRows.map((r) => r.draftClass).filter(Boolean));
         heroMetrics.innerHTML = `
           <div class="hero-metric-card">
             <div class="hero-metric-value">${allRows.length}</div>
+            <div class="hero-metric-label">Players Tracked</div>
+          </div>
+          <div class="hero-metric-card">
+            <div class="hero-metric-value">${scoredCount}</div>
             <div class="hero-metric-label">Prospects Graded</div>
           </div>
           <div class="hero-metric-card">
@@ -217,10 +223,6 @@
           <div class="hero-metric-card">
             <div class="hero-metric-value">${positions.size}</div>
             <div class="hero-metric-label">Positions Tracked</div>
-          </div>
-          <div class="hero-metric-card">
-            <div class="hero-metric-value">4</div>
-            <div class="hero-metric-label">Tier Bands</div>
           </div>
         `;
       }
@@ -236,12 +238,15 @@
           .map(([position, count]) => `${position}: ${count}`)
           .join(' • ');
         const tierCount = groupRookiesByTier(activeRows).length;
-        const tierRules = getRookieTierRules().map((rule) => Number.isFinite(rule.minGrade) ? `${rule.label} (${rule.minGrade}+)` : rule.label).join(' | ');
+        const tierRules = [
+          ...getRookieTierRules().map((rule) => Number.isFinite(rule.minGrade) ? `${rule.label} (${rule.minGrade}+)` : rule.label),
+          'Unscored (draft-fact only)',
+        ].join(' | ');
 
         summaryRoot.innerHTML = `
           <div><span class="section-title">Board snapshot</span><div class="board-summary-value">${activeRows.length} shown / ${allRows.length} total</div></div>
           <div><span class="section-title">Position mix</span><div class="meta">${topPositionBits || 'No position data available'}</div></div>
-          <div><span class="section-title">Tier bands</span><div class="meta">${tierCount} shown • ${tierRules}</div></div>
+          <div><span class="section-title">Tier / status bands</span><div class="meta">${tierCount} shown • ${tierRules}</div></div>
         `;
       }
 
@@ -467,8 +472,8 @@
 
       try {
         hydrateStateFromUrl();
-        const cards = await getAllRookieCards();
-        const rows = buildRookieBoardRows(cards);
+        const [cards, stubs] = await Promise.all([getAllRookieCards(), get2026RookieStubs()]);
+        const rows = mergeRookieBoardRowsWithStubs(buildRookieBoardRows(cards), stubs);
         renderHeroMetrics(rows);
         render(rows);
 

--- a/cards/rookies/player.html
+++ b/cards/rookies/player.html
@@ -48,7 +48,9 @@
 
     <script type="module">
       import { getAllRookieCards } from '/lib/rookies/getRookieCardData.js';
+      import { findRookieStubBySlug, get2026RookieStubs } from '/lib/rookies/rookieStubs.js';
       import { renderRookieCard } from '/components/rookies/RookieCardPhase1B.js';
+      import { renderRookieStubCard } from '/components/rookies/RookieStubCard.js';
       import { addRookieToQueue, getQueuedRookieAnnotation, isRookieQueued, removeRookieFromQueue } from '/lib/rookies/rookieQueueStore.js';
       import { deriveRookieTier } from '/lib/rookies/deriveRookieTier.js';
       import { findSimilarAthletes, getSporqDistribution } from '/lib/rookies/sporqHistorical.js';
@@ -199,10 +201,16 @@
       }
 
       try {
-        const cards = await getAllRookieCards();
+        const [cards, stubs] = await Promise.all([getAllRookieCards(), get2026RookieStubs()]);
+        const stub = slug ? findRookieStubBySlug(stubs, slug) : null;
         const card = slug ? cards.find((candidate) => candidate.slug === slug) ?? null : cards[0] ?? null;
 
-        if (!card) {
+        if (stub) {
+          document.title = `TIBER Rookie Draft Facts | ${stub.name}`;
+          actionsRoot.innerHTML = '';
+          sporqCompsRoot.innerHTML = '';
+          renderRookieStubCard(root, stub);
+        } else if (!card) {
           actionsRoot.innerHTML = '';
           root.innerHTML = '<div class="meta">No rookie card data available for 2026.</div>';
         } else {

--- a/components/rookies/RookieBoardRow.js
+++ b/components/rookies/RookieBoardRow.js
@@ -1,5 +1,6 @@
 import { getCollegeLogoUrl, getNflTeamLogoUrl } from '/lib/rookies/teamLogos.js';
 import { athleticChipLabel, athleticChipTitle } from '/lib/rookies/athleticLabel.js';
+import { renderRookieStubBoardRow } from './RookieStubBoardRow.js';
 
 function esc(str) {
   return String(str ?? '')
@@ -222,6 +223,10 @@ function renderMobileCard(row, { isQueued = false, queueAnnotation = null } = {}
 }
 
 export function renderRookieBoardRow(row, { isQueued = false, queueAnnotation = null } = {}) {
+  if (row.alphaStatus === 'not_scored') {
+    return renderRookieStubBoardRow(row);
+  }
+
   const rank = row.classRank == null ? 'N/A' : `#${row.classRank}`;
   const preDraftGrade = row.preDraftGrade == null ? 'N/A' : row.preDraftGrade.toFixed(1);
   const slug = encodeURIComponent(String(row.slug ?? ''));

--- a/components/rookies/RookieStubBoardRow.js
+++ b/components/rookies/RookieStubBoardRow.js
@@ -1,0 +1,65 @@
+import { ROOKIE_STUB_STATUS_COPY } from '../../lib/rookies/rookieStubs.js';
+
+function esc(value) {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function renderPositionBadge(position) {
+  const normalized = String(position ?? '').toUpperCase();
+  const className = ['QB', 'RB', 'WR', 'TE'].includes(normalized) ? `pos-badge-${normalized}` : '';
+  return `<span class="pos-badge ${className}">${esc(normalized)}</span>`;
+}
+
+function renderDraftFacts(row) {
+  return `${esc(row.draftFacts.team)} · Round ${esc(row.draftFacts.round)} · Pick ${esc(row.draftFacts.overallPick)}`;
+}
+
+function renderMobileStub(row) {
+  const slug = encodeURIComponent(String(row.slug ?? ''));
+  return `
+    <div class="board-mobile-card board-mobile-card-unscored">
+      <div class="bmc-header">
+        <span class="unscored-state">${ROOKIE_STUB_STATUS_COPY}</span>
+      </div>
+      <div class="bmc-name">
+        <a class="board-player-name board-player-link" href="/cards/rookies/player.html?slug=${slug}">${esc(row.name)}</a>
+      </div>
+      <div class="bmc-meta">${renderPositionBadge(row.position)} · ${renderDraftFacts(row)}</div>
+      <div class="bmc-thesis">No Rookie Alpha score or model-derived projection is attached to this source-backed draft record.</div>
+      <div class="bmc-actions-utility">
+        <a class="nav-link" href="/cards/rookies/player.html?slug=${slug}">Draft facts</a>
+      </div>
+    </div>
+  `;
+}
+
+export function renderRookieStubBoardRow(row) {
+  const slug = encodeURIComponent(String(row.slug ?? ''));
+  return `
+    <article class="board-row board-row-unscored">
+      ${renderMobileStub(row)}
+      <div class="board-cell board-rank board-num" data-label="Rank">—</div>
+      <div class="board-cell board-player" data-label="Player">
+        <div class="board-player-top">
+          <a class="board-player-name board-player-link" href="/cards/rookies/player.html?slug=${slug}">${esc(row.name)}</a>
+        </div>
+        <div class="meta board-summary-line">${renderDraftFacts(row)}</div>
+      </div>
+      <div class="board-cell" data-label="Position">${renderPositionBadge(row.position)}</div>
+      <div class="board-cell" data-label="School">${esc(row.school)}</div>
+      <div class="board-cell board-grade" data-label="Pre/Post Grade">
+        <span class="unscored-state">${ROOKIE_STUB_STATUS_COPY}</span>
+      </div>
+      <div class="board-cell" data-label="Tier"><span class="board-tier-pill board-tier-unscored">Not scored</span></div>
+      <div class="board-cell" data-label="PPR Range"><span class="ppr-na">—</span></div>
+      <div class="board-cell" data-label="Model Edge"><span class="delta-na">—</span></div>
+      <div class="board-cell board-actions" data-label="Actions">
+        <a class="nav-link" href="/cards/rookies/player.html?slug=${slug}">Draft facts</a>
+      </div>
+    </article>
+  `;
+}

--- a/components/rookies/RookieStubCard.js
+++ b/components/rookies/RookieStubCard.js
@@ -1,4 +1,7 @@
-import { ROOKIE_STUB_STATUS_COPY } from '../../lib/rookies/rookieStubs.js';
+import {
+  getRookieStubReasonCopy,
+  ROOKIE_STUB_STATUS_COPY,
+} from '../../lib/rookies/rookieStubs.js';
 
 function esc(value) {
   return String(value ?? '')
@@ -50,7 +53,7 @@ export function buildRookieStubCardHtml(stub) {
       <section class="card-actions-row">
         <div class="card-actions-copy">
           <div class="section-title">Coverage state</div>
-          <div class="meta">Reason: below Day-2 scoring floor.</div>
+          <div class="meta">Reason: ${esc(getRookieStubReasonCopy(stub.reason))}</div>
         </div>
         <div class="card-actions-links">
           <a class="nav-link nav-link-action" href="/cards/rookies/board/">← Back to board</a>

--- a/components/rookies/RookieStubCard.js
+++ b/components/rookies/RookieStubCard.js
@@ -1,0 +1,77 @@
+import { ROOKIE_STUB_STATUS_COPY } from '../../lib/rookies/rookieStubs.js';
+
+function esc(value) {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function safeHttpUrl(value) {
+  try {
+    const url = new URL(String(value));
+    return url.protocol === 'http:' || url.protocol === 'https:' ? url.href : null;
+  } catch {
+    return null;
+  }
+}
+
+function renderProvenance(stub) {
+  const provenance = stub.provenance;
+  const sourceUrl = safeHttpUrl(provenance.source_url);
+  const source = sourceUrl
+    ? `<a href="${esc(sourceUrl)}" target="_blank" rel="noopener noreferrer">${esc(provenance.source_name)}</a>`
+    : esc(provenance.source_name);
+
+  return `
+    <section class="card-panel stub-provenance-panel">
+      <div class="section-title">Draft-fact provenance</div>
+      <div class="stub-provenance-source">${source}</div>
+      <div class="meta">Source status: ${esc(provenance.source_status)} · Upstream: ${esc(provenance.upstream_provenance_status)}</div>
+      <div class="meta">Ingested from ${esc(provenance.ingested_from)} on ${esc(provenance.ingested_at)}</div>
+    </section>
+  `;
+}
+
+export function buildRookieStubCardHtml(stub) {
+  return `
+    <article class="rookie-card rookie-card-layout rookie-stub-card">
+      <section class="hero-panel stub-hero-panel">
+        <div class="section-title">TIBER Rookie Coverage Stub</div>
+        <h1 class="player-name">
+          <span class="avatar-pos pos-${esc(stub.position)}">${esc(stub.position)}</span>
+          ${esc(stub.name)}
+        </h1>
+        <div class="unscored-state unscored-state-large">${ROOKIE_STUB_STATUS_COPY}</div>
+        <p class="profile-summary">This page contains source-backed draft facts only. No Rookie Alpha score, tier, projection, model edge, or scouting evaluation is attached.</p>
+      </section>
+
+      <section class="card-actions-row">
+        <div class="card-actions-copy">
+          <div class="section-title">Coverage state</div>
+          <div class="meta">Reason: below Day-2 scoring floor.</div>
+        </div>
+        <div class="card-actions-links">
+          <a class="nav-link nav-link-action" href="/cards/rookies/board/">← Back to board</a>
+        </div>
+      </section>
+
+      <div class="stub-detail-grid">
+        <section class="card-panel">
+          <div class="section-title">Draft facts</div>
+          <div class="identity-strip stub-fact-strip">
+            <div class="pill"><div class="pill-label">NFL team</div><div class="pill-value">${esc(stub.team)}</div></div>
+            <div class="pill"><div class="pill-label">Round</div><div class="pill-value">${esc(stub.round)}</div></div>
+            <div class="pill"><div class="pill-label">Overall pick</div><div class="pill-value">${esc(stub.overallPick)}</div></div>
+          </div>
+        </section>
+        ${renderProvenance(stub)}
+      </div>
+    </article>
+  `;
+}
+
+export function renderRookieStubCard(container, stub) {
+  container.innerHTML = buildRookieStubCardHtml(stub);
+}

--- a/components/rookies/rookieCardStyles.css
+++ b/components/rookies/rookieCardStyles.css
@@ -26,6 +26,7 @@
   --tier-strong: #84CC16;
   --tier-mid: #6B7280;
   --tier-dart: #78716C;
+  --tier-unscored: #8B7D6B;
 }
 
 body {
@@ -601,6 +602,10 @@ body {
 .board-row.tier-strong { border-left-color: var(--tier-strong); }
 .board-row.tier-mid    { border-left-color: var(--tier-mid); }
 .board-row.tier-dart   { border-left-color: var(--tier-dart); }
+.board-row-unscored {
+  border-left-color: var(--tier-unscored);
+  background: rgba(139, 125, 107, 0.045);
+}
 
 .board-header {
   border-top: none;
@@ -668,6 +673,48 @@ body {
   font-size: 11px;
   padding: 3px 7px;
 }
+.board-tier-unscored {
+  border-color: rgba(158, 139, 122, 0.4);
+  background: rgba(158, 139, 122, 0.1);
+  color: #C8B9A8;
+}
+.unscored-state {
+  display: inline-block;
+  color: #D7C8B6;
+  border: 1px solid rgba(158, 139, 122, 0.45);
+  background: rgba(158, 139, 122, 0.1);
+  border-radius: 999px;
+  padding: 3px 8px;
+  font-family: Inter, system-ui, sans-serif;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: .02em;
+  text-transform: lowercase;
+}
+.unscored-state-large {
+  margin-top: 8px;
+  padding: 5px 10px;
+  font-size: 13px;
+}
+.board-mobile-card-unscored .bmc-header { justify-content: flex-start; }
+
+/* ─── Draft-fact-only stub detail ───────────────────────────────────────── */
+.stub-hero-panel {
+  border-color: rgba(158, 139, 122, 0.45);
+  background: radial-gradient(ellipse 90% 120% at 100% 0%, rgba(158, 139, 122, 0.12), transparent 55%), rgba(22, 18, 14, 0.95);
+}
+.stub-detail-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+  margin-top: 14px;
+}
+.stub-fact-strip { margin-top: 10px; }
+.stub-provenance-source {
+  margin: 10px 0 8px;
+  line-height: 1.5;
+}
+.stub-provenance-source a { color: var(--accent-soft); }
 
 /* ─── Mini score chart ────────────────────────────────────────────────────── */
 .mini-score-chart {
@@ -1167,6 +1214,7 @@ body {
   .hero-top { flex-direction: column; }
   .hero-score { width: 100%; min-width: 0; }
   .card-columns { grid-template-columns: 1fr; }
+  .stub-detail-grid { grid-template-columns: 1fr; }
   .comp-grid { grid-template-columns: 1fr; }
   .card-actions-links { width: 100%; }
   .nav-link-action { flex: 1 1 220px; text-align: center; }

--- a/data/processed/2026_rookie_stubs_v0.json
+++ b/data/processed/2026_rookie_stubs_v0.json
@@ -1,0 +1,884 @@
+[
+  {
+    "player_id": "qb-fernando-mendoza",
+    "name": "Fernando Mendoza",
+    "position": "QB",
+    "team": "LV",
+    "round": 1,
+    "overall_pick": 1,
+    "alpha_status": "not_scored",
+    "reason": "below_day2_scoring_floor",
+    "provenance": {
+      "source_name": "NBC Sports ProFootballTalk 2026 NFL Draft picks full tracker, published 2026-04-25",
+      "source_url": "https://www.nbcsports.com/nfl/profootballtalk/news/2026-nfl-draft-picks-full-tracker-of-every-selection-rounds-1-7",
+      "source_status": "external_verified",
+      "upstream_provenance_status": "source_verified",
+      "ingested_from": "tiber_data_nfl_draft_results_v1",
+      "ingested_at": "2026-05-17"
+    }
+  },
+  {
+    "player_id": "wr-brenen-thompson",
+    "name": "Brenen Thompson",
+    "position": "WR",
+    "team": "LAC",
+    "round": 4,
+    "overall_pick": 105,
+    "alpha_status": "not_scored",
+    "reason": "below_day2_scoring_floor",
+    "provenance": {
+      "source_name": "NBC Sports ProFootballTalk 2026 NFL Draft picks full tracker, published 2026-04-25",
+      "source_url": "https://www.nbcsports.com/nfl/profootballtalk/news/2026-nfl-draft-picks-full-tracker-of-every-selection-rounds-1-7",
+      "source_status": "external_verified",
+      "upstream_provenance_status": "source_verified",
+      "ingested_from": "tiber_data_nfl_draft_results_v1",
+      "ingested_at": "2026-05-17"
+    }
+  },
+  {
+    "player_id": "rb-jonah-coleman",
+    "name": "Jonah Coleman",
+    "position": "RB",
+    "team": "DEN",
+    "round": 4,
+    "overall_pick": 108,
+    "alpha_status": "not_scored",
+    "reason": "below_day2_scoring_floor",
+    "provenance": {
+      "source_name": "NBC Sports ProFootballTalk 2026 NFL Draft picks full tracker, published 2026-04-25",
+      "source_url": "https://www.nbcsports.com/nfl/profootballtalk/news/2026-nfl-draft-picks-full-tracker-of-every-selection-rounds-1-7",
+      "source_status": "external_verified",
+      "upstream_provenance_status": "source_verified",
+      "ingested_from": "tiber_data_nfl_draft_results_v1",
+      "ingested_at": "2026-05-17"
+    }
+  },
+  {
+    "player_id": "qb-cade-klubnik",
+    "name": "Cade Klubnik",
+    "position": "QB",
+    "team": "NYJ",
+    "round": 4,
+    "overall_pick": 110,
+    "alpha_status": "not_scored",
+    "reason": "below_day2_scoring_floor",
+    "provenance": {
+      "source_name": "NBC Sports ProFootballTalk 2026 NFL Draft picks full tracker, published 2026-04-25",
+      "source_url": "https://www.nbcsports.com/nfl/profootballtalk/news/2026-nfl-draft-picks-full-tracker-of-every-selection-rounds-1-7",
+      "source_status": "external_verified",
+      "upstream_provenance_status": "source_verified",
+      "ingested_from": "tiber_data_nfl_draft_results_v1",
+      "ingested_at": "2026-05-17"
+    }
+  },
+  {
+    "player_id": "wr-elijah-sarratt",
+    "name": "Elijah Sarratt",
+    "position": "WR",
+    "team": "BAL",
+    "round": 4,
+    "overall_pick": 115,
+    "alpha_status": "not_scored",
+    "reason": "below_day2_scoring_floor",
+    "provenance": {
+      "source_name": "NBC Sports ProFootballTalk 2026 NFL Draft picks full tracker, published 2026-04-25",
+      "source_url": "https://www.nbcsports.com/nfl/profootballtalk/news/2026-nfl-draft-picks-full-tracker-of-every-selection-rounds-1-7",
+      "source_status": "external_verified",
+      "upstream_provenance_status": "source_verified",
+      "ingested_from": "tiber_data_nfl_draft_results_v1",
+      "ingested_at": "2026-05-17"
+    }
+  },
+  {
+    "player_id": "wr-kaden-wetjen",
+    "name": "Kaden Wetjen",
+    "position": "WR",
+    "team": "PIT",
+    "round": 4,
+    "overall_pick": 121,
+    "alpha_status": "not_scored",
+    "reason": "below_day2_scoring_floor",
+    "provenance": {
+      "source_name": "NBC Sports ProFootballTalk 2026 NFL Draft picks full tracker, published 2026-04-25",
+      "source_url": "https://www.nbcsports.com/nfl/profootballtalk/news/2026-nfl-draft-picks-full-tracker-of-every-selection-rounds-1-7",
+      "source_status": "external_verified",
+      "upstream_provenance_status": "source_verified",
+      "ingested_from": "tiber_data_nfl_draft_results_v1",
+      "ingested_at": "2026-05-17"
+    }
+  },
+  {
+    "player_id": "rb-mike-washington-jr",
+    "name": "Mike Washington Jr.",
+    "position": "RB",
+    "team": "LV",
+    "round": 4,
+    "overall_pick": 122,
+    "alpha_status": "not_scored",
+    "reason": "below_day2_scoring_floor",
+    "provenance": {
+      "source_name": "NBC Sports ProFootballTalk 2026 NFL Draft picks full tracker, published 2026-04-25",
+      "source_url": "https://www.nbcsports.com/nfl/profootballtalk/news/2026-nfl-draft-picks-full-tracker-of-every-selection-rounds-1-7",
+      "source_status": "external_verified",
+      "upstream_provenance_status": "source_verified",
+      "ingested_from": "tiber_data_nfl_draft_results_v1",
+      "ingested_at": "2026-05-17"
+    }
+  },
+  {
+    "player_id": "wr-skyler-bell",
+    "name": "Skyler Bell",
+    "position": "WR",
+    "team": "BUF",
+    "round": 4,
+    "overall_pick": 125,
+    "alpha_status": "not_scored",
+    "reason": "below_day2_scoring_floor",
+    "provenance": {
+      "source_name": "NBC Sports ProFootballTalk 2026 NFL Draft picks full tracker, published 2026-04-25",
+      "source_url": "https://www.nbcsports.com/nfl/profootballtalk/news/2026-nfl-draft-picks-full-tracker-of-every-selection-rounds-1-7",
+      "source_status": "external_verified",
+      "upstream_provenance_status": "source_verified",
+      "ingested_from": "tiber_data_nfl_draft_results_v1",
+      "ingested_at": "2026-05-17"
+    }
+  },
+  {
+    "player_id": "te-matthew-hibner",
+    "name": "Matthew Hibner",
+    "position": "TE",
+    "team": "BAL",
+    "round": 4,
+    "overall_pick": 133,
+    "alpha_status": "not_scored",
+    "reason": "below_day2_scoring_floor",
+    "provenance": {
+      "source_name": "NBC Sports ProFootballTalk 2026 NFL Draft picks full tracker, published 2026-04-25",
+      "source_url": "https://www.nbcsports.com/nfl/profootballtalk/news/2026-nfl-draft-picks-full-tracker-of-every-selection-rounds-1-7",
+      "source_status": "external_verified",
+      "upstream_provenance_status": "source_verified",
+      "ingested_from": "tiber_data_nfl_draft_results_v1",
+      "ingested_at": "2026-05-17"
+    }
+  },
+  {
+    "player_id": "wr-bryce-lance",
+    "name": "Bryce Lance",
+    "position": "WR",
+    "team": "NO",
+    "round": 4,
+    "overall_pick": 136,
+    "alpha_status": "not_scored",
+    "reason": "below_day2_scoring_floor",
+    "provenance": {
+      "source_name": "NBC Sports ProFootballTalk 2026 NFL Draft picks full tracker, published 2026-04-25",
+      "source_url": "https://www.nbcsports.com/nfl/profootballtalk/news/2026-nfl-draft-picks-full-tracker-of-every-selection-rounds-1-7",
+      "source_status": "external_verified",
+      "upstream_provenance_status": "source_verified",
+      "ingested_from": "tiber_data_nfl_draft_results_v1",
+      "ingested_at": "2026-05-17"
+    }
+  },
+  {
+    "player_id": "wr-colbie-young",
+    "name": "Colbie Young",
+    "position": "WR",
+    "team": "CIN",
+    "round": 4,
+    "overall_pick": 140,
+    "alpha_status": "not_scored",
+    "reason": "below_day2_scoring_floor",
+    "provenance": {
+      "source_name": "NBC Sports ProFootballTalk 2026 NFL Draft picks full tracker, published 2026-04-25",
+      "source_url": "https://www.nbcsports.com/nfl/profootballtalk/news/2026-nfl-draft-picks-full-tracker-of-every-selection-rounds-1-7",
+      "source_status": "external_verified",
+      "upstream_provenance_status": "source_verified",
+      "ingested_from": "tiber_data_nfl_draft_results_v1",
+      "ingested_at": "2026-05-17"
+    }
+  },
+  {
+    "player_id": "wr-reggie-virgil",
+    "name": "Reggie Virgil",
+    "position": "WR",
+    "team": "ARI",
+    "round": 5,
+    "overall_pick": 143,
+    "alpha_status": "not_scored",
+    "reason": "below_day2_scoring_floor",
+    "provenance": {
+      "source_name": "NBC Sports ProFootballTalk 2026 NFL Draft picks full tracker, published 2026-04-25",
+      "source_url": "https://www.nbcsports.com/nfl/profootballtalk/news/2026-nfl-draft-picks-full-tracker-of-every-selection-rounds-1-7",
+      "source_status": "external_verified",
+      "upstream_provenance_status": "source_verified",
+      "ingested_from": "tiber_data_nfl_draft_results_v1",
+      "ingested_at": "2026-05-17"
+    }
+  },
+  {
+    "player_id": "te-justin-joly",
+    "name": "Justin Joly",
+    "position": "TE",
+    "team": "DEN",
+    "round": 5,
+    "overall_pick": 152,
+    "alpha_status": "not_scored",
+    "reason": "below_day2_scoring_floor",
+    "provenance": {
+      "source_name": "NBC Sports ProFootballTalk 2026 NFL Draft picks full tracker, published 2026-04-25",
+      "source_url": "https://www.nbcsports.com/nfl/profootballtalk/news/2026-nfl-draft-picks-full-tracker-of-every-selection-rounds-1-7",
+      "source_status": "external_verified",
+      "upstream_provenance_status": "source_verified",
+      "ingested_from": "tiber_data_nfl_draft_results_v1",
+      "ingested_at": "2026-05-17"
+    }
+  },
+  {
+    "player_id": "te-max-bredeson",
+    "name": "Max Bredeson",
+    "position": "TE",
+    "team": "MIN",
+    "round": 5,
+    "overall_pick": 159,
+    "alpha_status": "not_scored",
+    "reason": "below_day2_scoring_floor",
+    "provenance": {
+      "source_name": "NBC Sports ProFootballTalk 2026 NFL Draft picks full tracker, published 2026-04-25",
+      "source_url": "https://www.nbcsports.com/nfl/profootballtalk/news/2026-nfl-draft-picks-full-tracker-of-every-selection-rounds-1-7",
+      "source_status": "external_verified",
+      "upstream_provenance_status": "source_verified",
+      "ingested_from": "tiber_data_nfl_draft_results_v1",
+      "ingested_at": "2026-05-17"
+    }
+  },
+  {
+    "player_id": "rb-emmett-johnson",
+    "name": "Emmett Johnson",
+    "position": "RB",
+    "team": "KC",
+    "round": 5,
+    "overall_pick": 161,
+    "alpha_status": "not_scored",
+    "reason": "below_day2_scoring_floor",
+    "provenance": {
+      "source_name": "NBC Sports ProFootballTalk 2026 NFL Draft picks full tracker, published 2026-04-25",
+      "source_url": "https://www.nbcsports.com/nfl/profootballtalk/news/2026-nfl-draft-picks-full-tracker-of-every-selection-rounds-1-7",
+      "source_status": "external_verified",
+      "upstream_provenance_status": "source_verified",
+      "ingested_from": "tiber_data_nfl_draft_results_v1",
+      "ingested_at": "2026-05-17"
+    }
+  },
+  {
+    "player_id": "te-tanner-koziol",
+    "name": "Tanner Koziol",
+    "position": "TE",
+    "team": "JAX",
+    "round": 5,
+    "overall_pick": 164,
+    "alpha_status": "not_scored",
+    "reason": "below_day2_scoring_floor",
+    "provenance": {
+      "source_name": "NBC Sports ProFootballTalk 2026 NFL Draft picks full tracker, published 2026-04-25",
+      "source_url": "https://www.nbcsports.com/nfl/profootballtalk/news/2026-nfl-draft-picks-full-tracker-of-every-selection-rounds-1-7",
+      "source_status": "external_verified",
+      "upstream_provenance_status": "source_verified",
+      "ingested_from": "tiber_data_nfl_draft_results_v1",
+      "ingested_at": "2026-05-17"
+    }
+  },
+  {
+    "player_id": "rb-nick-singleton",
+    "name": "Nicholas Singleton",
+    "position": "RB",
+    "team": "TEN",
+    "round": 5,
+    "overall_pick": 165,
+    "alpha_status": "not_scored",
+    "reason": "below_day2_scoring_floor",
+    "provenance": {
+      "source_name": "NBC Sports ProFootballTalk 2026 NFL Draft picks full tracker, published 2026-04-25",
+      "source_url": "https://www.nbcsports.com/nfl/profootballtalk/news/2026-nfl-draft-picks-full-tracker-of-every-selection-rounds-1-7",
+      "source_status": "external_verified",
+      "upstream_provenance_status": "source_verified",
+      "ingested_from": "tiber_data_nfl_draft_results_v1",
+      "ingested_at": "2026-05-17"
+    }
+  },
+  {
+    "player_id": "wr-kendrick-law",
+    "name": "Kendrick Law",
+    "position": "WR",
+    "team": "DET",
+    "round": 5,
+    "overall_pick": 168,
+    "alpha_status": "not_scored",
+    "reason": "below_day2_scoring_floor",
+    "provenance": {
+      "source_name": "NBC Sports ProFootballTalk 2026 NFL Draft picks full tracker, published 2026-04-25",
+      "source_url": "https://www.nbcsports.com/nfl/profootballtalk/news/2026-nfl-draft-picks-full-tracker-of-every-selection-rounds-1-7",
+      "source_status": "external_verified",
+      "upstream_provenance_status": "source_verified",
+      "ingested_from": "tiber_data_nfl_draft_results_v1",
+      "ingested_at": "2026-05-17"
+    }
+  },
+  {
+    "player_id": "te-riley-nowakowski",
+    "name": "Riley Nowakowski",
+    "position": "TE",
+    "team": "PIT",
+    "round": 5,
+    "overall_pick": 169,
+    "alpha_status": "not_scored",
+    "reason": "below_day2_scoring_floor",
+    "provenance": {
+      "source_name": "NBC Sports ProFootballTalk 2026 NFL Draft picks full tracker, published 2026-04-25",
+      "source_url": "https://www.nbcsports.com/nfl/profootballtalk/news/2026-nfl-draft-picks-full-tracker-of-every-selection-rounds-1-7",
+      "source_status": "external_verified",
+      "upstream_provenance_status": "source_verified",
+      "ingested_from": "tiber_data_nfl_draft_results_v1",
+      "ingested_at": "2026-05-17"
+    }
+  },
+  {
+    "player_id": "te-joe-royer",
+    "name": "Joe Royer",
+    "position": "TE",
+    "team": "DEN",
+    "round": 5,
+    "overall_pick": 170,
+    "alpha_status": "not_scored",
+    "reason": "below_day2_scoring_floor",
+    "provenance": {
+      "source_name": "NBC Sports ProFootballTalk 2026 NFL Draft picks full tracker, published 2026-04-25",
+      "source_url": "https://www.nbcsports.com/nfl/profootballtalk/news/2026-nfl-draft-picks-full-tracker-of-every-selection-rounds-1-7",
+      "source_status": "external_verified",
+      "upstream_provenance_status": "source_verified",
+      "ingested_from": "tiber_data_nfl_draft_results_v1",
+      "ingested_at": "2026-05-17"
+    }
+  },
+  {
+    "player_id": "te-josh-cuevas",
+    "name": "Josh Cuevas",
+    "position": "TE",
+    "team": "BAL",
+    "round": 5,
+    "overall_pick": 173,
+    "alpha_status": "not_scored",
+    "reason": "below_day2_scoring_floor",
+    "provenance": {
+      "source_name": "NBC Sports ProFootballTalk 2026 NFL Draft picks full tracker, published 2026-04-25",
+      "source_url": "https://www.nbcsports.com/nfl/profootballtalk/news/2026-nfl-draft-picks-full-tracker-of-every-selection-rounds-1-7",
+      "source_status": "external_verified",
+      "upstream_provenance_status": "source_verified",
+      "ingested_from": "tiber_data_nfl_draft_results_v1",
+      "ingested_at": "2026-05-17"
+    }
+  },
+  {
+    "player_id": "rb-adam-randall",
+    "name": "Adam Randall",
+    "position": "RB",
+    "team": "BAL",
+    "round": 5,
+    "overall_pick": 174,
+    "alpha_status": "not_scored",
+    "reason": "below_day2_scoring_floor",
+    "provenance": {
+      "source_name": "NBC Sports ProFootballTalk 2026 NFL Draft picks full tracker, published 2026-04-25",
+      "source_url": "https://www.nbcsports.com/nfl/profootballtalk/news/2026-nfl-draft-picks-full-tracker-of-every-selection-rounds-1-7",
+      "source_status": "external_verified",
+      "upstream_provenance_status": "source_verified",
+      "ingested_from": "tiber_data_nfl_draft_results_v1",
+      "ingested_at": "2026-05-17"
+    }
+  },
+  {
+    "player_id": "wr-cyrus-allen",
+    "name": "Cyrus Allen",
+    "position": "WR",
+    "team": "KC",
+    "round": 5,
+    "overall_pick": 176,
+    "alpha_status": "not_scored",
+    "reason": "below_day2_scoring_floor",
+    "provenance": {
+      "source_name": "NBC Sports ProFootballTalk 2026 NFL Draft picks full tracker, published 2026-04-25",
+      "source_url": "https://www.nbcsports.com/nfl/profootballtalk/news/2026-nfl-draft-picks-full-tracker-of-every-selection-rounds-1-7",
+      "source_status": "external_verified",
+      "upstream_provenance_status": "source_verified",
+      "ingested_from": "tiber_data_nfl_draft_results_v1",
+      "ingested_at": "2026-05-17"
+    }
+  },
+  {
+    "player_id": "wr-kevin-coleman-jr",
+    "name": "Kevin Coleman Jr.",
+    "position": "WR",
+    "team": "MIA",
+    "round": 5,
+    "overall_pick": 177,
+    "alpha_status": "not_scored",
+    "reason": "below_day2_scoring_floor",
+    "provenance": {
+      "source_name": "NBC Sports ProFootballTalk 2026 NFL Draft picks full tracker, published 2026-04-25",
+      "source_url": "https://www.nbcsports.com/nfl/profootballtalk/news/2026-nfl-draft-picks-full-tracker-of-every-selection-rounds-1-7",
+      "source_status": "external_verified",
+      "upstream_provenance_status": "source_verified",
+      "ingested_from": "tiber_data_nfl_draft_results_v1",
+      "ingested_at": "2026-05-17"
+    }
+  },
+  {
+    "player_id": "qb-cole-payton",
+    "name": "Cole Payton",
+    "position": "QB",
+    "team": "PHI",
+    "round": 5,
+    "overall_pick": 178,
+    "alpha_status": "not_scored",
+    "reason": "below_day2_scoring_floor",
+    "provenance": {
+      "source_name": "NBC Sports ProFootballTalk 2026 NFL Draft picks full tracker, published 2026-04-25",
+      "source_url": "https://www.nbcsports.com/nfl/profootballtalk/news/2026-nfl-draft-picks-full-tracker-of-every-selection-rounds-1-7",
+      "source_status": "external_verified",
+      "upstream_provenance_status": "source_verified",
+      "ingested_from": "tiber_data_nfl_draft_results_v1",
+      "ingested_at": "2026-05-17"
+    }
+  },
+  {
+    "player_id": "te-seydou-traore",
+    "name": "Seydou Traore",
+    "position": "TE",
+    "team": "MIA",
+    "round": 5,
+    "overall_pick": 180,
+    "alpha_status": "not_scored",
+    "reason": "below_day2_scoring_floor",
+    "provenance": {
+      "source_name": "NBC Sports ProFootballTalk 2026 NFL Draft picks full tracker, published 2026-04-25",
+      "source_url": "https://www.nbcsports.com/nfl/profootballtalk/news/2026-nfl-draft-picks-full-tracker-of-every-selection-rounds-1-7",
+      "source_status": "external_verified",
+      "upstream_provenance_status": "source_verified",
+      "ingested_from": "tiber_data_nfl_draft_results_v1",
+      "ingested_at": "2026-05-17"
+    }
+  },
+  {
+    "player_id": "qb-taylen-green",
+    "name": "Taylen Green",
+    "position": "QB",
+    "team": "CLE",
+    "round": 6,
+    "overall_pick": 182,
+    "alpha_status": "not_scored",
+    "reason": "below_day2_scoring_floor",
+    "provenance": {
+      "source_name": "NBC Sports ProFootballTalk 2026 NFL Draft picks full tracker, published 2026-04-25",
+      "source_url": "https://www.nbcsports.com/nfl/profootballtalk/news/2026-nfl-draft-picks-full-tracker-of-every-selection-rounds-1-7",
+      "source_status": "external_verified",
+      "upstream_provenance_status": "source_verified",
+      "ingested_from": "tiber_data_nfl_draft_results_v1",
+      "ingested_at": "2026-05-17"
+    }
+  },
+  {
+    "player_id": "te-bauer-sharp",
+    "name": "Bauer Sharp",
+    "position": "TE",
+    "team": "TB",
+    "round": 6,
+    "overall_pick": 185,
+    "alpha_status": "not_scored",
+    "reason": "below_day2_scoring_floor",
+    "provenance": {
+      "source_name": "NBC Sports ProFootballTalk 2026 NFL Draft picks full tracker, published 2026-04-25",
+      "source_url": "https://www.nbcsports.com/nfl/profootballtalk/news/2026-nfl-draft-picks-full-tracker-of-every-selection-rounds-1-7",
+      "source_status": "external_verified",
+      "upstream_provenance_status": "source_verified",
+      "ingested_from": "tiber_data_nfl_draft_results_v1",
+      "ingested_at": "2026-05-17"
+    }
+  },
+  {
+    "player_id": "rb-kaytron-allen",
+    "name": "Kaytron Allen",
+    "position": "RB",
+    "team": "WAS",
+    "round": 6,
+    "overall_pick": 187,
+    "alpha_status": "not_scored",
+    "reason": "below_day2_scoring_floor",
+    "provenance": {
+      "source_name": "NBC Sports ProFootballTalk 2026 NFL Draft picks full tracker, published 2026-04-25",
+      "source_url": "https://www.nbcsports.com/nfl/profootballtalk/news/2026-nfl-draft-picks-full-tracker-of-every-selection-rounds-1-7",
+      "source_status": "external_verified",
+      "upstream_provenance_status": "source_verified",
+      "ingested_from": "tiber_data_nfl_draft_results_v1",
+      "ingested_at": "2026-05-17"
+    }
+  },
+  {
+    "player_id": "wr-barion-brown",
+    "name": "Barion Brown",
+    "position": "WR",
+    "team": "NO",
+    "round": 6,
+    "overall_pick": 190,
+    "alpha_status": "not_scored",
+    "reason": "below_day2_scoring_floor",
+    "provenance": {
+      "source_name": "NBC Sports ProFootballTalk 2026 NFL Draft picks full tracker, published 2026-04-25",
+      "source_url": "https://www.nbcsports.com/nfl/profootballtalk/news/2026-nfl-draft-picks-full-tracker-of-every-selection-rounds-1-7",
+      "source_status": "external_verified",
+      "upstream_provenance_status": "source_verified",
+      "ingested_from": "tiber_data_nfl_draft_results_v1",
+      "ingested_at": "2026-05-17"
+    }
+  },
+  {
+    "player_id": "wr-josh-cameron",
+    "name": "Josh Cameron",
+    "position": "WR",
+    "team": "JAX",
+    "round": 6,
+    "overall_pick": 191,
+    "alpha_status": "not_scored",
+    "reason": "below_day2_scoring_floor",
+    "provenance": {
+      "source_name": "NBC Sports ProFootballTalk 2026 NFL Draft picks full tracker, published 2026-04-25",
+      "source_url": "https://www.nbcsports.com/nfl/profootballtalk/news/2026-nfl-draft-picks-full-tracker-of-every-selection-rounds-1-7",
+      "source_status": "external_verified",
+      "upstream_provenance_status": "source_verified",
+      "ingested_from": "tiber_data_nfl_draft_results_v1",
+      "ingested_at": "2026-05-17"
+    }
+  },
+  {
+    "player_id": "wr-malik-benson",
+    "name": "Malik Benson",
+    "position": "WR",
+    "team": "LV",
+    "round": 6,
+    "overall_pick": 195,
+    "alpha_status": "not_scored",
+    "reason": "below_day2_scoring_floor",
+    "provenance": {
+      "source_name": "NBC Sports ProFootballTalk 2026 NFL Draft picks full tracker, published 2026-04-25",
+      "source_url": "https://www.nbcsports.com/nfl/profootballtalk/news/2026-nfl-draft-picks-full-tracker-of-every-selection-rounds-1-7",
+      "source_status": "external_verified",
+      "upstream_provenance_status": "source_verified",
+      "ingested_from": "tiber_data_nfl_draft_results_v1",
+      "ingested_at": "2026-05-17"
+    }
+  },
+  {
+    "player_id": "wr-cj-daniels",
+    "name": "CJ Daniels",
+    "position": "WR",
+    "team": "LAR",
+    "round": 6,
+    "overall_pick": 197,
+    "alpha_status": "not_scored",
+    "reason": "below_day2_scoring_floor",
+    "provenance": {
+      "source_name": "NBC Sports ProFootballTalk 2026 NFL Draft picks full tracker, published 2026-04-25",
+      "source_url": "https://www.nbcsports.com/nfl/profootballtalk/news/2026-nfl-draft-picks-full-tracker-of-every-selection-rounds-1-7",
+      "source_status": "external_verified",
+      "upstream_provenance_status": "source_verified",
+      "ingested_from": "tiber_data_nfl_draft_results_v1",
+      "ingested_at": "2026-05-17"
+    }
+  },
+  {
+    "player_id": "rb-demond-claiborne",
+    "name": "Demond Claiborne",
+    "position": "RB",
+    "team": "MIN",
+    "round": 6,
+    "overall_pick": 198,
+    "alpha_status": "not_scored",
+    "reason": "below_day2_scoring_floor",
+    "provenance": {
+      "source_name": "NBC Sports ProFootballTalk 2026 NFL Draft picks full tracker, published 2026-04-25",
+      "source_url": "https://www.nbcsports.com/nfl/profootballtalk/news/2026-nfl-draft-picks-full-tracker-of-every-selection-rounds-1-7",
+      "source_status": "external_verified",
+      "upstream_provenance_status": "source_verified",
+      "ingested_from": "tiber_data_nfl_draft_results_v1",
+      "ingested_at": "2026-05-17"
+    }
+  },
+  {
+    "player_id": "wr-emmanuel-henderson-jr",
+    "name": "Emmanuel Henderson Jr.",
+    "position": "WR",
+    "team": "SEA",
+    "round": 6,
+    "overall_pick": 199,
+    "alpha_status": "not_scored",
+    "reason": "below_day2_scoring_floor",
+    "provenance": {
+      "source_name": "NBC Sports ProFootballTalk 2026 NFL Draft picks full tracker, published 2026-04-25",
+      "source_url": "https://www.nbcsports.com/nfl/profootballtalk/news/2026-nfl-draft-picks-full-tracker-of-every-selection-rounds-1-7",
+      "source_status": "external_verified",
+      "upstream_provenance_status": "source_verified",
+      "ingested_from": "tiber_data_nfl_draft_results_v1",
+      "ingested_at": "2026-05-17"
+    }
+  },
+  {
+    "player_id": "wr-cj-williams",
+    "name": "CJ Williams",
+    "position": "WR",
+    "team": "JAX",
+    "round": 6,
+    "overall_pick": 203,
+    "alpha_status": "not_scored",
+    "reason": "below_day2_scoring_floor",
+    "provenance": {
+      "source_name": "NBC Sports ProFootballTalk 2026 NFL Draft picks full tracker, published 2026-04-25",
+      "source_url": "https://www.nbcsports.com/nfl/profootballtalk/news/2026-nfl-draft-picks-full-tracker-of-every-selection-rounds-1-7",
+      "source_status": "external_verified",
+      "upstream_provenance_status": "source_verified",
+      "ingested_from": "tiber_data_nfl_draft_results_v1",
+      "ingested_at": "2026-05-17"
+    }
+  },
+  {
+    "player_id": "wr-lewis-bond",
+    "name": "Lewis Bond",
+    "position": "WR",
+    "team": "HOU",
+    "round": 6,
+    "overall_pick": 204,
+    "alpha_status": "not_scored",
+    "reason": "below_day2_scoring_floor",
+    "provenance": {
+      "source_name": "NBC Sports ProFootballTalk 2026 NFL Draft picks full tracker, published 2026-04-25",
+      "source_url": "https://www.nbcsports.com/nfl/profootballtalk/news/2026-nfl-draft-picks-full-tracker-of-every-selection-rounds-1-7",
+      "source_status": "external_verified",
+      "upstream_provenance_status": "source_verified",
+      "ingested_from": "tiber_data_nfl_draft_results_v1",
+      "ingested_at": "2026-05-17"
+    }
+  },
+  {
+    "player_id": "wr-anthony-smith",
+    "name": "Anthony Smith",
+    "position": "WR",
+    "team": "DAL",
+    "round": 7,
+    "overall_pick": 218,
+    "alpha_status": "not_scored",
+    "reason": "below_day2_scoring_floor",
+    "provenance": {
+      "source_name": "NBC Sports ProFootballTalk 2026 NFL Draft picks full tracker, published 2026-04-25",
+      "source_url": "https://www.nbcsports.com/nfl/profootballtalk/news/2026-nfl-draft-picks-full-tracker-of-every-selection-rounds-1-7",
+      "source_status": "external_verified",
+      "upstream_provenance_status": "source_verified",
+      "ingested_from": "tiber_data_nfl_draft_results_v1",
+      "ingested_at": "2026-05-17"
+    }
+  },
+  {
+    "player_id": "te-jack-endries",
+    "name": "Jack Endries",
+    "position": "TE",
+    "team": "CIN",
+    "round": 7,
+    "overall_pick": 221,
+    "alpha_status": "not_scored",
+    "reason": "below_day2_scoring_floor",
+    "provenance": {
+      "source_name": "NBC Sports ProFootballTalk 2026 NFL Draft picks full tracker, published 2026-04-25",
+      "source_url": "https://www.nbcsports.com/nfl/profootballtalk/news/2026-nfl-draft-picks-full-tracker-of-every-selection-rounds-1-7",
+      "source_status": "external_verified",
+      "upstream_provenance_status": "source_verified",
+      "ingested_from": "tiber_data_nfl_draft_results_v1",
+      "ingested_at": "2026-05-17"
+    }
+  },
+  {
+    "player_id": "qb-athan-kaliakmanis",
+    "name": "Athan Kaliakmanis",
+    "position": "QB",
+    "team": "WAS",
+    "round": 7,
+    "overall_pick": 223,
+    "alpha_status": "not_scored",
+    "reason": "below_day2_scoring_floor",
+    "provenance": {
+      "source_name": "NBC Sports ProFootballTalk 2026 NFL Draft picks full tracker, published 2026-04-25",
+      "source_url": "https://www.nbcsports.com/nfl/profootballtalk/news/2026-nfl-draft-picks-full-tracker-of-every-selection-rounds-1-7",
+      "source_status": "external_verified",
+      "upstream_provenance_status": "source_verified",
+      "ingested_from": "tiber_data_nfl_draft_results_v1",
+      "ingested_at": "2026-05-17"
+    }
+  },
+  {
+    "player_id": "te-jaren-kanak",
+    "name": "Jaren Kanak",
+    "position": "TE",
+    "team": "TEN",
+    "round": 7,
+    "overall_pick": 225,
+    "alpha_status": "not_scored",
+    "reason": "below_day2_scoring_floor",
+    "provenance": {
+      "source_name": "NBC Sports ProFootballTalk 2026 NFL Draft picks full tracker, published 2026-04-25",
+      "source_url": "https://www.nbcsports.com/nfl/profootballtalk/news/2026-nfl-draft-picks-full-tracker-of-every-selection-rounds-1-7",
+      "source_status": "external_verified",
+      "upstream_provenance_status": "source_verified",
+      "ingested_from": "tiber_data_nfl_draft_results_v1",
+      "ingested_at": "2026-05-17"
+    }
+  },
+  {
+    "player_id": "rb-eli-heidenreich",
+    "name": "Eli Heidenreich",
+    "position": "RB",
+    "team": "PIT",
+    "round": 7,
+    "overall_pick": 230,
+    "alpha_status": "not_scored",
+    "reason": "below_day2_scoring_floor",
+    "provenance": {
+      "source_name": "NBC Sports ProFootballTalk 2026 NFL Draft picks full tracker, published 2026-04-25",
+      "source_url": "https://www.nbcsports.com/nfl/profootballtalk/news/2026-nfl-draft-picks-full-tracker-of-every-selection-rounds-1-7",
+      "source_status": "external_verified",
+      "upstream_provenance_status": "source_verified",
+      "ingested_from": "tiber_data_nfl_draft_results_v1",
+      "ingested_at": "2026-05-17"
+    }
+  },
+  {
+    "player_id": "qb-behren-morton",
+    "name": "Behren Morton",
+    "position": "QB",
+    "team": "NE",
+    "round": 7,
+    "overall_pick": 234,
+    "alpha_status": "not_scored",
+    "reason": "below_day2_scoring_floor",
+    "provenance": {
+      "source_name": "NBC Sports ProFootballTalk 2026 NFL Draft picks full tracker, published 2026-04-25",
+      "source_url": "https://www.nbcsports.com/nfl/profootballtalk/news/2026-nfl-draft-picks-full-tracker-of-every-selection-rounds-1-7",
+      "source_status": "external_verified",
+      "upstream_provenance_status": "source_verified",
+      "ingested_from": "tiber_data_nfl_draft_results_v1",
+      "ingested_at": "2026-05-17"
+    }
+  },
+  {
+    "player_id": "rb-seth-mcgowan",
+    "name": "Seth McGowan",
+    "position": "RB",
+    "team": "IND",
+    "round": 7,
+    "overall_pick": 237,
+    "alpha_status": "not_scored",
+    "reason": "below_day2_scoring_floor",
+    "provenance": {
+      "source_name": "NBC Sports ProFootballTalk 2026 NFL Draft picks full tracker, published 2026-04-25",
+      "source_url": "https://www.nbcsports.com/nfl/profootballtalk/news/2026-nfl-draft-picks-full-tracker-of-every-selection-rounds-1-7",
+      "source_status": "external_verified",
+      "upstream_provenance_status": "source_verified",
+      "ingested_from": "tiber_data_nfl_draft_results_v1",
+      "ingested_at": "2026-05-17"
+    }
+  },
+  {
+    "player_id": "rb-jam-miller",
+    "name": "Jam Miller",
+    "position": "RB",
+    "team": "NE",
+    "round": 7,
+    "overall_pick": 245,
+    "alpha_status": "not_scored",
+    "reason": "below_day2_scoring_floor",
+    "provenance": {
+      "source_name": "NBC Sports ProFootballTalk 2026 NFL Draft picks full tracker, published 2026-04-25",
+      "source_url": "https://www.nbcsports.com/nfl/profootballtalk/news/2026-nfl-draft-picks-full-tracker-of-every-selection-rounds-1-7",
+      "source_status": "external_verified",
+      "upstream_provenance_status": "source_verified",
+      "ingested_from": "tiber_data_nfl_draft_results_v1",
+      "ingested_at": "2026-05-17"
+    }
+  },
+  {
+    "player_id": "te-carsen-ryan",
+    "name": "Carsen Ryan",
+    "position": "TE",
+    "team": "CLE",
+    "round": 7,
+    "overall_pick": 248,
+    "alpha_status": "not_scored",
+    "reason": "below_day2_scoring_floor",
+    "provenance": {
+      "source_name": "NBC Sports ProFootballTalk 2026 NFL Draft picks full tracker, published 2026-04-25",
+      "source_url": "https://www.nbcsports.com/nfl/profootballtalk/news/2026-nfl-draft-picks-full-tracker-of-every-selection-rounds-1-7",
+      "source_status": "external_verified",
+      "upstream_provenance_status": "source_verified",
+      "ingested_from": "tiber_data_nfl_draft_results_v1",
+      "ingested_at": "2026-05-17"
+    }
+  },
+  {
+    "player_id": "qb-garrett-nussmeier",
+    "name": "Garrett Nussmeier",
+    "position": "QB",
+    "team": "KC",
+    "round": 7,
+    "overall_pick": 249,
+    "alpha_status": "not_scored",
+    "reason": "below_day2_scoring_floor",
+    "provenance": {
+      "source_name": "NBC Sports ProFootballTalk 2026 NFL Draft picks full tracker, published 2026-04-25",
+      "source_url": "https://www.nbcsports.com/nfl/profootballtalk/news/2026-nfl-draft-picks-full-tracker-of-every-selection-rounds-1-7",
+      "source_status": "external_verified",
+      "upstream_provenance_status": "source_verified",
+      "ingested_from": "tiber_data_nfl_draft_results_v1",
+      "ingested_at": "2026-05-17"
+    }
+  },
+  {
+    "player_id": "wr-deion-burks",
+    "name": "Deion Burks",
+    "position": "WR",
+    "team": "IND",
+    "round": 7,
+    "overall_pick": 254,
+    "alpha_status": "not_scored",
+    "reason": "below_day2_scoring_floor",
+    "provenance": {
+      "source_name": "NBC Sports ProFootballTalk 2026 NFL Draft picks full tracker, published 2026-04-25",
+      "source_url": "https://www.nbcsports.com/nfl/profootballtalk/news/2026-nfl-draft-picks-full-tracker-of-every-selection-rounds-1-7",
+      "source_status": "external_verified",
+      "upstream_provenance_status": "source_verified",
+      "ingested_from": "tiber_data_nfl_draft_results_v1",
+      "ingested_at": "2026-05-17"
+    }
+  },
+  {
+    "player_id": "te-dallen-bentley",
+    "name": "Dallen Bentley",
+    "position": "TE",
+    "team": "DEN",
+    "round": 7,
+    "overall_pick": 256,
+    "alpha_status": "not_scored",
+    "reason": "below_day2_scoring_floor",
+    "provenance": {
+      "source_name": "NBC Sports ProFootballTalk 2026 NFL Draft picks full tracker, published 2026-04-25",
+      "source_url": "https://www.nbcsports.com/nfl/profootballtalk/news/2026-nfl-draft-picks-full-tracker-of-every-selection-rounds-1-7",
+      "source_status": "external_verified",
+      "upstream_provenance_status": "source_verified",
+      "ingested_from": "tiber_data_nfl_draft_results_v1",
+      "ingested_at": "2026-05-17"
+    }
+  }
+]

--- a/data/processed/2026_rookie_stubs_v0.json
+++ b/data/processed/2026_rookie_stubs_v0.json
@@ -7,7 +7,7 @@
     "round": 1,
     "overall_pick": 1,
     "alpha_status": "not_scored",
-    "reason": "below_day2_scoring_floor",
+    "reason": "not_in_postdraft_alpha_coverage",
     "provenance": {
       "source_name": "NBC Sports ProFootballTalk 2026 NFL Draft picks full tracker, published 2026-04-25",
       "source_url": "https://www.nbcsports.com/nfl/profootballtalk/news/2026-nfl-draft-picks-full-tracker-of-every-selection-rounds-1-7",

--- a/lib/rookies/buildRookieBoardRows.js
+++ b/lib/rookies/buildRookieBoardRows.js
@@ -16,6 +16,7 @@ export function buildRookieBoardRows(cards) {
     const tier = deriveRookieTier(rookieGrade);
 
     return {
+      playerId: card.playerId,
       slug: card.slug,
       name: card.identity.name,
       position: card.identity.position ?? 'N/A',

--- a/lib/rookies/exportCsv.js
+++ b/lib/rookies/exportCsv.js
@@ -1,4 +1,4 @@
-import { compareRookies } from '/lib/rookies/compareRookies.js';
+import { compareRookies } from './compareRookies.js';
 
 function escCsvCell(value) {
   const str = String(value ?? '');
@@ -31,22 +31,27 @@ export function buildBoardCsv(rows) {
     'tier', 'rookie_grade', 'athletic_score', 'production_score', 'draft_capital_score',
     'consensus_delta_positional', 'evidence_tier', 'breakout_age',
   ];
-  const data = rows.map((row, i) => ({
-    board_rank: i + 1,
-    class_rank: row.classRank ?? '',
-    name: row.name ?? '',
-    position: row.position ?? '',
-    school: row.school ?? '',
-    draft_class: row.draftClass ?? '',
-    tier: row.tier?.label ?? '',
-    rookie_grade: row.rookieGrade?.toFixed(1) ?? '',
-    athletic_score: row.athleticScore?.toFixed(1) ?? '',
-    production_score: row.productionScore?.toFixed(1) ?? '',
-    draft_capital_score: row.draftCapitalScore?.toFixed(1) ?? '',
-    consensus_delta_positional: row.consensusDelta ?? '',
-    evidence_tier: row.evidenceTier ?? '',
-    breakout_age: row.breakoutAge ?? '',
-  }));
+  let scoredBoardRank = 0;
+  const data = rows.map((row) => {
+    const isUnscored = row.alphaStatus === 'not_scored';
+    if (!isUnscored) scoredBoardRank += 1;
+    return {
+      board_rank: isUnscored ? '' : scoredBoardRank,
+      class_rank: row.classRank ?? '',
+      name: row.name ?? '',
+      position: row.position ?? '',
+      school: row.school ?? '',
+      draft_class: row.draftClass ?? '',
+      tier: row.tier?.label ?? '',
+      rookie_grade: row.rookieGrade?.toFixed(1) ?? '',
+      athletic_score: row.athleticScore?.toFixed(1) ?? '',
+      production_score: row.productionScore?.toFixed(1) ?? '',
+      draft_capital_score: row.draftCapitalScore?.toFixed(1) ?? '',
+      consensus_delta_positional: row.consensusDelta ?? '',
+      evidence_tier: row.evidenceTier ?? '',
+      breakout_age: row.breakoutAge ?? '',
+    };
+  });
   return toCsvString(headers, data);
 }
 

--- a/lib/rookies/rookieStubs.js
+++ b/lib/rookies/rookieStubs.js
@@ -2,7 +2,8 @@ import { deriveRookieTier } from './deriveRookieTier.js';
 
 export const ROOKIE_STUB_PATH = '/data/processed/2026_rookie_stubs_v0.json';
 export const ROOKIE_STUB_ALPHA_STATUS = 'not_scored';
-export const ROOKIE_STUB_REASON = 'below_day2_scoring_floor';
+export const ROOKIE_STUB_REASON_BELOW_DAY2 = 'below_day2_scoring_floor';
+export const ROOKIE_STUB_REASON_COVERAGE_GAP = 'not_in_postdraft_alpha_coverage';
 export const ROOKIE_STUB_STATUS_COPY = 'unscored — draft-fact only';
 
 const PROVENANCE_FIELDS = [
@@ -27,13 +28,30 @@ function toSlug(playerId) {
     .replace(/^-+|-+$/g, '');
 }
 
+export function expectedRookieStubReason(round) {
+  return round <= 3
+    ? ROOKIE_STUB_REASON_COVERAGE_GAP
+    : ROOKIE_STUB_REASON_BELOW_DAY2;
+}
+
+export function getRookieStubReasonCopy(reason) {
+  if (reason === ROOKIE_STUB_REASON_COVERAGE_GAP) {
+    return 'Not included in post-draft Rookie Alpha coverage.';
+  }
+  if (reason === ROOKIE_STUB_REASON_BELOW_DAY2) {
+    return 'Below Day-2 scoring floor.';
+  }
+  return 'Unscored draft-fact record.';
+}
+
 export function normalizeRookieStub(raw) {
   if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
   if (!nonEmptyString(raw.player_id) || raw.player_id !== raw.player_id.trim().toLowerCase()) return null;
   if (!nonEmptyString(raw.name) || !nonEmptyString(raw.position) || !nonEmptyString(raw.team)) return null;
   if (!Number.isInteger(raw.round) || raw.round < 1 || raw.round > 7) return null;
   if (!Number.isInteger(raw.overall_pick) || raw.overall_pick < 1) return null;
-  if (raw.alpha_status !== ROOKIE_STUB_ALPHA_STATUS || raw.reason !== ROOKIE_STUB_REASON) return null;
+  if (raw.alpha_status !== ROOKIE_STUB_ALPHA_STATUS) return null;
+  if (raw.reason !== expectedRookieStubReason(raw.round)) return null;
   if (!raw.provenance || typeof raw.provenance !== 'object' || Array.isArray(raw.provenance)) return null;
   if (PROVENANCE_FIELDS.some((field) => !nonEmptyString(raw.provenance[field]))) return null;
 
@@ -135,6 +153,7 @@ export function buildRookieStubBoardRow(stub) {
 export function mergeRookieBoardRowsWithStubs(rows, stubs) {
   const stubRows = stubs.map(buildRookieStubBoardRow);
   const stubIds = new Set(stubRows.map((row) => row.playerId));
+  // Post-draft stub membership intentionally overrides stale 2026 pre-draft cards.
   const nonStubRows = rows.filter(
     (row) => String(row.draftClass) !== '2026' || !stubIds.has(row.playerId),
   );

--- a/lib/rookies/rookieStubs.js
+++ b/lib/rookies/rookieStubs.js
@@ -1,0 +1,146 @@
+import { deriveRookieTier } from './deriveRookieTier.js';
+
+export const ROOKIE_STUB_PATH = '/data/processed/2026_rookie_stubs_v0.json';
+export const ROOKIE_STUB_ALPHA_STATUS = 'not_scored';
+export const ROOKIE_STUB_REASON = 'below_day2_scoring_floor';
+export const ROOKIE_STUB_STATUS_COPY = 'unscored — draft-fact only';
+
+const PROVENANCE_FIELDS = [
+  'source_name',
+  'source_url',
+  'source_status',
+  'upstream_provenance_status',
+  'ingested_from',
+  'ingested_at',
+];
+
+let rookieStubsPromise = null;
+
+function nonEmptyString(value) {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function toSlug(playerId) {
+  return String(playerId ?? '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+export function normalizeRookieStub(raw) {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
+  if (!nonEmptyString(raw.player_id) || raw.player_id !== raw.player_id.trim().toLowerCase()) return null;
+  if (!nonEmptyString(raw.name) || !nonEmptyString(raw.position) || !nonEmptyString(raw.team)) return null;
+  if (!Number.isInteger(raw.round) || raw.round < 1 || raw.round > 7) return null;
+  if (!Number.isInteger(raw.overall_pick) || raw.overall_pick < 1) return null;
+  if (raw.alpha_status !== ROOKIE_STUB_ALPHA_STATUS || raw.reason !== ROOKIE_STUB_REASON) return null;
+  if (!raw.provenance || typeof raw.provenance !== 'object' || Array.isArray(raw.provenance)) return null;
+  if (PROVENANCE_FIELDS.some((field) => !nonEmptyString(raw.provenance[field]))) return null;
+
+  return {
+    playerId: raw.player_id,
+    slug: toSlug(raw.player_id),
+    name: raw.name,
+    position: raw.position,
+    team: raw.team,
+    round: raw.round,
+    overallPick: raw.overall_pick,
+    alphaStatus: raw.alpha_status,
+    reason: raw.reason,
+    provenance: Object.fromEntries(
+      PROVENANCE_FIELDS.map((field) => [field, raw.provenance[field]]),
+    ),
+  };
+}
+
+export function normalizeRookieStubs(payload) {
+  if (!Array.isArray(payload)) {
+    throw new Error('Rookie stub artifact must be a top-level array.');
+  }
+
+  const normalized = payload.map(normalizeRookieStub);
+  const invalidIndex = normalized.findIndex((stub) => stub == null);
+  if (invalidIndex >= 0) {
+    throw new Error(`Rookie stub artifact row ${invalidIndex} is malformed.`);
+  }
+
+  const seen = new Set();
+  for (const stub of normalized) {
+    if (seen.has(stub.playerId)) {
+      throw new Error(`Rookie stub artifact contains duplicate player_id: ${stub.playerId}`);
+    }
+    seen.add(stub.playerId);
+  }
+
+  return normalized;
+}
+
+export async function get2026RookieStubs() {
+  if (!rookieStubsPromise) {
+    rookieStubsPromise = fetch(ROOKIE_STUB_PATH).then(async (response) => {
+      if (!response.ok) {
+        throw new Error(`Failed to load ${ROOKIE_STUB_PATH}: ${response.status}`);
+      }
+      return normalizeRookieStubs(await response.json());
+    });
+  }
+  return rookieStubsPromise;
+}
+
+export function buildRookieStubBoardRow(stub) {
+  return {
+    playerId: stub.playerId,
+    slug: stub.slug,
+    name: stub.name,
+    position: stub.position,
+    school: 'Unavailable in stub',
+    nflTeam: stub.team,
+    draftClass: 2026,
+    rookieGrade: null,
+    preDraftGrade: null,
+    preDraftRank: null,
+    postDraftStatus: ROOKIE_STUB_ALPHA_STATUS,
+    classRank: null,
+    tier: deriveRookieTier(null),
+    profileSummary: `${stub.team} · Round ${stub.round} · Pick ${stub.overallPick}`,
+    tags: [],
+    translationFlags: [],
+    pprProjection: null,
+    consensusDelta: null,
+    evidenceTier: null,
+    evidenceTierReason: null,
+    isCappedDisagreement: null,
+    dynastyDelta: null,
+    volumeTrend: null,
+    efficiencyTrend: null,
+    breakoutAge: null,
+    youngBreakoutFlag: false,
+    breakoutAgeRating: null,
+    breakoutLabel: null,
+    athleticScore: null,
+    athleticSource: null,
+    productionScore: null,
+    draftCapitalScore: null,
+    alphaStatus: stub.alphaStatus,
+    unscoredReason: stub.reason,
+    draftFacts: {
+      team: stub.team,
+      round: stub.round,
+      overallPick: stub.overallPick,
+    },
+    provenance: stub.provenance,
+  };
+}
+
+export function mergeRookieBoardRowsWithStubs(rows, stubs) {
+  const stubRows = stubs.map(buildRookieStubBoardRow);
+  const stubIds = new Set(stubRows.map((row) => row.playerId));
+  const nonStubRows = rows.filter(
+    (row) => String(row.draftClass) !== '2026' || !stubIds.has(row.playerId),
+  );
+  return [...nonStubRows, ...stubRows];
+}
+
+export function findRookieStubBySlug(stubs, slug) {
+  return stubs.find((stub) => stub.slug === slug) ?? null;
+}

--- a/scripts/build_2026_rookie_stubs.py
+++ b/scripts/build_2026_rookie_stubs.py
@@ -26,6 +26,16 @@ PROVENANCE_FIELDS = (
     "ingested_at",
 )
 
+BELOW_DAY2_SCORING_FLOOR = "below_day2_scoring_floor"
+NOT_IN_POSTDRAFT_ALPHA_COVERAGE = "not_in_postdraft_alpha_coverage"
+
+
+def reason_for_round(draft_round: int) -> str:
+    """Return a truthful reason for the player's missing post-draft Alpha score."""
+    if draft_round <= 3:
+        return NOT_IN_POSTDRAFT_ALPHA_COVERAGE
+    return BELOW_DAY2_SCORING_FLOOR
+
 
 def load_json(path: Path) -> Any:
     try:
@@ -93,7 +103,7 @@ def build_stub(row: dict[str, Any], index: int) -> dict[str, Any]:
         "round": required_values["draft_round"],
         "overall_pick": required_values["overall_pick"],
         "alpha_status": "not_scored",
-        "reason": "below_day2_scoring_floor",
+        "reason": reason_for_round(required_values["draft_round"]),
         "provenance": provenance,
     }
 

--- a/scripts/build_2026_rookie_stubs.py
+++ b/scripts/build_2026_rookie_stubs.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Build source-backed stub rows for drafted 2026 players without Alpha coverage."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_DRAFT_RESULTS = REPO_ROOT / "data/processed/2026_draft_results.json"
+DEFAULT_ALPHA_CONTEXT = (
+    REPO_ROOT
+    / "exports/promoted/rookie-alpha/2026_rookie_alpha_postdraft_role_context_v0.json"
+)
+DEFAULT_OUTPUT = REPO_ROOT / "data/processed/2026_rookie_stubs_v0.json"
+
+PROVENANCE_FIELDS = (
+    "source_name",
+    "source_url",
+    "source_status",
+    "upstream_provenance_status",
+    "ingested_from",
+    "ingested_at",
+)
+
+
+def load_json(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ValueError(f"Required input does not exist: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Required input is not valid JSON: {path}: {exc}") from exc
+
+
+def require_player_id(row: dict[str, Any], source: str, index: int) -> str:
+    player_id = row.get("player_id")
+    if not isinstance(player_id, str) or not player_id.strip():
+        raise ValueError(f"{source} row {index} is missing player_id")
+    normalized = player_id.strip().lower()
+    if normalized != player_id:
+        raise ValueError(f"{source} row {index} has a non-canonical player_id: {player_id}")
+    return normalized
+
+
+def collect_unique_ids(rows: list[Any], source: str) -> set[str]:
+    ids: set[str] = set()
+    for index, raw_row in enumerate(rows):
+        if not isinstance(raw_row, dict):
+            raise ValueError(f"{source} row {index} is not an object")
+        player_id = require_player_id(raw_row, source, index)
+        if player_id in ids:
+            raise ValueError(f"{source} contains duplicate player_id: {player_id}")
+        ids.add(player_id)
+    return ids
+
+
+def build_stub(row: dict[str, Any], index: int) -> dict[str, Any]:
+    player_id = require_player_id(row, "draft-results", index)
+    required_values = {
+        "player_name": row.get("player_name"),
+        "position": row.get("position"),
+        "nfl_team": row.get("nfl_team"),
+        "draft_round": row.get("draft_round"),
+        "overall_pick": row.get("overall_pick"),
+    }
+    missing = [key for key, value in required_values.items() if value is None or value == ""]
+    if missing:
+        raise ValueError(f"draft-results row {index} ({player_id}) is missing: {', '.join(missing)}")
+    for field in ("player_name", "position", "nfl_team"):
+        if not isinstance(required_values[field], str):
+            raise ValueError(f"draft-results row {index} ({player_id}) has invalid {field}")
+    if not isinstance(required_values["draft_round"], int) or not 1 <= required_values["draft_round"] <= 7:
+        raise ValueError(f"draft-results row {index} ({player_id}) has invalid draft_round")
+    if not isinstance(required_values["overall_pick"], int) or required_values["overall_pick"] < 1:
+        raise ValueError(f"draft-results row {index} ({player_id}) has invalid overall_pick")
+
+    provenance: dict[str, Any] = {}
+    for field in PROVENANCE_FIELDS:
+        value = row.get(field)
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError(f"draft-results row {index} ({player_id}) is missing {field}")
+        provenance[field] = value
+
+    return {
+        "player_id": player_id,
+        "name": required_values["player_name"],
+        "position": required_values["position"],
+        "team": required_values["nfl_team"],
+        "round": required_values["draft_round"],
+        "overall_pick": required_values["overall_pick"],
+        "alpha_status": "not_scored",
+        "reason": "below_day2_scoring_floor",
+        "provenance": provenance,
+    }
+
+
+def build_stubs(draft_results: Any, alpha_context: Any) -> list[dict[str, Any]]:
+    if not isinstance(draft_results, list):
+        raise ValueError("draft-results input must be a top-level array")
+    if not isinstance(alpha_context, dict) or not isinstance(alpha_context.get("rows"), list):
+        raise ValueError("Alpha role-context input must be an object with a rows array")
+
+    draft_ids = collect_unique_ids(draft_results, "draft-results")
+    scored_ids = collect_unique_ids(alpha_context["rows"], "Alpha role-context")
+    unknown_scored_ids = scored_ids - draft_ids
+    if unknown_scored_ids:
+        raise ValueError(
+            "Alpha role-context contains player_ids absent from draft-results: "
+            + ", ".join(sorted(unknown_scored_ids))
+        )
+
+    stubs: list[dict[str, Any]] = []
+    for index, row in enumerate(draft_results):
+        if row.get("draft_result_status") != "drafted":
+            continue
+        player_id = require_player_id(row, "draft-results", index)
+        if player_id not in scored_ids:
+            stubs.append(build_stub(row, index))
+
+    return stubs
+
+
+def render_stubs(stubs: list[dict[str, Any]]) -> str:
+    return f"{json.dumps(stubs, indent=2, ensure_ascii=False)}\n"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--draft-results", type=Path, default=DEFAULT_DRAFT_RESULTS)
+    parser.add_argument("--alpha-context", type=Path, default=DEFAULT_ALPHA_CONTEXT)
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Fail when the checked-in output differs from a fresh deterministic build.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    stubs = build_stubs(load_json(args.draft_results), load_json(args.alpha_context))
+    rendered = render_stubs(stubs)
+
+    if args.check:
+        try:
+            existing = args.output.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            print(f"Stub artifact missing: {args.output}")
+            return 1
+        if existing != rendered:
+            print(f"Stub artifact is stale: {args.output}")
+            return 1
+        print(f"Stub artifact is current: {len(stubs)} rows")
+        return 0
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(rendered, encoding="utf-8")
+    print(f"Wrote {len(stubs)} stub rows to {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/card-disclosure-wiring.test.mjs
+++ b/tests/card-disclosure-wiring.test.mjs
@@ -9,6 +9,7 @@ import { isValidTransitionProfileEnvelope } from '../lib/rookies/rookieDataContr
 import { athleticMetricLabel, athleticChipLabel } from '../lib/rookies/athleticLabel.js';
 import {
   buildRookieStubBoardRow,
+  expectedRookieStubReason,
   mergeRookieBoardRowsWithStubs,
   normalizeRookieStub,
   normalizeRookieStubs,
@@ -131,20 +132,36 @@ test('2026 stub artifact is the exact drafted-minus-role-context set with copied
     assert.equal(stub.round, source.draft_round);
     assert.equal(stub.overall_pick, source.overall_pick);
     assert.equal(stub.alpha_status, 'not_scored');
-    assert.equal(stub.reason, 'below_day2_scoring_floor');
+    assert.equal(
+      stub.reason,
+      source.draft_round <= 3
+        ? 'not_in_postdraft_alpha_coverage'
+        : 'below_day2_scoring_floor',
+    );
     expectedProvenanceKeys.forEach((key) => assert.equal(stub.provenance[key], source[key]));
   });
 
   assert.equal(stubs.some((stub) => stub.player_id === 'rb-jeremiyah-love'), false);
-  assert.equal(stubs.some((stub) => stub.player_id === 'qb-fernando-mendoza'), true);
+  const mendoza = stubs.find((stub) => stub.player_id === 'qb-fernando-mendoza');
+  assert.equal(mendoza.reason, 'not_in_postdraft_alpha_coverage');
+  assert.equal(
+    stubs.filter((stub) => stub.round >= 4)
+      .every((stub) => stub.reason === 'below_day2_scoring_floor'),
+    true,
+  );
 });
 
 test('stub normalization fails closed and board merge gives stub state precedence for 2026', () => {
   const rawStubs = readJson('../data/processed/2026_rookie_stubs_v0.json');
   const stubs = normalizeRookieStubs(rawStubs);
   const mendoza = stubs.find((stub) => stub.playerId === 'qb-fernando-mendoza');
+  const rawCyrus = rawStubs.find((stub) => stub.player_id === 'wr-cyrus-allen');
   assert.ok(mendoza);
+  assert.equal(expectedRookieStubReason(3), 'not_in_postdraft_alpha_coverage');
+  assert.equal(expectedRookieStubReason(4), 'below_day2_scoring_floor');
   assert.equal(normalizeRookieStub({ ...rawStubs[0], alpha_status: 'scored' }), null);
+  assert.equal(normalizeRookieStub({ ...rawStubs[0], reason: 'below_day2_scoring_floor' }), null);
+  assert.equal(normalizeRookieStub({ ...rawCyrus, reason: 'not_in_postdraft_alpha_coverage' }), null);
   assert.equal(normalizeRookieStub({ ...rawStubs[0], provenance: {} }), null);
 
   const existingRows = [
@@ -177,8 +194,18 @@ test('stub board and player renderers disclose draft facts without score or comp
   assert.match(playerHtml, /Cyrus Allen/);
   assert.match(playerHtml, /Overall pick/);
   assert.match(playerHtml, /176/);
+  assert.match(playerHtml, /Below Day-2 scoring floor\./);
   assert.match(playerHtml, /NBC Sports ProFootballTalk/);
   assert.doesNotMatch(playerHtml, /Model Scores|Model Input Radar|PPR|Compare/);
+});
+
+test('round-one stub detail states a coverage gap instead of a scoring-floor claim', () => {
+  const raw = readJson('../data/processed/2026_rookie_stubs_v0.json')
+    .find((stub) => stub.player_id === 'qb-fernando-mendoza');
+  const html = buildRookieStubCardHtml(normalizeRookieStub(raw));
+
+  assert.match(html, /Not included in post-draft Rookie Alpha coverage\./);
+  assert.doesNotMatch(html, /Below Day-2 scoring floor\./);
 });
 
 test('board CSV leaves stub ranks and grades blank without creating scored-rank gaps', () => {

--- a/tests/card-disclosure-wiring.test.mjs
+++ b/tests/card-disclosure-wiring.test.mjs
@@ -7,6 +7,16 @@ import { renderPprProjection } from '../components/rookies/renderPprProjection.j
 import { normalizeRookieIdentity } from '../lib/rookies/normalizeRookieIdentity.js';
 import { isValidTransitionProfileEnvelope } from '../lib/rookies/rookieDataContract.js';
 import { athleticMetricLabel, athleticChipLabel } from '../lib/rookies/athleticLabel.js';
+import {
+  buildRookieStubBoardRow,
+  mergeRookieBoardRowsWithStubs,
+  normalizeRookieStub,
+  normalizeRookieStubs,
+  ROOKIE_STUB_STATUS_COPY,
+} from '../lib/rookies/rookieStubs.js';
+import { renderRookieStubBoardRow } from '../components/rookies/RookieStubBoardRow.js';
+import { buildRookieStubCardHtml } from '../components/rookies/RookieStubCard.js';
+import { buildBoardCsv } from '../lib/rookies/exportCsv.js';
 
 const baseAlphaPlayer = { player_id: 'wr-data-gap-test', position: 'WR' };
 
@@ -86,6 +96,103 @@ test('renderPprProjection adds the grade-band caveat for insufficient-evidence c
 test('WR role label is a neutral receiver profile, not perimeter-specific', () => {
   const identity = normalizeRookieIdentity({ alphaPlayer: { position: 'WR' } });
   assert.equal(identity.roleLabel, 'Receiver profile');
+});
+
+// ── Issue #288 Tier 1: source-backed unscored coverage stubs ───────────────
+
+test('2026 stub artifact is the exact drafted-minus-role-context set with copied provenance', () => {
+  const draftResults = readJson('../data/processed/2026_draft_results.json');
+  const roleContext = readJson('../exports/promoted/rookie-alpha/2026_rookie_alpha_postdraft_role_context_v0.json');
+  const stubs = readJson('../data/processed/2026_rookie_stubs_v0.json');
+  const scoredIds = new Set(roleContext.rows.map((row) => row.player_id));
+  const expectedDraftRows = draftResults.filter(
+    (row) => row.draft_result_status === 'drafted' && !scoredIds.has(row.player_id),
+  );
+  const expectedKeys = [
+    'player_id', 'name', 'position', 'team', 'round', 'overall_pick',
+    'alpha_status', 'reason', 'provenance',
+  ];
+  const expectedProvenanceKeys = [
+    'source_name', 'source_url', 'source_status', 'upstream_provenance_status',
+    'ingested_from', 'ingested_at',
+  ];
+
+  assert.equal(stubs.length, 49);
+  assert.deepEqual(stubs.map((stub) => stub.player_id), expectedDraftRows.map((row) => row.player_id));
+  assert.equal(new Set(stubs.map((stub) => stub.player_id)).size, stubs.length);
+
+  stubs.forEach((stub, index) => {
+    const source = expectedDraftRows[index];
+    assert.deepEqual(Object.keys(stub), expectedKeys);
+    assert.deepEqual(Object.keys(stub.provenance), expectedProvenanceKeys);
+    assert.equal(stub.name, source.player_name);
+    assert.equal(stub.position, source.position);
+    assert.equal(stub.team, source.nfl_team);
+    assert.equal(stub.round, source.draft_round);
+    assert.equal(stub.overall_pick, source.overall_pick);
+    assert.equal(stub.alpha_status, 'not_scored');
+    assert.equal(stub.reason, 'below_day2_scoring_floor');
+    expectedProvenanceKeys.forEach((key) => assert.equal(stub.provenance[key], source[key]));
+  });
+
+  assert.equal(stubs.some((stub) => stub.player_id === 'rb-jeremiyah-love'), false);
+  assert.equal(stubs.some((stub) => stub.player_id === 'qb-fernando-mendoza'), true);
+});
+
+test('stub normalization fails closed and board merge gives stub state precedence for 2026', () => {
+  const rawStubs = readJson('../data/processed/2026_rookie_stubs_v0.json');
+  const stubs = normalizeRookieStubs(rawStubs);
+  const mendoza = stubs.find((stub) => stub.playerId === 'qb-fernando-mendoza');
+  assert.ok(mendoza);
+  assert.equal(normalizeRookieStub({ ...rawStubs[0], alpha_status: 'scored' }), null);
+  assert.equal(normalizeRookieStub({ ...rawStubs[0], provenance: {} }), null);
+
+  const existingRows = [
+    { playerId: 'qb-fernando-mendoza', slug: 'qb-fernando-mendoza', draftClass: 2026, rookieGrade: 77 },
+    { playerId: 'wr-scored-control', slug: 'wr-scored-control', draftClass: 2026, rookieGrade: 70 },
+    { playerId: 'qb-fernando-mendoza', slug: 'historical-mendoza', draftClass: 2025, rookieGrade: 60 },
+  ];
+  const merged = mergeRookieBoardRowsWithStubs(existingRows, [mendoza]);
+
+  assert.equal(merged.filter((row) => row.slug === 'qb-fernando-mendoza').length, 1);
+  assert.equal(merged.find((row) => row.slug === 'qb-fernando-mendoza').alphaStatus, 'not_scored');
+  assert.equal(merged.some((row) => row.slug === 'wr-scored-control'), true);
+  assert.equal(merged.some((row) => row.slug === 'historical-mendoza'), true);
+});
+
+test('stub board and player renderers disclose draft facts without score or compare surfaces', () => {
+  const raw = readJson('../data/processed/2026_rookie_stubs_v0.json')
+    .find((stub) => stub.player_id === 'wr-cyrus-allen');
+  const stub = normalizeRookieStub(raw);
+  const boardHtml = renderRookieStubBoardRow(buildRookieStubBoardRow(stub));
+  const playerHtml = buildRookieStubCardHtml(stub);
+
+  assert.match(boardHtml, new RegExp(ROOKIE_STUB_STATUS_COPY));
+  assert.match(boardHtml, /KC · Round 5 · Pick 176/);
+  assert.match(boardHtml, /Unavailable in stub/);
+  assert.doesNotMatch(boardHtml, /Compare/);
+  assert.doesNotMatch(boardHtml, /Add to queue/);
+
+  assert.match(playerHtml, new RegExp(ROOKIE_STUB_STATUS_COPY));
+  assert.match(playerHtml, /Cyrus Allen/);
+  assert.match(playerHtml, /Overall pick/);
+  assert.match(playerHtml, /176/);
+  assert.match(playerHtml, /NBC Sports ProFootballTalk/);
+  assert.doesNotMatch(playerHtml, /Model Scores|Model Input Radar|PPR|Compare/);
+});
+
+test('board CSV leaves stub ranks and grades blank without creating scored-rank gaps', () => {
+  const csv = buildBoardCsv([
+    { name: 'Scored One', alphaStatus: 'scored', rookieGrade: 70 },
+    { name: 'Cyrus Allen', alphaStatus: 'not_scored', rookieGrade: null },
+    { name: 'Scored Two', alphaStatus: 'scored', rookieGrade: 65 },
+  ]);
+  const [, scoredOne, cyrus, scoredTwo] = csv.split('\n');
+
+  assert.equal(scoredOne.split(',')[0], '1');
+  assert.equal(cyrus.split(',')[0], '');
+  assert.equal(cyrus.split(',')[7], '');
+  assert.equal(scoredTwo.split(',')[0], '2');
 });
 
 // ── Phase 1A: card temporal-integrity contract ──────────────────────────────

--- a/tests/runtime-server.smoke.test.cjs
+++ b/tests/runtime-server.smoke.test.cjs
@@ -136,6 +136,26 @@ test('standalone runtime smoke routes', async (t) => {
     assert.match(body, /<!doctype html>/i);
   }
 
+  const boardPage = await fetch(buildUrl(port, '/cards/rookies/board/index.html'));
+  const boardHtml = await boardPage.text();
+  assert.match(boardHtml, /get2026RookieStubs/);
+  assert.match(boardHtml, /mergeRookieBoardRowsWithStubs/);
+
+  const playerPage = await fetch(buildUrl(port, '/cards/rookies/player.html?slug=wr-cyrus-allen'));
+  const playerHtml = await playerPage.text();
+  assert.match(playerHtml, /findRookieStubBySlug/);
+  assert.match(playerHtml, /renderRookieStubCard/);
+
+  const rookieStubs = await fetch(
+    buildUrl(port, '/data/processed/2026_rookie_stubs_v0.json'),
+  );
+  assert.equal(rookieStubs.status, 200);
+  assert.match(rookieStubs.headers.get('content-type') || '', /application\/json/);
+  const stubPayload = await rookieStubs.json();
+  assert.equal(stubPayload.length, 49);
+  assert.equal(stubPayload[0].alpha_status, 'not_scored');
+  assert.equal(stubPayload[0].reason, 'below_day2_scoring_floor');
+
   const css = await fetch(buildUrl(port, '/components/rookies/rookieCardStyles.css'));
   assert.equal(css.status, 200);
   assert.match(css.headers.get('content-type') || '', /text\/css/);

--- a/tests/runtime-server.smoke.test.cjs
+++ b/tests/runtime-server.smoke.test.cjs
@@ -154,7 +154,12 @@ test('standalone runtime smoke routes', async (t) => {
   const stubPayload = await rookieStubs.json();
   assert.equal(stubPayload.length, 49);
   assert.equal(stubPayload[0].alpha_status, 'not_scored');
-  assert.equal(stubPayload[0].reason, 'below_day2_scoring_floor');
+  assert.equal(stubPayload[0].reason, 'not_in_postdraft_alpha_coverage');
+  assert.equal(
+    stubPayload.filter((stub) => stub.round >= 4)
+      .every((stub) => stub.reason === 'below_day2_scoring_floor'),
+    true,
+  );
 
   const css = await fetch(buildUrl(port, '/components/rookies/rookieCardStyles.css'));
   assert.equal(css.status, 200);


### PR DESCRIPTION
Implements Tier 1 of #288.

## 1. What lane is this?

**Product.** This is the operator-authorized, bounded Tier 1 coverage-floor implementation from Brief B.

## 2. What repo owns it?

**TIBER-Rookies.** This repo owns rookie data shaping and the standalone rookie-card runtime surfaces.

## 3. What changed?

- Added a deterministic generator and `data/processed/2026_rookie_stubs_v0.json`.
- Generated **49** stub rows: the exact canonical-`player_id` difference between 81 drafted rows in `2026_draft_results.json` and 32 rows in the promoted post-draft role-context artifact.
- Copied source lineage exactly into nested provenance: `source_name`, `source_url`, `source_status`, `upstream_provenance_status`, `ingested_from`, and `ingested_at`.
- Added truthful round-aware reasons: `not_in_postdraft_alpha_coverage` for Rounds 1–3 and `below_day2_scoring_floor` for Rounds 4–7.
- Added Board/Player-only loading with stub precedence for overlapping pre-draft cards, so all required stub IDs visibly render as **“unscored — draft-fact only”**.
- Added purpose-built stub board/detail renderers that show only identity, team, round, pick, reason, and provenance.
- Kept stub rows out of compare/queue behavior and left their CSV rank/grade blank.

Root cause: the runtime had no representation for draft-result players outside the scored role-context coverage set, so those players had no honest draft-fact-only state to attach to.

Review correction: the initial brief prescribed `below_day2_scoring_floor` for every stub. Review identified that this would be false for Fernando Mendoza (Round 1, pick 1). The operator authorized the review to supersede that blanket requirement, so the generator, regenerated artifact, closed validator, and player-page copy now use the round-aware reason contract together.

## 4. What is explicitly out of scope?

- Tier 2 / Day-3 Alpha methodology or any model scoring change.
- Any file under `exports/promoted/`.
- Gallery, Compare, Swipe, or ML Workbench stub support.
- TIBER-Fantasy or other downstream repos.
- Upstream expansion of the current draft-results input beyond its 81 QB/RB/WR/TE rows.
- Special routing changes in `runtime-server.js`; its existing static resolver already serves the new JSON and both pages.

## 5. What guardrails apply?

- Join coverage by canonical `player_id`, never by name/team display text.
- Preserve provenance without relabeling or synthesizing source fields.
- Do not invent grades, tiers, projections, model edges, scouting claims, or false reason codes.
- Enforce the closed reason mapping by draft round: Rounds 1–3 are coverage gaps; Rounds 4–7 are below the Day-2 floor.
- Do not recompute model output at request time.
- Keep unscored stubs visibly unranked and unavailable to scored-card comparison flows.
- Make no changes under `exports/promoted/`.

## 6. What tests / builds ran?

- `python3 scripts/build_2026_rookie_stubs.py --check` — passed; artifact current at 49 rows.
- `npm run test:runtime-smoke` — passed, 1/1.
- `npm run test:card-disclosure` — passed, 39/39.
- Python compile, new-module `node --check`, and `git diff --check` — passed.
- Promoted-export diff guard — passed; zero changed files under `exports/promoted/`.
- **GitHub CI run 1159 passed** its full Python tests, promoted-export validation, runtime smoke tests, and card-disclosure tests.

## 7. What follow-up remains parked?

- Tier 2 scoring/methodology remains parked in #288.
- The issue body describes all 257 picks, while the current processed input contains 81 drafted skill-position rows; upstream full-draft expansion remains parked.
- Any future stub-safe Gallery/Compare/Swipe behavior remains separately scoped.
