### PR TITLE
Extend promoted-export integrity enforcement to all five artifact families (#274 Finding 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
             --export-json exports/promoted/rookie-alpha/2026_rookie_alpha_predraft_v0.json \
             --manifest exports/promoted/rookie-alpha/2026_manifest.json
 
+      - name: Validate promoted export integrity (all artifact families)
+        run: python3 scripts/validate_promoted_integrity.py
+
       - name: Set up Node
         uses: actions/setup-node@v4
         with:

--- a/exports/promoted_integrity_registry_v0.json
+++ b/exports/promoted_integrity_registry_v0.json
@@ -1,0 +1,272 @@
+{
+  "schema_version": "promoted-integrity-registry-v0.1.0",
+  "families": [
+    {
+      "family": "historical-comps",
+      "manifest_checks": [],
+      "artifacts": [
+        {
+          "path": "2026_historical_comps_v0.json",
+          "sha256": "5d2f43eca5db11ac787ec7343a52a1990e3f037f15e218b89c51cfc4eb26756a",
+          "bytes": 128098
+        }
+      ]
+    },
+    {
+      "family": "nfl-fantasy-outcomes",
+      "manifest_checks": [],
+      "artifacts": [
+        {
+          "path": "context_flag_outcome_summary_v1.csv",
+          "sha256": "fa3453810020ae3c9f888dfa823cc9040c8a78b7b1c9136912a81a60eb97edd2",
+          "bytes": 45431
+        },
+        {
+          "path": "context_flag_outcome_summary_v1.json",
+          "sha256": "c4dc6f541195e0cbf7ed4039f9fdb17b57af71f0be77042499b32aa0782eb1a2",
+          "bytes": 62027
+        },
+        {
+          "path": "player_year_ppr_outcomes_v1.csv",
+          "sha256": "0e60c176c421022da8e85c66822b1b86e7e1555a07200d7f108ca4fb1654b279",
+          "bytes": 2496437
+        },
+        {
+          "path": "player_year_ppr_outcomes_v1.json",
+          "sha256": "eaf5044e89738eb0ea7300c1e313f4978d22fa956627bf19c460febec01a6d54",
+          "bytes": 6412381
+        }
+      ]
+    },
+    {
+      "family": "rookie-alpha",
+      "manifest_checks": [
+        {
+          "validator": "rookie-alpha-manifest-v0",
+          "export_json": "2022_rookie_alpha_predraft_v0.json",
+          "manifest": "2022_manifest.json"
+        },
+        {
+          "validator": "rookie-alpha-manifest-v0",
+          "export_json": "2023_rookie_alpha_predraft_v0.json",
+          "manifest": "2023_manifest.json"
+        },
+        {
+          "validator": "rookie-alpha-manifest-v0",
+          "export_json": "2024_rookie_alpha_predraft_v0.json",
+          "manifest": "2024_manifest.json"
+        },
+        {
+          "validator": "rookie-alpha-manifest-v0",
+          "export_json": "2025_rookie_alpha_predraft_v0.json",
+          "manifest": "2025_manifest.json"
+        },
+        {
+          "validator": "rookie-alpha-manifest-v0",
+          "export_json": "2026_rookie_alpha_predraft_v0.json",
+          "manifest": "2026_manifest.json"
+        }
+      ],
+      "artifacts": [
+        {
+          "path": "2022_manifest.json",
+          "sha256": "cbacccbf1397199fb398f29f9936f34d07bb6ba82c0ce839a191ed428bf8b911",
+          "bytes": 2546
+        },
+        {
+          "path": "2022_rookie_alpha_predraft_v0.csv",
+          "sha256": "5538a64abaac84ee1afbcc11c296b263f524e8f7c7925f37339936972470cac5",
+          "bytes": 3501
+        },
+        {
+          "path": "2022_rookie_alpha_predraft_v0.json",
+          "sha256": "42558cb14dfde603025a04fe55f69d5637229453901516fcec9eff36d422dc76",
+          "bytes": 38076
+        },
+        {
+          "path": "2023_manifest.json",
+          "sha256": "761ae24780aab0a165d7c0027893d75c731f97788e738f44747c4228e8beec8c",
+          "bytes": 2544
+        },
+        {
+          "path": "2023_rookie_alpha_predraft_v0.csv",
+          "sha256": "51c4cf4a388819a233778cc749f0578e426bdd6bd74ed1ea58748065c8d157fc",
+          "bytes": 3147
+        },
+        {
+          "path": "2023_rookie_alpha_predraft_v0.json",
+          "sha256": "a37d5ca72409b0c18b1fd28d315d5192068df6702be28b392409e848a06590b6",
+          "bytes": 40406
+        },
+        {
+          "path": "2024_manifest.json",
+          "sha256": "393fa878cd8a9a54abac5778eb66da7c2c1f23eef6724a33a360f074bd704f6f",
+          "bytes": 2784
+        },
+        {
+          "path": "2024_rookie_alpha_predraft_v0.csv",
+          "sha256": "aec0923fcc56715d13a4ed67f7d919d9d24ba08761872eb400889268aad69c86",
+          "bytes": 3820
+        },
+        {
+          "path": "2024_rookie_alpha_predraft_v0.json",
+          "sha256": "2dffd50acbf9d6a63ec83a529b6102d2d01ef4324f97c77ad4c255a55a3d162c",
+          "bytes": 57138
+        },
+        {
+          "path": "2025_manifest.json",
+          "sha256": "b21644fea3051807b88e0f1a711a51fb96a643708511716d12ad6a87a7e175d4",
+          "bytes": 2786
+        },
+        {
+          "path": "2025_rookie_alpha_predraft_v0.csv",
+          "sha256": "38a2f849249dea023c6efba9b3426f9370c2b73090749086e19d59631cd1f331",
+          "bytes": 14773
+        },
+        {
+          "path": "2025_rookie_alpha_predraft_v0.json",
+          "sha256": "eac4ce0e76c8a1f85a8ba9bf97c461f6be61ac78399d33307c2c4fe1086af4f6",
+          "bytes": 252390
+        },
+        {
+          "path": "2026_manifest.json",
+          "sha256": "c2f6c2d2c8c4a7f8f49a7b4a6de44fb941d40e22deae93991a2d2abe178066a8",
+          "bytes": 2793
+        },
+        {
+          "path": "2026_rookie_alpha_postdraft_missing_baselines_v0.json",
+          "sha256": "37517e5f3dc66819f61f5a7bb8ace1921282415f10551d2defa5c3eb0985b570",
+          "bytes": 3
+        },
+        {
+          "path": "2026_rookie_alpha_postdraft_role_context_v0.csv",
+          "sha256": "b337703ff8de7f0de891e6f1a42689d7255a1d3b50a718d6e14c0853934d11ef",
+          "bytes": 45594
+        },
+        {
+          "path": "2026_rookie_alpha_postdraft_role_context_v0.json",
+          "sha256": "205c8d64232f072308f55bd9b163783d86ffa4bcb22131233708877c6e9a907d",
+          "bytes": 97133
+        },
+        {
+          "path": "2026_rookie_alpha_postdraft_team_context_v0.csv",
+          "sha256": "30a18e39a9b7f4791a73e8fa99ae3b5700649f9241c7bef0163c27cec4b13190",
+          "bytes": 32325
+        },
+        {
+          "path": "2026_rookie_alpha_postdraft_team_context_v0.json",
+          "sha256": "b5dfc4df994d7d8a3e48e2fcf06af44ce3ac3b1308fbd4111501eec5266f1963",
+          "bytes": 66970
+        },
+        {
+          "path": "2026_rookie_alpha_postdraft_v0.csv",
+          "sha256": "4af6505fb49027d8604bee66d09b7ac3cdbfffed81f5fd7e5bc5542c7eb785ce",
+          "bytes": 19215
+        },
+        {
+          "path": "2026_rookie_alpha_postdraft_v0.json",
+          "sha256": "cfa6689e7c8ea2031acc8b156fa2c3fd1703ae4d00e8ed881bc351ecf6173271",
+          "bytes": 40324
+        },
+        {
+          "path": "2026_rookie_alpha_predraft_v0.csv",
+          "sha256": "aef3105e6c2a56aa44dc79c519d61ab0150a47ec66399d84ba86547934050e99",
+          "bytes": 10898
+        },
+        {
+          "path": "2026_rookie_alpha_predraft_v0.json",
+          "sha256": "5a7c6c945ad477c1a54e61e7337e9f5bd6b5e69455669ca4700d7668fe9816e3",
+          "bytes": 191496
+        },
+        {
+          "path": "historical_class_comparison.csv",
+          "sha256": "58660a392b4e51dbf1b3e6ce116f5ada05330307b7efb3b6d81124a70767ae0c",
+          "bytes": 6488
+        },
+        {
+          "path": "historical_class_comparison.json",
+          "sha256": "ba4acf55c796a1a345fa4a59cc41331f756e7f7f418f1b4f6d678f2fa668e283",
+          "bytes": 30686
+        }
+      ]
+    },
+    {
+      "family": "rookie-ml-lane",
+      "manifest_checks": [],
+      "artifacts": [
+        {
+          "path": "dataset_diagnostics.json",
+          "sha256": "89947ec0c97e0a00defe10bbf7c5341fd1b654b4c8668fb193280f1b5d045291",
+          "bytes": 1100
+        },
+        {
+          "path": "evaluation_report.json",
+          "sha256": "b9c448e95ef0ce1d097eefbfffc9bd1e00612874f945f4fad7202687a6a98585",
+          "bytes": 12873
+        },
+        {
+          "path": "feature_coverage_report.json",
+          "sha256": "dabb3bd6039bea9ac61c5dd5873f0559a68644b9d0ccc459348ad5b6bdc1b1a4",
+          "bytes": 3673
+        },
+        {
+          "path": "feature_importance_report.json",
+          "sha256": "839e416cc019e3b6f0913f647bf429eb3703e3f975f6e9bb80f1717abab3a104",
+          "bytes": 1122
+        },
+        {
+          "path": "feature_table.json",
+          "sha256": "99dca17ae65043312a57e7ca4f8dbf39442a2d8cd41ea0c1ac51e001a67d3a8e",
+          "bytes": 14851
+        },
+        {
+          "path": "heldout_probabilities.csv",
+          "sha256": "3a57453506050dd20e1c497b83705e4279757c7dbfe67f7aa4ac973b11f8b4f6",
+          "bytes": 253
+        },
+        {
+          "path": "heldout_probabilities.json",
+          "sha256": "9fecb43979174820e8f704983025c36004d6d0e02abc74772d323057844244f6",
+          "bytes": 366
+        },
+        {
+          "path": "historical_labeled_dataset.csv",
+          "sha256": "0561559e00022a3a2d53a3c1fc7573f8486e196f682301f55934fcae00bf6fa8",
+          "bytes": 4321
+        },
+        {
+          "path": "historical_labeled_dataset.json",
+          "sha256": "279cef5ee2fa40b99c2e283feff3c894ea650ea193833a5cedb0bc1d54499356",
+          "bytes": 18524
+        }
+      ]
+    },
+    {
+      "family": "rookie-transition-profile",
+      "manifest_checks": [
+        {
+          "validator": "rookie-transition-profile-v0",
+          "export_json": "2026_rookie_transition_profile_v0.json",
+          "manifest": "2026_manifest.json"
+        }
+      ],
+      "artifacts": [
+        {
+          "path": "2026_manifest.json",
+          "sha256": "0acf361c6d2d8cc6f684026481a5aa279e9f7fa718256fad78da0366d5804413",
+          "bytes": 2943
+        },
+        {
+          "path": "2026_rookie_transition_profile_v0.csv",
+          "sha256": "3005bcd6ad4ffc87a312c6926e20c5e3658747012855aa9d8ccfa33d898545e6",
+          "bytes": 63915
+        },
+        {
+          "path": "2026_rookie_transition_profile_v0.json",
+          "sha256": "c95b941c7855612daccfc2226fc51e0e34dbb2ebe8a2487596675d2522a22f37",
+          "bytes": 155916
+        }
+      ]
+    }
+  ]
+}

--- a/exports/promoted_integrity_registry_v0.json
+++ b/exports/promoted_integrity_registry_v0.json
@@ -1,9 +1,8 @@
 {
-  "schema_version": "promoted-integrity-registry-v0.1.0",
+  "schema_version": "promoted-integrity-registry-v0.2.0",
   "families": [
     {
       "family": "historical-comps",
-      "manifest_checks": [],
       "artifacts": [
         {
           "path": "2026_historical_comps_v0.json",
@@ -14,7 +13,6 @@
     },
     {
       "family": "nfl-fantasy-outcomes",
-      "manifest_checks": [],
       "artifacts": [
         {
           "path": "context_flag_outcome_summary_v1.csv",
@@ -40,33 +38,6 @@
     },
     {
       "family": "rookie-alpha",
-      "manifest_checks": [
-        {
-          "validator": "rookie-alpha-manifest-v0",
-          "export_json": "2022_rookie_alpha_predraft_v0.json",
-          "manifest": "2022_manifest.json"
-        },
-        {
-          "validator": "rookie-alpha-manifest-v0",
-          "export_json": "2023_rookie_alpha_predraft_v0.json",
-          "manifest": "2023_manifest.json"
-        },
-        {
-          "validator": "rookie-alpha-manifest-v0",
-          "export_json": "2024_rookie_alpha_predraft_v0.json",
-          "manifest": "2024_manifest.json"
-        },
-        {
-          "validator": "rookie-alpha-manifest-v0",
-          "export_json": "2025_rookie_alpha_predraft_v0.json",
-          "manifest": "2025_manifest.json"
-        },
-        {
-          "validator": "rookie-alpha-manifest-v0",
-          "export_json": "2026_rookie_alpha_predraft_v0.json",
-          "manifest": "2026_manifest.json"
-        }
-      ],
       "artifacts": [
         {
           "path": "2022_manifest.json",
@@ -192,7 +163,6 @@
     },
     {
       "family": "rookie-ml-lane",
-      "manifest_checks": [],
       "artifacts": [
         {
           "path": "dataset_diagnostics.json",
@@ -243,13 +213,6 @@
     },
     {
       "family": "rookie-transition-profile",
-      "manifest_checks": [
-        {
-          "validator": "rookie-transition-profile-v0",
-          "export_json": "2026_rookie_transition_profile_v0.json",
-          "manifest": "2026_manifest.json"
-        }
-      ],
       "artifacts": [
         {
           "path": "2026_manifest.json",

--- a/scripts/validate_promoted_integrity.py
+++ b/scripts/validate_promoted_integrity.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+"""Fail-closed integrity validation for every promoted export artifact family.
+
+`validate_promoted_export.py` and `validate_rookie_transition_profile.py` each
+enforce a rich manifest contract, but only for the families that declare a
+manifest. This script closes the gap identified in issue #274 Finding 1: it
+holds a byte-level digest for *every* file under `exports/promoted/`, so a
+directly-edited promoted artifact is rejected in CI regardless of which family
+it belongs to.
+
+Two enforcement tiers are declared per family in the registry:
+
+* ``digest``   - registry <-> disk bijection plus sha256/size of canonical bytes.
+                 Applies to every promoted artifact without exception.
+* ``manifest`` - the family additionally declares an export/manifest pair, which
+                 is delegated to that family's existing validator on top of the
+                 digest tier.
+
+The digest tier is never a fallback for a *skipped* family. Every file is
+digest-checked; the manifest tier is strictly additive where a manifest
+contract already exists in the repository. Families without a manifest are
+declared as such in the registry rather than silently passed over.
+
+The registry records only values mechanically derived from the canonical bytes
+already committed to the repository (path, sha256, size) plus the family's
+already-declared manifest contract. It invents no schema identity, run id, or
+provenance for artifacts that do not carry one.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+from typing import Any, Callable
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.validate_promoted_export import (  # noqa: E402
+    validate_export_manifest as validate_rookie_alpha_manifest,
+)
+from scripts.validate_rookie_transition_profile import (  # noqa: E402
+    validate_export_manifest as validate_rookie_transition_profile_manifest,
+)
+
+REGISTRY_SCHEMA_VERSION = "promoted-integrity-registry-v0.1.0"
+
+DEFAULT_PROMOTED_ROOT = REPO_ROOT / "exports/promoted"
+DEFAULT_REGISTRY = REPO_ROOT / "exports/promoted_integrity_registry_v0.json"
+
+# The declared promoted artifact universe. Shrinking this set is a contract
+# change, not a validator change: an unexpected or absent family fails closed.
+DECLARED_FAMILIES = (
+    "historical-comps",
+    "nfl-fantasy-outcomes",
+    "rookie-alpha",
+    "rookie-ml-lane",
+    "rookie-transition-profile",
+)
+
+MANIFEST_VALIDATORS: dict[str, Callable[..., list[str]]] = {
+    "rookie-alpha-manifest-v0": validate_rookie_alpha_manifest,
+    "rookie-transition-profile-v0": validate_rookie_transition_profile_manifest,
+}
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def load_json(path: Path) -> Any:
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def iter_promoted_files(promoted_root: Path) -> list[str]:
+    """Every file under the promoted root, as sorted POSIX-relative paths."""
+    return sorted(
+        p.relative_to(promoted_root).as_posix()
+        for p in promoted_root.rglob("*")
+        if p.is_file()
+    )
+
+
+def build_registry(promoted_root: Path, registry_path: Path) -> dict[str, Any]:
+    """Derive a registry from the canonical bytes currently on disk.
+
+    Manifest pairings are carried over from the existing registry when present,
+    because which export/manifest pairs a family declares is a contract fact,
+    not something derivable from bytes.
+    """
+    existing_checks: dict[str, list[dict[str, str]]] = {}
+    if registry_path.exists():
+        for family in load_json(registry_path).get("families", []):
+            existing_checks[family["family"]] = family.get("manifest_checks", [])
+
+    families = []
+    for family_name in DECLARED_FAMILIES:
+        family_dir = promoted_root / family_name
+        artifacts = [
+            {
+                "path": rel,
+                "sha256": sha256_file(family_dir / rel),
+                "bytes": (family_dir / rel).stat().st_size,
+            }
+            for rel in iter_promoted_files(family_dir)
+        ]
+        families.append(
+            {
+                "family": family_name,
+                "manifest_checks": existing_checks.get(family_name, []),
+                "artifacts": artifacts,
+            }
+        )
+    return {"schema_version": REGISTRY_SCHEMA_VERSION, "families": families}
+
+
+def _validate_family_artifacts(
+    family_name: str, entries: list[Any], promoted_root: Path
+) -> tuple[list[str], set[str]]:
+    """Digest-tier checks for one family. Returns (errors, registered paths)."""
+    errors: list[str] = []
+    registered: set[str] = set()
+
+    for entry in entries:
+        if not isinstance(entry, dict):
+            errors.append(f"[{family_name}] artifact entries must be objects, got: {entry!r}")
+            continue
+        rel_path = entry.get("path")
+        expected_hash = entry.get("sha256")
+        expected_bytes = entry.get("bytes")
+        if not rel_path or not expected_hash or expected_bytes is None:
+            errors.append(f"[{family_name}] artifact entry missing path/sha256/bytes: {entry!r}")
+            continue
+
+        registry_key = f"{family_name}/{rel_path}"
+        if registry_key in registered:
+            errors.append(f"[{family_name}] duplicate registry entry: {rel_path}")
+            continue
+        registered.add(registry_key)
+
+        family_root = (promoted_root / family_name).resolve()
+        resolved = promoted_root / family_name / rel_path
+        # A registry entry must not reach outside the family it declares.
+        if not resolved.resolve().is_relative_to(family_root):
+            errors.append(f"[{family_name}] registry path escapes the family directory: {rel_path}")
+            continue
+        if not resolved.is_file():
+            errors.append(f"[{family_name}] registered artifact is missing from disk: {rel_path}")
+            continue
+
+        actual_bytes = resolved.stat().st_size
+        if actual_bytes != expected_bytes:
+            errors.append(
+                f"[{family_name}] size mismatch for {rel_path}: "
+                f"expected {expected_bytes}, got {actual_bytes}"
+            )
+        actual_hash = sha256_file(resolved)
+        if actual_hash != expected_hash:
+            errors.append(
+                f"[{family_name}] sha256 mismatch for {rel_path}: "
+                f"expected {expected_hash}, got {actual_hash}"
+            )
+
+    return errors, registered
+
+
+def _validate_family_manifests(
+    family_name: str, checks: list[Any], promoted_root: Path
+) -> list[str]:
+    """Manifest-tier checks, delegated to the family's declared validator."""
+    errors: list[str] = []
+    for check in checks:
+        if not isinstance(check, dict):
+            errors.append(f"[{family_name}] manifest_checks entries must be objects, got: {check!r}")
+            continue
+        validator_name = check.get("validator")
+        export_rel = check.get("export_json")
+        manifest_rel = check.get("manifest")
+        if not validator_name or not export_rel or not manifest_rel:
+            errors.append(
+                f"[{family_name}] manifest check missing validator/export_json/manifest: {check!r}"
+            )
+            continue
+        validator = MANIFEST_VALIDATORS.get(validator_name)
+        if validator is None:
+            errors.append(
+                f"[{family_name}] unknown manifest validator {validator_name!r}; "
+                f"declared validators: {sorted(MANIFEST_VALIDATORS)}"
+            )
+            continue
+        export_path = promoted_root / family_name / export_rel
+        manifest_path = promoted_root / family_name / manifest_rel
+        for err in validator(export_path=export_path, manifest_path=manifest_path):
+            errors.append(f"[{family_name}] {export_rel}: {err}")
+    return errors
+
+
+def validate_promoted_integrity(
+    promoted_root: Path, registry_path: Path
+) -> tuple[list[str], dict[str, dict[str, int]]]:
+    """Validate every promoted artifact. Returns (errors, per-family coverage)."""
+    coverage: dict[str, dict[str, int]] = {}
+
+    if not registry_path.is_file():
+        return ([f"Integrity registry not found: {registry_path}"], coverage)
+    if not promoted_root.is_dir():
+        return ([f"Promoted export root not found: {promoted_root}"], coverage)
+
+    try:
+        registry = load_json(registry_path)
+    except Exception as exc:
+        return ([f"Failed to parse integrity registry: {exc}"], coverage)
+
+    if not isinstance(registry, dict):
+        return (["Integrity registry must be a JSON object."], coverage)
+    if registry.get("schema_version") != REGISTRY_SCHEMA_VERSION:
+        return (
+            [
+                f"Integrity registry schema_version mismatch: expected "
+                f"{REGISTRY_SCHEMA_VERSION!r}, got {registry.get('schema_version')!r}"
+            ],
+            coverage,
+        )
+
+    families = registry.get("families")
+    if not isinstance(families, list):
+        return (["Integrity registry 'families' must be a list."], coverage)
+
+    errors: list[str] = []
+    registered_paths: set[str] = set()
+
+    registered_families = [f.get("family") for f in families if isinstance(f, dict)]
+    missing_families = set(DECLARED_FAMILIES) - set(registered_families)
+    if missing_families:
+        errors.append(
+            f"Integrity registry does not declare required families: {sorted(missing_families)}"
+        )
+    unexpected_families = set(registered_families) - set(DECLARED_FAMILIES)
+    if unexpected_families:
+        errors.append(
+            f"Integrity registry declares unknown families: {sorted(unexpected_families)}"
+        )
+
+    for family in families:
+        if not isinstance(family, dict):
+            errors.append(f"Registry family entries must be objects, got: {family!r}")
+            continue
+        family_name = family.get("family")
+        if family_name not in DECLARED_FAMILIES:
+            continue
+        entries = family.get("artifacts")
+        if not isinstance(entries, list):
+            errors.append(f"[{family_name}] 'artifacts' must be a list.")
+            continue
+        if not entries:
+            errors.append(f"[{family_name}] declares no artifacts; the family must not be empty.")
+            continue
+
+        family_errors, family_registered = _validate_family_artifacts(
+            family_name, entries, promoted_root
+        )
+        errors.extend(family_errors)
+        registered_paths |= family_registered
+
+        checks = family.get("manifest_checks", [])
+        if not isinstance(checks, list):
+            errors.append(f"[{family_name}] 'manifest_checks' must be a list.")
+            checks = []
+        errors.extend(_validate_family_manifests(family_name, checks, promoted_root))
+
+        coverage[family_name] = {
+            "artifacts": len(family_registered),
+            "manifest_checks": len(checks),
+        }
+
+    # Bijection: an artifact added to the tree without a registered digest is
+    # exactly the direct-edit bypass this check exists to stop.
+    on_disk = set(iter_promoted_files(promoted_root))
+    unregistered = on_disk - registered_paths
+    for rel_path in sorted(unregistered):
+        errors.append(f"Promoted artifact is not registered in the integrity registry: {rel_path}")
+
+    return (errors, coverage)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Validate byte-level integrity of every promoted export artifact"
+    )
+    parser.add_argument("--promoted-root", type=Path, default=DEFAULT_PROMOTED_ROOT)
+    parser.add_argument("--registry", type=Path, default=DEFAULT_REGISTRY)
+    parser.add_argument(
+        "--update",
+        action="store_true",
+        help="Rewrite the registry from the canonical bytes on disk instead of validating.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    if args.update:
+        registry = build_registry(args.promoted_root, args.registry)
+        args.registry.write_text(json.dumps(registry, indent=2) + "\n", encoding="utf-8")
+        total = sum(len(f["artifacts"]) for f in registry["families"])
+        print(f"Wrote {args.registry} covering {total} artifacts across {len(registry['families'])} families.")
+        return
+
+    errors, coverage = validate_promoted_integrity(args.promoted_root, args.registry)
+
+    for family_name in DECLARED_FAMILIES:
+        stats = coverage.get(family_name)
+        if stats is None:
+            print(f"- {family_name}: NOT COVERED")
+            continue
+        print(
+            f"- {family_name}: {stats['artifacts']} artifacts digest-checked, "
+            f"{stats['manifest_checks']} manifest contract(s) enforced"
+        )
+
+    if errors:
+        print("PROMOTED INTEGRITY VALIDATION FAILED")
+        for err in errors:
+            print(f"- {err}")
+        raise SystemExit(1)
+
+    total = sum(stats["artifacts"] for stats in coverage.values())
+    print(f"PROMOTED INTEGRITY VALIDATION PASSED ({total} artifacts across {len(coverage)} families)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate_promoted_integrity.py
+++ b/scripts/validate_promoted_integrity.py
@@ -47,7 +47,7 @@ from scripts.validate_rookie_transition_profile import (  # noqa: E402
     validate_export_manifest as validate_rookie_transition_profile_manifest,
 )
 
-REGISTRY_SCHEMA_VERSION = "promoted-integrity-registry-v0.1.0"
+REGISTRY_SCHEMA_VERSION = "promoted-integrity-registry-v0.2.0"
 
 DEFAULT_PROMOTED_ROOT = REPO_ROOT / "exports/promoted"
 DEFAULT_REGISTRY = REPO_ROOT / "exports/promoted_integrity_registry_v0.json"
@@ -65,6 +65,30 @@ DECLARED_FAMILIES = (
 MANIFEST_VALIDATORS: dict[str, Callable[..., list[str]]] = {
     "rookie-alpha-manifest-v0": validate_rookie_alpha_manifest,
     "rookie-transition-profile-v0": validate_rookie_transition_profile_manifest,
+}
+
+# The authoritative manifest-delegation contract, pinned here rather than in the
+# registry. The registry is a digest record and is expected to change whenever a
+# promoted artifact is legitimately regenerated; which export/manifest pairs must
+# be enforced is a contract fact that must not be editable alongside it.
+#
+# Driving delegation from registry data allowed a tampered registry to swap the
+# 2022-2025 rookie-alpha entries for duplicates of the valid 2026 tuple: the
+# count stayed at five and CI stayed green while four manifest contracts went
+# unenforced. Each tuple below is (validator, export_json, manifest), relative to
+# the family directory, and the set is required to be exact and duplicate-free.
+EXPECTED_MANIFEST_CHECKS: dict[str, tuple[tuple[str, str, str], ...]] = {
+    "rookie-alpha": tuple(
+        ("rookie-alpha-manifest-v0", f"{year}_rookie_alpha_predraft_v0.json", f"{year}_manifest.json")
+        for year in (2022, 2023, 2024, 2025, 2026)
+    ),
+    "rookie-transition-profile": (
+        (
+            "rookie-transition-profile-v0",
+            "2026_rookie_transition_profile_v0.json",
+            "2026_manifest.json",
+        ),
+    ),
 }
 
 
@@ -90,18 +114,12 @@ def iter_promoted_files(promoted_root: Path) -> list[str]:
     )
 
 
-def build_registry(promoted_root: Path, registry_path: Path) -> dict[str, Any]:
+def build_registry(promoted_root: Path) -> dict[str, Any]:
     """Derive a registry from the canonical bytes currently on disk.
 
-    Manifest pairings are carried over from the existing registry when present,
-    because which export/manifest pairs a family declares is a contract fact,
-    not something derivable from bytes.
+    Digests only. Which export/manifest pairs must be enforced is pinned in
+    EXPECTED_MANIFEST_CHECKS and is deliberately not regenerable from bytes.
     """
-    existing_checks: dict[str, list[dict[str, str]]] = {}
-    if registry_path.exists():
-        for family in load_json(registry_path).get("families", []):
-            existing_checks[family["family"]] = family.get("manifest_checks", [])
-
     families = []
     for family_name in DECLARED_FAMILIES:
         family_dir = promoted_root / family_name
@@ -113,13 +131,7 @@ def build_registry(promoted_root: Path, registry_path: Path) -> dict[str, Any]:
             }
             for rel in iter_promoted_files(family_dir)
         ]
-        families.append(
-            {
-                "family": family_name,
-                "manifest_checks": existing_checks.get(family_name, []),
-                "artifacts": artifacts,
-            }
-        )
+        families.append({"family": family_name, "artifacts": artifacts})
     return {"schema_version": REGISTRY_SCHEMA_VERSION, "families": families}
 
 
@@ -173,23 +185,40 @@ def _validate_family_artifacts(
     return errors, registered
 
 
-def _validate_family_manifests(
-    family_name: str, checks: list[Any], promoted_root: Path
+def _check_member_path(
+    family_name: str, member: str, role: str, promoted_root: Path, registered: set[str]
 ) -> list[str]:
-    """Manifest-tier checks, delegated to the family's declared validator."""
+    """A declared check member must stay inside its own family and be digest-pinned."""
     errors: list[str] = []
-    for check in checks:
-        if not isinstance(check, dict):
-            errors.append(f"[{family_name}] manifest_checks entries must be objects, got: {check!r}")
-            continue
-        validator_name = check.get("validator")
-        export_rel = check.get("export_json")
-        manifest_rel = check.get("manifest")
-        if not validator_name or not export_rel or not manifest_rel:
-            errors.append(
-                f"[{family_name}] manifest check missing validator/export_json/manifest: {check!r}"
-            )
-            continue
+    if Path(member).is_absolute() or Path(member).parts[:1] == ("..",):
+        errors.append(f"[{family_name}] manifest check {role} must be a relative in-family path: {member}")
+        return errors
+    family_root = (promoted_root / family_name).resolve()
+    resolved = (promoted_root / family_name / member).resolve()
+    if not resolved.is_relative_to(family_root):
+        errors.append(f"[{family_name}] manifest check {role} escapes the family directory: {member}")
+        return errors
+    if f"{family_name}/{member}" not in registered:
+        errors.append(
+            f"[{family_name}] manifest check {role} is not digest-registered in this family: {member}"
+        )
+    return errors
+
+
+def _validate_family_manifests(
+    family_name: str, promoted_root: Path, registered: set[str]
+) -> tuple[list[str], int]:
+    """Manifest-tier checks, driven by the pinned contract rather than the registry.
+
+    Returns (errors, number of checks executed).
+    """
+    expected = EXPECTED_MANIFEST_CHECKS.get(family_name, ())
+    if len(set(expected)) != len(expected):
+        return ([f"[{family_name}] pinned manifest contract contains duplicate checks."], 0)
+
+    errors: list[str] = []
+    executed = 0
+    for validator_name, export_rel, manifest_rel in expected:
         validator = MANIFEST_VALIDATORS.get(validator_name)
         if validator is None:
             errors.append(
@@ -197,11 +226,24 @@ def _validate_family_manifests(
                 f"declared validators: {sorted(MANIFEST_VALIDATORS)}"
             )
             continue
+
+        member_errors = _check_member_path(
+            family_name, export_rel, "export_json", promoted_root, registered
+        )
+        member_errors += _check_member_path(
+            family_name, manifest_rel, "manifest", promoted_root, registered
+        )
+        if member_errors:
+            errors.extend(member_errors)
+            continue
+
         export_path = promoted_root / family_name / export_rel
         manifest_path = promoted_root / family_name / manifest_rel
+        executed += 1
         for err in validator(export_path=export_path, manifest_path=manifest_path):
             errors.append(f"[{family_name}] {export_rel}: {err}")
-    return errors
+
+    return errors, executed
 
 
 def validate_promoted_integrity(
@@ -271,15 +313,24 @@ def validate_promoted_integrity(
         errors.extend(family_errors)
         registered_paths |= family_registered
 
-        checks = family.get("manifest_checks", [])
-        if not isinstance(checks, list):
-            errors.append(f"[{family_name}] 'manifest_checks' must be a list.")
-            checks = []
-        errors.extend(_validate_family_manifests(family_name, checks, promoted_root))
+        # The registry is a digest record only. A leftover manifest_checks key
+        # would read as if it still drove delegation; reject it rather than
+        # ignoring it silently.
+        unexpected_keys = set(family) - {"family", "artifacts"}
+        if unexpected_keys:
+            errors.append(
+                f"[{family_name}] unexpected registry keys {sorted(unexpected_keys)}; "
+                f"the manifest-delegation contract is pinned in the validator, not the registry."
+            )
+
+        manifest_errors, executed = _validate_family_manifests(
+            family_name, promoted_root, family_registered
+        )
+        errors.extend(manifest_errors)
 
         coverage[family_name] = {
             "artifacts": len(family_registered),
-            "manifest_checks": len(checks),
+            "manifest_checks": executed,
         }
 
     # Bijection: an artifact added to the tree without a registered digest is
@@ -310,7 +361,7 @@ def main() -> None:
     args = parse_args()
 
     if args.update:
-        registry = build_registry(args.promoted_root, args.registry)
+        registry = build_registry(args.promoted_root)
         args.registry.write_text(json.dumps(registry, indent=2) + "\n", encoding="utf-8")
         total = sum(len(f["artifacts"]) for f in registry["families"])
         print(f"Wrote {args.registry} covering {total} artifacts across {len(registry['families'])} families.")

--- a/scripts/validate_promoted_integrity.py
+++ b/scripts/validate_promoted_integrity.py
@@ -8,23 +8,33 @@ holds a byte-level digest for *every* file under `exports/promoted/`, so a
 directly-edited promoted artifact is rejected in CI regardless of which family
 it belongs to.
 
-Two enforcement tiers are declared per family in the registry:
+Enforcement has two tiers, and they deliberately have **separate sources of
+truth**:
 
-* ``digest``   - registry <-> disk bijection plus sha256/size of canonical bytes.
-                 Applies to every promoted artifact without exception.
-* ``manifest`` - the family additionally declares an export/manifest pair, which
-                 is delegated to that family's existing validator on top of the
-                 digest tier.
+* ``digest``   - driven by the integrity registry, which is digest-only: it
+                 records nothing but path, sha256, and size. Enforced as a
+                 registry <-> disk bijection, so a modified, deleted, or
+                 undeclared artifact all fail. Applies to every promoted
+                 artifact without exception.
+* ``manifest`` - driven by EXPECTED_MANIFEST_CHECKS below, pinned in this
+                 module rather than in the registry. Each entry names an
+                 export/manifest pair delegated to that family's existing
+                 validator, on top of the digest tier.
 
-The digest tier is never a fallback for a *skipped* family. Every file is
-digest-checked; the manifest tier is strictly additive where a manifest
-contract already exists in the repository. Families without a manifest are
-declared as such in the registry rather than silently passed over.
+The split is the point. The registry legitimately changes whenever an artifact
+is regenerated; *which* export/manifest pairs must be enforced is a contract
+fact that must not be editable alongside it. When delegation was driven by
+registry data, a tampered registry could swap four of the five rookie-alpha
+entries for duplicates of the fifth and stay green. The registry therefore
+carries no manifest contract at all, and a family entry bearing any key beyond
+`family` and `artifacts` is rejected rather than ignored.
 
-The registry records only values mechanically derived from the canonical bytes
-already committed to the repository (path, sha256, size) plus the family's
-already-declared manifest contract. It invents no schema identity, run id, or
-provenance for artifacts that do not carry one.
+A family absent from EXPECTED_MANIFEST_CHECKS receives digest enforcement only.
+That is a property of the repository, not a skipped check: those families
+declare no manifest or schema contract anywhere in the repo, and this validator
+does not invent one. It fabricates no schema identity, run id, or provenance
+for artifacts that do not carry one, and every value in the registry is
+mechanically derived from bytes already committed.
 """
 
 from __future__ import annotations

--- a/tests/test_validate_promoted_integrity.py
+++ b/tests/test_validate_promoted_integrity.py
@@ -1,0 +1,343 @@
+"""Mutation corpus for promoted-export integrity enforcement (issue #274, Finding 1).
+
+Every declared promoted artifact family must fail closed on a tampered,
+missing, or undeclared artifact. Mutations are applied to a throwaway mirror of
+the promoted tree; the canonical artifacts in the repository are never written
+to by these tests.
+"""
+
+import json
+import os
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.validate_promoted_integrity import (
+    DECLARED_FAMILIES,
+    REGISTRY_SCHEMA_VERSION,
+    iter_promoted_files,
+    sha256_file,
+    validate_promoted_integrity,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CANONICAL_PROMOTED = REPO_ROOT / "exports/promoted"
+CANONICAL_REGISTRY = REPO_ROOT / "exports/promoted_integrity_registry_v0.json"
+
+# One representative artifact per family, so the corpus proves rejection for
+# every declared family rather than only the manifest-bearing ones.
+FAMILY_MUTATION_TARGETS = {
+    "historical-comps": "2026_historical_comps_v0.json",
+    "nfl-fantasy-outcomes": "player_year_ppr_outcomes_v1.csv",
+    # Deliberately a postdraft variant: predraft was the only file CI covered
+    # before this change.
+    "rookie-alpha": "2026_rookie_alpha_postdraft_v0.json",
+    "rookie-ml-lane": "feature_table.json",
+    "rookie-transition-profile": "2026_rookie_transition_profile_v0.csv",
+}
+
+
+class PromotedIntegrityCanonicalTests(unittest.TestCase):
+    """Checks against the real repository artifacts."""
+
+    def test_canonical_promoted_tree_passes(self) -> None:
+        errors, coverage = validate_promoted_integrity(CANONICAL_PROMOTED, CANONICAL_REGISTRY)
+        self.assertEqual(errors, [])
+        self.assertEqual(set(coverage), set(DECLARED_FAMILIES))
+
+    def test_registry_covers_every_promoted_artifact(self) -> None:
+        registry = json.loads(CANONICAL_REGISTRY.read_text(encoding="utf-8"))
+        registered = {
+            f"{family['family']}/{artifact['path']}"
+            for family in registry["families"]
+            for artifact in family["artifacts"]
+        }
+        self.assertEqual(registered, set(iter_promoted_files(CANONICAL_PROMOTED)))
+
+    def test_every_declared_family_is_registered_and_non_empty(self) -> None:
+        registry = json.loads(CANONICAL_REGISTRY.read_text(encoding="utf-8"))
+        by_name = {family["family"]: family for family in registry["families"]}
+        self.assertEqual(set(by_name), set(DECLARED_FAMILIES))
+        for name, family in by_name.items():
+            with self.subTest(family=name):
+                self.assertGreater(len(family["artifacts"]), 0)
+
+    def test_manifest_contracts_are_enforced_where_declared(self) -> None:
+        _, coverage = validate_promoted_integrity(CANONICAL_PROMOTED, CANONICAL_REGISTRY)
+        self.assertEqual(coverage["rookie-alpha"]["manifest_checks"], 5)
+        self.assertEqual(coverage["rookie-transition-profile"]["manifest_checks"], 1)
+
+
+class PromotedIntegrityMutationTests(unittest.TestCase):
+    """Deterministic mutation corpus applied to a mirror of the promoted tree."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.mirror = Path(self._tmp.name)
+        # Mirror the repository layout so the delegated manifest validators
+        # resolve their declared input paths exactly as they do in CI.
+        (self.mirror / ".git").mkdir()
+        os.symlink(REPO_ROOT / "data", self.mirror / "data")
+        (self.mirror / "exports").mkdir()
+        self.promoted = self.mirror / "exports/promoted"
+        shutil.copytree(CANONICAL_PROMOTED, self.promoted)
+        self.registry = self.mirror / "exports/promoted_integrity_registry_v0.json"
+        shutil.copyfile(CANONICAL_REGISTRY, self.registry)
+        self.addCleanup(self._tmp.cleanup)
+
+    def run_validator(self) -> list[str]:
+        errors, _ = validate_promoted_integrity(self.promoted, self.registry)
+        return errors
+
+    def read_registry(self) -> dict:
+        return json.loads(self.registry.read_text(encoding="utf-8"))
+
+    def write_registry(self, registry: dict) -> None:
+        self.registry.write_text(json.dumps(registry, indent=2) + "\n", encoding="utf-8")
+
+    def reregister(self, family: str, rel_path: str) -> None:
+        """Re-derive the digest for a mutated file.
+
+        Used to isolate manifest-tier failures: without this the digest tier
+        would fire first and the test would not prove the manifest contract is
+        actually wired up.
+        """
+        target = self.promoted / family / rel_path
+        registry = self.read_registry()
+        for entry in registry["families"]:
+            if entry["family"] != family:
+                continue
+            for artifact in entry["artifacts"]:
+                if artifact["path"] == rel_path:
+                    artifact["sha256"] = sha256_file(target)
+                    artifact["bytes"] = target.stat().st_size
+        self.write_registry(registry)
+
+    def assert_baseline_clean(self) -> None:
+        self.assertEqual(self.run_validator(), [], "mirror should validate before mutation")
+
+    # --- Mutation class 1: modified artifact bytes / digest mismatch --------
+
+    def test_appended_byte_is_rejected_for_every_family(self) -> None:
+        self.assert_baseline_clean()
+        for family, rel_path in FAMILY_MUTATION_TARGETS.items():
+            with self.subTest(family=family):
+                target = self.promoted / family / rel_path
+                original = target.read_bytes()
+                target.write_bytes(original + b" ")
+                errors = self.run_validator()
+                self.assertTrue(
+                    any(f"sha256 mismatch for {rel_path}" in err and family in err for err in errors),
+                    f"{family}: appended byte not rejected; errors={errors}",
+                )
+                target.write_bytes(original)
+
+    def test_same_length_byte_flip_is_rejected_for_every_family(self) -> None:
+        """Proves the digest, not just the recorded size, is doing the work."""
+        self.assert_baseline_clean()
+        for family, rel_path in FAMILY_MUTATION_TARGETS.items():
+            with self.subTest(family=family):
+                target = self.promoted / family / rel_path
+                original = target.read_bytes()
+                flipped = bytes([original[0] ^ 0x20]) + original[1:]
+                self.assertNotEqual(flipped, original)
+                self.assertEqual(len(flipped), len(original))
+                target.write_bytes(flipped)
+                errors = self.run_validator()
+                self.assertTrue(
+                    any(f"sha256 mismatch for {rel_path}" in err and family in err for err in errors),
+                    f"{family}: same-length mutation not rejected; errors={errors}",
+                )
+                self.assertFalse(
+                    any(f"size mismatch for {rel_path}" in err for err in errors),
+                    f"{family}: size check should not fire on a same-length mutation",
+                )
+                target.write_bytes(original)
+
+    # --- Mutation class 2: missing required companion ----------------------
+
+    def test_deleted_artifact_is_rejected_for_every_family(self) -> None:
+        self.assert_baseline_clean()
+        for family, rel_path in FAMILY_MUTATION_TARGETS.items():
+            with self.subTest(family=family):
+                target = self.promoted / family / rel_path
+                original = target.read_bytes()
+                target.unlink()
+                errors = self.run_validator()
+                self.assertTrue(
+                    any(
+                        f"registered artifact is missing from disk: {rel_path}" in err
+                        and family in err
+                        for err in errors
+                    ),
+                    f"{family}: deleted artifact not rejected; errors={errors}",
+                )
+                target.write_bytes(original)
+
+    def test_missing_manifest_is_rejected(self) -> None:
+        self.assert_baseline_clean()
+        for family, manifest_name in (
+            ("rookie-alpha", "2026_manifest.json"),
+            ("rookie-transition-profile", "2026_manifest.json"),
+        ):
+            with self.subTest(family=family):
+                manifest = self.promoted / family / manifest_name
+                original = manifest.read_bytes()
+                manifest.unlink()
+                # Drop the digest entry too, so only the manifest tier can fail.
+                registry = self.read_registry()
+                for entry in registry["families"]:
+                    if entry["family"] == family:
+                        entry["artifacts"] = [
+                            a for a in entry["artifacts"] if a["path"] != manifest_name
+                        ]
+                self.write_registry(registry)
+                errors = self.run_validator()
+                self.assertTrue(
+                    any("Required companion file not found" in err and family in err for err in errors),
+                    f"{family}: missing manifest not rejected; errors={errors}",
+                )
+                manifest.write_bytes(original)
+
+    # --- Mutation class 3: incompatible manifest / schema identity ---------
+
+    def test_manifest_metadata_mismatch_is_rejected_for_rookie_alpha(self) -> None:
+        self.assert_baseline_clean()
+        manifest = self.promoted / "rookie-alpha/2026_manifest.json"
+        payload = json.loads(manifest.read_text(encoding="utf-8"))
+        payload["export_metadata"]["run_id"] = "tampered-run-id"
+        manifest.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+        self.reregister("rookie-alpha", "2026_manifest.json")
+
+        errors = self.run_validator()
+        self.assertTrue(
+            any("export_metadata does not exactly match export JSON metadata" in err for err in errors),
+            f"rookie-alpha manifest identity mismatch not rejected; errors={errors}",
+        )
+
+    def test_manifest_output_hash_mismatch_is_rejected_for_rookie_alpha(self) -> None:
+        """A tampered export plus a matching registry digest must still fail."""
+        self.assert_baseline_clean()
+        export = self.promoted / "rookie-alpha/2026_rookie_alpha_predraft_v0.json"
+        export.write_text("{}\n", encoding="utf-8")
+        self.reregister("rookie-alpha", "2026_rookie_alpha_predraft_v0.json")
+
+        errors = self.run_validator()
+        self.assertTrue(
+            any("Output hash mismatch" in err for err in errors),
+            f"rookie-alpha manifest output hash mismatch not rejected; errors={errors}",
+        )
+
+    def test_schema_identity_mismatch_is_rejected_for_transition_profile(self) -> None:
+        self.assert_baseline_clean()
+        artifact = self.promoted / "rookie-transition-profile/2026_rookie_transition_profile_v0.json"
+        payload = json.loads(artifact.read_text(encoding="utf-8"))
+        payload["schema_version"] = "rookie-transition-profile-v99.0.0"
+        artifact.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+        self.reregister("rookie-transition-profile", "2026_rookie_transition_profile_v0.json")
+
+        errors = self.run_validator()
+        self.assertTrue(
+            any("schema_version must be" in err for err in errors),
+            f"transition-profile schema identity mismatch not rejected; errors={errors}",
+        )
+
+    # --- Mutation class 4: undeclared / shrunken artifact universe ---------
+
+    def test_unregistered_artifact_is_rejected_for_every_family(self) -> None:
+        self.assert_baseline_clean()
+        for family in DECLARED_FAMILIES:
+            with self.subTest(family=family):
+                smuggled = self.promoted / family / "smuggled_artifact_v0.json"
+                smuggled.write_text('{"smuggled": true}\n', encoding="utf-8")
+                errors = self.run_validator()
+                self.assertTrue(
+                    any(
+                        "not registered in the integrity registry" in err
+                        and f"{family}/smuggled_artifact_v0.json" in err
+                        for err in errors
+                    ),
+                    f"{family}: unregistered artifact not rejected; errors={errors}",
+                )
+                smuggled.unlink()
+
+    def test_dropping_a_family_from_the_registry_is_rejected(self) -> None:
+        self.assert_baseline_clean()
+        for family in DECLARED_FAMILIES:
+            with self.subTest(family=family):
+                registry = self.read_registry()
+                registry["families"] = [f for f in registry["families"] if f["family"] != family]
+                self.write_registry(registry)
+                errors = self.run_validator()
+                self.assertTrue(
+                    any("does not declare required families" in err and family in err for err in errors),
+                    f"{family}: family removal not rejected; errors={errors}",
+                )
+                shutil.copyfile(CANONICAL_REGISTRY, self.registry)
+
+    def test_emptying_a_family_is_rejected(self) -> None:
+        self.assert_baseline_clean()
+        registry = self.read_registry()
+        for entry in registry["families"]:
+            if entry["family"] == "rookie-ml-lane":
+                entry["artifacts"] = []
+        self.write_registry(registry)
+        errors = self.run_validator()
+        self.assertTrue(
+            any("declares no artifacts" in err for err in errors),
+            f"emptied family not rejected; errors={errors}",
+        )
+
+    # --- Mutation class 5: registry integrity itself -----------------------
+
+    def test_registry_schema_version_mismatch_is_rejected(self) -> None:
+        self.assert_baseline_clean()
+        registry = self.read_registry()
+        registry["schema_version"] = "promoted-integrity-registry-v99.0.0"
+        self.write_registry(registry)
+        errors = self.run_validator()
+        self.assertTrue(
+            any("schema_version mismatch" in err for err in errors),
+            f"registry schema mismatch not rejected; errors={errors}",
+        )
+
+    def test_unknown_manifest_validator_is_rejected(self) -> None:
+        self.assert_baseline_clean()
+        registry = self.read_registry()
+        for entry in registry["families"]:
+            if entry["family"] == "rookie-alpha":
+                entry["manifest_checks"][0]["validator"] = "not-a-real-validator"
+        self.write_registry(registry)
+        errors = self.run_validator()
+        self.assertTrue(
+            any("unknown manifest validator" in err for err in errors),
+            f"unknown validator not rejected; errors={errors}",
+        )
+
+    def test_registry_path_escaping_its_family_is_rejected(self) -> None:
+        self.assert_baseline_clean()
+        registry = self.read_registry()
+        for entry in registry["families"]:
+            if entry["family"] == "rookie-ml-lane":
+                entry["artifacts"][0]["path"] = "../rookie-alpha/2026_manifest.json"
+        self.write_registry(registry)
+        errors = self.run_validator()
+        self.assertTrue(
+            any("escapes the family directory" in err for err in errors),
+            f"registry path traversal not rejected; errors={errors}",
+        )
+
+    def test_missing_registry_is_rejected(self) -> None:
+        self.assert_baseline_clean()
+        self.registry.unlink()
+        errors = self.run_validator()
+        self.assertTrue(
+            any("Integrity registry not found" in err for err in errors),
+            f"missing registry not rejected; errors={errors}",
+        )
+        self.assertEqual(REGISTRY_SCHEMA_VERSION, "promoted-integrity-registry-v0.1.0")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_validate_promoted_integrity.py
+++ b/tests/test_validate_promoted_integrity.py
@@ -13,8 +13,11 @@ import tempfile
 import unittest
 from pathlib import Path
 
+from unittest import mock
+
 from scripts.validate_promoted_integrity import (
     DECLARED_FAMILIES,
+    EXPECTED_MANIFEST_CHECKS,
     REGISTRY_SCHEMA_VERSION,
     iter_promoted_files,
     sha256_file,
@@ -68,6 +71,40 @@ class PromotedIntegrityCanonicalTests(unittest.TestCase):
         self.assertEqual(coverage["rookie-alpha"]["manifest_checks"], 5)
         self.assertEqual(coverage["rookie-transition-profile"]["manifest_checks"], 1)
 
+    def test_pinned_manifest_contract_is_exact_and_duplicate_free(self) -> None:
+        """A count assertion alone would let duplicates stand in for real checks."""
+        expected = {
+            "rookie-alpha": {
+                ("rookie-alpha-manifest-v0", f"{year}_rookie_alpha_predraft_v0.json", f"{year}_manifest.json")
+                for year in (2022, 2023, 2024, 2025, 2026)
+            },
+            "rookie-transition-profile": {
+                (
+                    "rookie-transition-profile-v0",
+                    "2026_rookie_transition_profile_v0.json",
+                    "2026_manifest.json",
+                )
+            },
+        }
+        self.assertEqual(set(EXPECTED_MANIFEST_CHECKS), set(expected))
+        for family, tuples in EXPECTED_MANIFEST_CHECKS.items():
+            with self.subTest(family=family):
+                self.assertEqual(len(set(tuples)), len(tuples), "duplicate checks in pinned contract")
+                self.assertEqual(set(tuples), expected[family])
+
+    def test_every_manifest_check_member_is_digest_registered(self) -> None:
+        registry = json.loads(CANONICAL_REGISTRY.read_text(encoding="utf-8"))
+        registered = {
+            f"{family['family']}/{artifact['path']}"
+            for family in registry["families"]
+            for artifact in family["artifacts"]
+        }
+        for family, tuples in EXPECTED_MANIFEST_CHECKS.items():
+            for _, export_rel, manifest_rel in tuples:
+                with self.subTest(family=family, export=export_rel):
+                    self.assertIn(f"{family}/{export_rel}", registered)
+                    self.assertIn(f"{family}/{manifest_rel}", registered)
+
 
 class PromotedIntegrityMutationTests(unittest.TestCase):
     """Deterministic mutation corpus applied to a mirror of the promoted tree."""
@@ -113,6 +150,14 @@ class PromotedIntegrityMutationTests(unittest.TestCase):
                     artifact["sha256"] = sha256_file(target)
                     artifact["bytes"] = target.stat().st_size
         self.write_registry(registry)
+
+    def patched_contract(self, family: str, tuples: tuple) -> mock._patch:
+        """Temporarily replace the pinned contract for one family."""
+        patched = dict(EXPECTED_MANIFEST_CHECKS)
+        patched[family] = tuples
+        return mock.patch(
+            "scripts.validate_promoted_integrity.EXPECTED_MANIFEST_CHECKS", patched
+        )
 
     def assert_baseline_clean(self) -> None:
         self.assertEqual(self.run_validator(), [], "mirror should validate before mutation")
@@ -176,6 +221,7 @@ class PromotedIntegrityMutationTests(unittest.TestCase):
                 target.write_bytes(original)
 
     def test_missing_manifest_is_rejected(self) -> None:
+        """Deleting a manifest must fail even though its digest entry remains."""
         self.assert_baseline_clean()
         for family, manifest_name in (
             ("rookie-alpha", "2026_manifest.json"),
@@ -185,7 +231,24 @@ class PromotedIntegrityMutationTests(unittest.TestCase):
                 manifest = self.promoted / family / manifest_name
                 original = manifest.read_bytes()
                 manifest.unlink()
-                # Drop the digest entry too, so only the manifest tier can fail.
+                errors = self.run_validator()
+                self.assertTrue(
+                    any("Required companion file not found" in err and family in err for err in errors),
+                    f"{family}: missing manifest not rejected by the manifest tier; errors={errors}",
+                )
+                manifest.write_bytes(original)
+
+    def test_deregistering_a_manifest_check_member_is_rejected(self) -> None:
+        """A check member must stay digest-pinned; dropping its entry fails closed."""
+        self.assert_baseline_clean()
+        for family, manifest_name in (
+            ("rookie-alpha", "2026_manifest.json"),
+            ("rookie-transition-profile", "2026_manifest.json"),
+        ):
+            with self.subTest(family=family):
+                manifest = self.promoted / family / manifest_name
+                original = manifest.read_bytes()
+                manifest.unlink()
                 registry = self.read_registry()
                 for entry in registry["families"]:
                     if entry["family"] == family:
@@ -195,10 +258,11 @@ class PromotedIntegrityMutationTests(unittest.TestCase):
                 self.write_registry(registry)
                 errors = self.run_validator()
                 self.assertTrue(
-                    any("Required companion file not found" in err and family in err for err in errors),
-                    f"{family}: missing manifest not rejected; errors={errors}",
+                    any("is not digest-registered in this family" in err and family in err for err in errors),
+                    f"{family}: deregistered manifest not rejected; errors={errors}",
                 )
                 manifest.write_bytes(original)
+                shutil.copyfile(CANONICAL_REGISTRY, self.registry)
 
     # --- Mutation class 3: incompatible manifest / schema identity ---------
 
@@ -241,6 +305,111 @@ class PromotedIntegrityMutationTests(unittest.TestCase):
         self.assertTrue(
             any("schema_version must be" in err for err in errors),
             f"transition-profile schema identity mismatch not rejected; errors={errors}",
+        )
+
+    def test_every_rookie_alpha_year_contract_is_individually_enforced(self) -> None:
+        """The exact regression from review: four years could go unenforced.
+
+        Tampering with each year's manifest in turn must surface that year's
+        contract failure, so no year can be silently substituted by another.
+        """
+        self.assert_baseline_clean()
+        for year in (2022, 2023, 2024, 2025, 2026):
+            with self.subTest(year=year):
+                manifest = self.promoted / f"rookie-alpha/{year}_manifest.json"
+                original = manifest.read_bytes()
+                payload = json.loads(manifest.read_text(encoding="utf-8"))
+                payload["export_metadata"]["run_id"] = f"tampered-{year}"
+                manifest.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+                self.reregister("rookie-alpha", f"{year}_manifest.json")
+
+                errors = self.run_validator()
+                self.assertTrue(
+                    any(
+                        "export_metadata does not exactly match export JSON metadata" in err
+                        and f"{year}_rookie_alpha_predraft_v0.json" in err
+                        for err in errors
+                    ),
+                    f"{year}: manifest contract not enforced; errors={errors}",
+                )
+                manifest.write_bytes(original)
+                shutil.copyfile(CANONICAL_REGISTRY, self.registry)
+
+    def test_registry_redeclaring_manifest_checks_is_rejected(self) -> None:
+        """The registry must not be able to supply or weaken the manifest contract."""
+        self.assert_baseline_clean()
+        good = {
+            "validator": "rookie-alpha-manifest-v0",
+            "export_json": "2026_rookie_alpha_predraft_v0.json",
+            "manifest": "2026_manifest.json",
+        }
+        registry = self.read_registry()
+        for entry in registry["families"]:
+            if entry["family"] == "rookie-alpha":
+                # Five copies of one valid tuple: the exact substitution that
+                # previously kept the count at five while disabling 2022-2025.
+                entry["manifest_checks"] = [dict(good) for _ in range(5)]
+        self.write_registry(registry)
+        errors = self.run_validator()
+        self.assertTrue(
+            any("unexpected registry keys" in err and "manifest_checks" in err for err in errors),
+            f"registry-supplied manifest_checks not rejected; errors={errors}",
+        )
+
+    def test_duplicate_checks_in_the_pinned_contract_are_rejected(self) -> None:
+        self.assert_baseline_clean()
+        duplicated = tuple(
+            [("rookie-alpha-manifest-v0", "2026_rookie_alpha_predraft_v0.json", "2026_manifest.json")] * 5
+        )
+        with self.patched_contract("rookie-alpha", duplicated):
+            errors = self.run_validator()
+        self.assertTrue(
+            any("duplicate checks" in err for err in errors),
+            f"duplicate pinned checks not rejected; errors={errors}",
+        )
+
+    def test_escaping_manifest_check_path_is_rejected(self) -> None:
+        self.assert_baseline_clean()
+        with self.patched_contract(
+            "rookie-alpha",
+            (("rookie-alpha-manifest-v0", "../../../etc/passwd", "2026_manifest.json"),),
+        ):
+            errors = self.run_validator()
+        self.assertTrue(
+            any("must be a relative in-family path" in err or "escapes the family directory" in err
+                for err in errors),
+            f"escaping check path not rejected; errors={errors}",
+        )
+
+    def test_cross_family_manifest_check_path_is_rejected(self) -> None:
+        self.assert_baseline_clean()
+        with self.patched_contract(
+            "rookie-transition-profile",
+            (
+                (
+                    "rookie-transition-profile-v0",
+                    "../rookie-alpha/2026_rookie_alpha_predraft_v0.json",
+                    "2026_manifest.json",
+                ),
+            ),
+        ):
+            errors = self.run_validator()
+        self.assertTrue(
+            any("must be a relative in-family path" in err or "escapes the family directory" in err
+                for err in errors),
+            f"cross-family check path not rejected; errors={errors}",
+        )
+
+    def test_unregistered_manifest_check_member_is_rejected(self) -> None:
+        self.assert_baseline_clean()
+        with self.patched_contract(
+            "rookie-alpha",
+            (("rookie-alpha-manifest-v0", "not_registered_v0.json", "2026_manifest.json"),),
+        ):
+            errors = self.run_validator()
+        self.assertTrue(
+            any("is not digest-registered in this family" in err for err in errors),
+            f"unregistered check member not rejected; errors={errors}",
         )
 
     # --- Mutation class 4: undeclared / shrunken artifact universe ---------
@@ -304,12 +473,11 @@ class PromotedIntegrityMutationTests(unittest.TestCase):
 
     def test_unknown_manifest_validator_is_rejected(self) -> None:
         self.assert_baseline_clean()
-        registry = self.read_registry()
-        for entry in registry["families"]:
-            if entry["family"] == "rookie-alpha":
-                entry["manifest_checks"][0]["validator"] = "not-a-real-validator"
-        self.write_registry(registry)
-        errors = self.run_validator()
+        with self.patched_contract(
+            "rookie-alpha",
+            (("not-a-real-validator", "2026_rookie_alpha_predraft_v0.json", "2026_manifest.json"),),
+        ):
+            errors = self.run_validator()
         self.assertTrue(
             any("unknown manifest validator" in err for err in errors),
             f"unknown validator not rejected; errors={errors}",
@@ -336,7 +504,7 @@ class PromotedIntegrityMutationTests(unittest.TestCase):
             any("Integrity registry not found" in err for err in errors),
             f"missing registry not rejected; errors={errors}",
         )
-        self.assertEqual(REGISTRY_SCHEMA_VERSION, "promoted-integrity-registry-v0.1.0")
+        self.assertEqual(REGISTRY_SCHEMA_VERSION, "promoted-integrity-registry-v0.2.0")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Bounded implementation of issue #274 **Finding 1 only**, under the operator activation at [issuecomment-5386297699](https://github.com/Prometheus-Frameworks/TIBER-Rookies/issues/274#issuecomment-5386297699).

- Authorized starting SHA: `fb170fd12c0e2cc82a94a2b35259e5e40f2e74d8` (verified; worktree clean; `origin/main` still at this SHA, no divergence)
- Current head: `b9b1e73eb392eac60f7a79a2cedca3cfba74f292`

## Problem

CI gated the sha256/schema of exactly one promoted export/manifest pair (2026 rookie-alpha predraft). That covered **2 of 41** promoted artifacts. A directly-edited file in `historical-comps`, `nfl-fantasy-outcomes`, `rookie-ml-lane`, the rookie-alpha postdraft variants, or `rookie-transition-profile` would merge with no automated detection.

## Change

`exports/promoted_integrity_registry_v0.json` records the sha256 and byte size of every file under `exports/promoted/`. `scripts/validate_promoted_integrity.py` enforces a registry↔disk bijection over the full declared universe, in two tiers with **separate sources of truth**:

| Tier | Source of truth | Applies to |
|---|---|---|
| `digest` | the registry (path, sha256, size — nothing else) | every promoted artifact, without exception |
| `manifest` | `EXPECTED_MANIFEST_CHECKS`, pinned in validator code | families with an already-declared manifest contract |

The split is deliberate. The registry legitimately changes whenever an artifact is regenerated; **which** export/manifest pairs must be enforced is a contract fact and must not be editable alongside it. The pinned set is required to be exact and duplicate-free; a registry family entry bearing any key beyond `family` and `artifacts` is rejected rather than ignored; each declared member must be a relative in-family path that neither escapes its family nor crosses into another; and each member must also be digest-registered in that same family — so the manifest tier can never run against an unpinned file.

`scripts/validate_rookie_transition_profile.py` already existed in the repo but was never wired into CI. It now runs through this delegation.

The registry holds only values mechanically derived from the canonical bytes already committed. A family absent from `EXPECTED_MANIFEST_CHECKS` receives digest enforcement only — that is a property of the repository, not a skipped check: those families declare no manifest or schema contract anywhere, and this validator invents none. The registry lives outside `exports/promoted/` so it has no self-reference, and it covers the manifests themselves — which their own `output_files` do not.

## Coverage

| Family | Manifest contract | Artifacts | Before | After |
|---|---|---:|---|---|
| historical-comps | none in repo | 1 | uncovered | digest |
| nfl-fantasy-outcomes | none in repo | 4 | uncovered | digest |
| rookie-alpha | 5 (2022–2026) | 24 | 2 files | digest + 5 manifest |
| rookie-ml-lane | none in repo | 9 | uncovered | digest |
| rookie-transition-profile | 1 (existed, not in CI) | 3 | uncovered | digest + 1 manifest |

**1 of 5 families / 2 of 41 artifacts → 5 of 5 families / 41 of 41 artifacts.**

## Canonical bytes unchanged

- `git diff fb170fd1 -- exports/promoted/` is empty.
- All 41 registry digests verified against the `git show fb170fd1:<path>` blob bytes — 41/41 match.

Nothing was regenerated, normalized, or rewritten to satisfy the validator.

## Mutation corpus

`tests/test_validate_promoted_integrity.py` mutates a throwaway mirror; canonical artifacts are never written to. Every declared mutation is rejected.

| Mutation | Scope |
|---|---|
| Appended byte | all 5 families |
| Same-length byte flip | all 5 families (proves digest, not size, does the work) |
| Deleted artifact | all 5 families |
| Unregistered artifact added | all 5 families |
| Family dropped from registry / emptied | all 5 families |
| Missing manifest | both manifest families |
| Manifest metadata identity, output-hash | rookie-alpha |
| Schema identity | rookie-transition-profile |
| Each of the 5 rookie-alpha years tampered in turn | rookie-alpha |
| Registry re-declaring `manifest_checks` | registry |
| Duplicate checks in the pinned contract | contract |
| Escaping / cross-family check path | contract |
| Unregistered / deregistered check member | contract |
| Registry schema-version mismatch, unknown validator, path escape | registry |

Manifest-tier mutations re-derive the registry digest for the mutated file first, so the digest tier cannot mask the result.

**Negative controls** confirm the corpus is not vacuously green: disabling the sha256 comparison, the bijection, the manifest delegation, the unexpected-key guard, and the member path/registration guard each produce targeted failures. Restoring the pre-review vulnerable contract fails 24 tests.

## Review history

| Head | Event |
|---|---|
| `4497be71` | Initial implementation. Blocking **P2**: manifest delegation was driven by registry-supplied `manifest_checks` with only a **count** assertion, so the 2022–2025 entries could be replaced by four copies of the valid 2026 tuple — count still 5, CI still green, four contracts silently unenforced ([thread](https://github.com/Prometheus-Frameworks/TIBER-Rookies/pull/290#discussion_r3838749364)). Reproduced with zero errors before fixing. |
| `6b95cd3c` | P2 fix: contract pinned in code, `manifest_checks` removed from the registry, containment/registration guards added, targeted mutations added. Registry `schema_version` → `v0.2.0`; digests unchanged. Follow-up **P3**: the module docstring still described the superseded registry-controlled design ([thread](https://github.com/Prometheus-Frameworks/TIBER-Rookies/pull/290#discussion_r3838866798)). |
| `b9b1e73e` | P3 fix: docstring rewritten to the implemented source-of-truth split. Documentation-only — the module AST is identical apart from the docstring. Exact-head review reported clean; both threads resolved. Marked ready for review by the operator. |

## Verification

| Command | Result |
|---|---|
| `python3 -m py_compile scripts/compute_rookie_alpha.py` | pass |
| `python3 -m pytest tests -q` | **498 passed, 47 subtests** (baseline 471) |
| `validate_promoted_export.py` (existing CI step, unchanged) | VALIDATION PASSED |
| `validate_promoted_integrity.py` | PASSED — 41 artifacts, 5 families |
| `npm run test:runtime-smoke` | 1/1 pass |
| `npm run test:card-disclosure` | 39/39 pass |
| `--update` on a clean tree | regenerates byte-identically |

The existing CI validator step is retained unchanged; the new step is additive. Exact-head CI is green on `b9b1e73e`.

## Residual risks

- The registry shares the trust model of any committed lockfile: an attacker editing an artifact **and** its digest entry in the same commit passes CI. The defense is review visibility — the tamper must appear as a diff in a file whose only purpose is integrity. Inherent to in-repo integrity records; not resolved here. The manifest contract is no longer exposed to this, being pinned in code.
- Digest-tier families are pinned to their current bytes but have no semantic/schema contract, because none is declared in the repo. Legitimate regeneration requires `--update` plus review of the resulting digest diff.
- Runtime integrity enforcement in `runtime-server.js` was explicitly out of scope and remains absent.

## Out of scope (untouched)

Finding 2 (CSV formula-injection), the `RookieCard.js` URL-scheme note, runtime enforcement, artifact regeneration, contract redesign, dependency upgrades.

## Review boundary

Not self-certified by the implementer. An exact-head review at `b9b1e73e` reported clean and resolved both reviewer-owned threads; that review was submitted from the `Prometheus-Frameworks` account, which is also this PR's authoring account, so whether it satisfies the activation's independent-review requirement is the operator's call, not the implementer's.

This PR was opened as a draft and **marked ready for review by the operator** at 2026-08-23T16:52Z — not by the implementer, whose activation reserves that action. Merge authority likewise remains with the operator: the implementer has not merged this PR and will not, and issue #274 remains open.